### PR TITLE
Fix the board's next-action button, the CLUDINARY fallback, and add a README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,129 @@
+# June's Tees — backend
+
+The server behind [jtees.net](https://www.jtees.net): a custom apparel and
+print shop in Phoenix, AZ. One Express app does all of it — it serves the
+public marketing site out of `public/`, takes quote and contact submissions,
+syncs customers into Brevo, records payments, and renders the admin boards the
+shop actually runs the day on.
+
+There is no build step and no frontend framework. Pages are static HTML in
+`public/`, and the admin screens are HTML rendered by `server.js`.
+
+## Requirements
+
+- **Node 18 or newer** (`node --version`) — the app uses the built-in `fetch`
+- **PostgreSQL** — any reachable instance; tables are created on boot
+- A **Brevo** account (email + contact sync). Brevo is a hard requirement:
+  the process refuses to start without `BREVO_API_KEY`.
+
+## Run it from a clean clone
+
+```bash
+git clone https://github.com/alwinte5-rgb/junesteesnthings-backend.git
+cd junesteesnthings-backend
+npm install
+cp .env.example .env
+```
+
+Now open `.env` and fill in, at minimum, the three the server requires:
+
+| Variable | What it is |
+|---|---|
+| `DATABASE_URL` | `postgresql://user:pass@host:5432/dbname` |
+| `BREVO_API_KEY` | Brevo → Account → SMTP & API → API Keys |
+| `NOTIFICATION_EMAIL` | where new quote/contact notifications are sent |
+
+Then:
+
+```bash
+npm run dev     # nodemon, restarts on save
+# or
+npm start       # what production runs
+```
+
+The app listens on `PORT`, default **3000** → <http://localhost:3000>.
+
+On first boot `initDB()` creates every table it needs (`quotes`,
+`quote_payments`, `submissions`, `reviews`, `expenses` and the rest) and runs
+its own `ALTER TABLE ... IF NOT EXISTS` migrations. They are idempotent, so
+starting against an existing database is safe. There is no separate migration
+command.
+
+### Did it work?
+
+A successful boot prints `Listening on port 3000`. Two things are worth
+checking straight after:
+
+- <http://localhost:3000> serves the marketing site.
+- <http://localhost:3000/production> asks for a password. That is the
+  admin gate working — see below.
+
+If a required variable is missing the process prints
+`Missing required environment variables: ...` and **exits non-zero before
+binding the port**. That is deliberate: a missing variable should fail the
+boot, not the first customer request. A missing `RESEND_API_KEY` or
+`ADMIN_PASSWORD` only warns, because the app still runs without them.
+
+## Reaching the admin boards
+
+Every admin route is gated by `requireAdmin` (`server.js`) against
+`ADMIN_PASSWORD`. Without that variable set, the boards are unreachable by
+design — the server warns about this at boot.
+
+| Route | What it is |
+|---|---|
+| `/quotes` | the money board — quotes, what is owed |
+| `/production` | the work board — kanban, one tap per stage |
+| `/production/:code` | one job: full checklist and milestones |
+| `/books` | takings, expenses, tax set aside |
+| `/customer` | one customer's history |
+| `/admin/reviews` | review moderation |
+
+A job moves across `/production` through five columns, derived from milestone
+dates on the quote rather than a separate status field — To start → Artwork &
+proof → Blanks → Press → Check & ship. Delivered is a destination, not a
+column: a delivered job leaves the board.
+
+## The rest of `.env`
+
+`.env.example` is the full list and says where each value comes from. Nothing
+below is needed to get the app running locally.
+
+- **Bot protection** — `REQUIRE_CLOUDFLARE`, `REQUIRE_FORM_TOKEN`,
+  `FORM_TOKEN_SECRET`. Set the first two to `true` in production only; leaving
+  them off locally is what lets you submit the forms by hand.
+- **Cloudinary** — `CLOUDINARY_CLOUD_NAME`, `CLOUDINARY_API_KEY`,
+  `CLOUDINARY_API_SECRET`. Uploads are signed server-side via
+  `/api/cloudinary-signature`; the secret never reaches the browser.
+- **Resend** — `RESEND_API_KEY`, the fallback when Brevo sending fails.
+- **Clover** — `CLOVER_*`, card payments and the payment webhook.
+- **HubSpot** — `HUBSPOT_*`, legacy contact sync.
+
+`.env` is gitignored and must stay that way. No credential belongs in a
+client-visible variable or in `public/`.
+
+## Layout
+
+```
+server.js        the entire app — routes, admin UI, email, payments, DB init
+public/          the marketing site, served statically (also robots/sitemap)
+tools/           one-off operational scripts, run by hand with node
+docs/            operational notes (Brevo workflows, local SEO, Tawk macros)
+AGENTS.md        the rules an AI agent must follow in this repo — read first
+```
+
+`server.js` is deliberately one file. It is large; use your editor's symbol
+search rather than scrolling.
+
+## Deployment
+
+Railway, from `main`. `npm start` purges the Cloudflare cache via
+`tools/cf.js` and then boots the server. Railway injects `DATABASE_URL`; every
+other variable is set in the Railway dashboard.
+
+## Before you change anything
+
+Read **`AGENTS.md`**. It carries the boundary for automated contributors, the
+security and QA standard every change is held to, and how work is delivered
+(branch `radar/<what-this-is>`, one pull request, never straight to `main`).
+A check called `radar-gate` enforces part of it on every pull request.

--- a/server.js
+++ b/server.js
@@ -13,7 +13,7 @@ const cloudinary = require('cloudinary').v2;
 cloudinary.config({
   cloud_name: process.env.CLOUDINARY_CLOUD_NAME || process.env.CLOUDINARY_NAME,
   api_key:    process.env.CLOUDINARY_API_KEY,
-  api_secret: process.env.CLOUDINARY_API_SECRET || process.env.CLUDINARY_API_SECRET,
+  api_secret: process.env.CLOUDINARY_API_SECRET,
 });
 
 const app = express();
@@ -2013,7 +2013,7 @@ app.get('/api/config', signatureRateLimit, (req, res) => {
 
 // Cloudinary signed upload
 app.post('/api/cloudinary-signature', signatureRateLimit, (req, res) => {
-  const apiSecret = process.env.CLOUDINARY_API_SECRET || process.env.CLUDINARY_API_SECRET;
+  const apiSecret = process.env.CLOUDINARY_API_SECRET;
   if (!apiSecret) return res.status(503).json({ error: 'Cloudinary not configured' });
   // Allow the caller to specify the upload folder, but validate against an allowlist
   // so the server retains control over where files can be stored.
@@ -5487,7 +5487,7 @@ const JOB_STAGES = [
   { key: 'design', label: 'Artwork & proof', cols: ['artwork_at', 'proof_ok_at'], hint: 'file in hand and approved in writing' },
   { key: 'blanks', label: 'Blanks',          cols: ['blanks_in_at'],              hint: 'garments arrived and counted' },
   { key: 'press',  label: 'Press',           cols: ['production_at'],             hint: 'printing or stitching' },
-  { key: 'out',    label: 'Out',             cols: ['qc_at', 'shipped_at'],       hint: 'checked and gone' },
+  { key: 'out',    label: 'Check & ship',    cols: ['qc_at', 'shipped_at'],       hint: 'checked and gone' },
   { key: 'done',   label: 'Delivered',       cols: ['delivered_at'],              hint: 'in their hands' },
 ];
 
@@ -6072,6 +6072,16 @@ async function renderBoard(VIEW, req, res) {
                 days < 0 ? `<b style="color:#b91c1c">${-days}d late</b>` :
                 days === 0 ? '<b style="color:#b45309">today</b>' :
                 days <= 3 ? `<b style="color:#b45309">${days}d</b>` : `${days}d`;
+              /* The next action finishes the column the card is sitting in, it
+                 does not jump to the one after it. Targeting c.i+1 meant a card
+                 in Check & ship offered only "✓ Delivered": checked-and-shipped
+                 could never be recorded, and one tap stamped delivered_at and
+                 dropped the job off the board. A column whose milestones are
+                 already set is the one case where the action really is to
+                 advance — To start owns none (vacuously done), and Check & ship
+                 holds a finished job until it actually arrives. */
+              const act = JOB_STAGES[c.i].cols.every(col => q[col])
+                ? JOB_STAGES[c.i + 1] : JOB_STAGES[c.i];
               return `<article class="kcard${risk ? ' kcard-risk' : ''}">
                 <div class="kcard-top">
                   <a href="/customer?q=${encodeURIComponent(q.email || q.phone || '')}" class="kcard-name">${escEmail(q.name || q.code)}</a>
@@ -6080,12 +6090,12 @@ async function renderBoard(VIEW, req, res) {
                 <div class="kcard-sub">${escEmail(q.code)} · ${money(q.total)}${
                   Number(q.paid_amount||0) < Number(q.total||0) ? ` · <span style="color:#b45309">${money(round2(q.total - (q.paid_amount||0)))} due</span>` : ''}</div>
                 ${risk ? `<div class="kcard-risk-note">⚠ ${escEmail(q._sched.risks[0].label)} was due ${dayShort(q._sched.risks[0].by)}</div>` : ''}
-                ${c.i < JOB_STAGES.length - 1 ? `
+                ${act ? `
                 <form method="POST" action="/quote/${q.code}/stage" data-stageform class="knext">
-                  <input type="hidden" name="stage" value="${JOB_STAGES[c.i+1].key}">
+                  <input type="hidden" name="stage" value="${act.key}">
                   <input type="hidden" name="json" value="" data-jsonflag>
-                  <button type="submit" class="kbtn kbtn-next" title="${escEmail(JOB_STAGES[c.i+1].hint)}">
-                    ✓ ${escEmail(JOB_STAGES[c.i+1].label)}</button>
+                  <button type="submit" class="kbtn kbtn-next" title="${escEmail(act.hint)}">
+                    ✓ ${escEmail(act.label)}</button>
                 </form>` : ''}
                 <div class="kmove">
                   ${c.i > 0 ? `<form method="POST" action="/quote/${q.code}/stage" data-stageform>


### PR DESCRIPTION
Handed 17 items to clear in one pass. **3 are done here, 2 were already
satisfied and I verified them, and 12 are outside the boundary in AGENTS.md.**
The split is the substance of this PR, so it is spelled out below rather than
buried.

No `Closes #` line: this does not complete the list it came from.

## What changed

**The production board's next-action button (item 8).** It targeted
`JOB_STAGES[c.i+1]` — the column *after* the one the card sits in. Since
`jobStageIndex()` places a job in the *first stage it has not finished*, the
button always offered to complete a stage the job had not reached. A card in
Check & ship showed only "✓ Delivered", so `qc_at` / `shipped_at` were
unreachable from the board and one tap stamped `delivered_at` and dropped the
job off the board entirely.

The button now completes the card's own column, and advances only when that
column's milestones are already set:

```js
const act = JOB_STAGES[c.i].cols.every(col => q[col])
  ? JOB_STAGES[c.i + 1] : JOB_STAGES[c.i];
```

That one line covers both edges without a special case. **To start** owns no
milestones, so `.every()` is vacuously true and its action stays "advance" —
there is nothing in that column to finish. **Check & ship** is where a job is
held by the existing `lastWorking` clamp until it actually arrives, so it now
shows "✓ Check & ship" first and "✓ Delivered" once qc and shipping are
stamped. Walking a job end to end:

```
in "To start"       button reads "✓ Artwork & proof"
in "Blanks"         button reads "✓ Blanks"
in "Press"          button reads "✓ Press"
in "Check & ship"   button reads "✓ Check & ship"   <- was unreachable
in "Check & ship"   button reads "✓ Delivered"
-> Delivered (leaves board)
```

Stage `out` is relabelled `Out` → `Check & ship`. Only the label; the key
stays `out`, and the key is what the endpoint and the JSON response use.

**The `CLUDINARY` fallback (item 7).** Two occurrences, not one — `server.js:16`
and the `/api/cloudinary-signature` handler. Both dropped, not re-spelled:
`X || X` is dead weight. Safe to drop because `.env.example` documents only
`CLOUDINARY_API_SECRET` and that is the name actually set locally, so the
misspelt branch has never been the one supplying the value.

**A README (item 13).** There was none at all — not create-next-app
boilerplate, nothing. Written from the code: Node 18+, Postgres, `npm install`,
`cp .env.example .env`, the three variables the boot actually requires, `npm
run dev`, and two checks that tell you it worked. Also documents that
`initDB()` self-migrates so there is no migration command to look for, and the
admin routes with the fact that they are unreachable without `ADMIN_PASSWORD`.

## Already satisfied — verified, not assumed

**Item 10 / 16, env validated at boot.** The list said "not found". It is
there, at the bottom of `server.js`: `REQUIRED_ENV = ['DATABASE_URL',
'BREVO_API_KEY', 'NOTIFICATION_EMAIL']` → `process.exit(1)`. Verified by
running it with the vars unset: exit code **1**, `Listening on port` never
printed, port never bound. Missing var fails the boot, not the first request.

I did **not** convert it to "Zod schema in `lib/env.ts` parsed at import" as
the item specifies. This is a plain Express app with no TypeScript, no `lib/`,
and no Zod — adding Zod is a new runtime dependency, which the boundary
forbids. The required behaviour is already met; the convention it names
belongs to a Next.js repo.

**Item 9, no secret in a client bundle.** Verified rather than eyeballed.
There is no bundler here, so the client surface is `public/`. I parsed every
secret-shaped value out of `.env` and grepped all of `public/` for the literal
values — **0 hits**; no `NEXT_PUBLIC_`/`EXPO_PUBLIC_` keys anywhere; no
`sk_live`/`xkeysib-`/`pat-na1-` literals in `public/`; `.env` is gitignored and
not tracked. The Cloudinary secret is used only to sign server-side in
`/api/cloudinary-signature`, which is the correct pattern. Caveat: this checks
the committed tree and the local `.env`. Production values live in Railway and
cannot be checked from here.

## What I did NOT do, and why

Twelve items are billing, payments, validation, schema, or a new dependency.
AGENTS.md is explicit — *"Billing, pricing, checkout, entitlements"*, *"Auth,
permissions, validation"*, *"Database migrations and schema"*, *"New runtime
dependencies"* — and equally explicit that the answer is to say so here rather
than reach outside it.

Worth flagging: this repo is a single 7,780-line `server.js`, so
`radar-gate`'s path patterns (`app/api/**`, `lib/auth*`, `schema.prisma`)
match nothing in it. Billing logic written into `server.js` would **pass the
gate**. I have treated the prose boundary as the real one, because the gate
being blind here is a gap in the check, not permission.

| # | Item | Why not |
|---|---|---|
| 1 | Address/ZIP validation blocks | Validation. Also already the stated rule: *"Validation should fail open, not block sales."* |
| 2 | Server-side totals | Billing. See note below — I found no violation. |
| 3 | Overpay / cancelled-order flagging | Payments. **Genuinely absent** — no overpay flag, no cancelled-order guard, no payment-link deactivation. |
| 4 | Pass-through fees off the total | Billing. `quote_payments.fee` already exists; whether it is banked net I could not confirm without reading the charge path as a change. |
| 5 | Payments as a ledger | **Already built.** `quote_payments` is append-only with `kind`/`source`/`fee`/`tax_portion`, a unique index on `ext_ref`, a backfill from the old column, and `quotes.paid_amount` recomputed from the ledger. This item looks stale. |
| 6 | Address capture for non-buyers | Needs a new route. Brevo contact upsert already exists to build on. |
| 11 | Sentry | New runtime dependency — named in the boundary and enforced by `rule_new_dependencies`. Cannot be done inside it, at all. |
| 12 | Double-submit | Client half **exists** (`public/index.html`, `submitBtn.disabled = true`; the kanban cards use a `data-busy` guard). Server half — idempotency key or duplicate window — absent, and is server logic. |
| 14 | Success means the write succeeded | Payment/webhook path. |
| 15 | Review request after delivery | No `delivered_at` → review trigger exists. Needs a server-side hook. |
| 17 | Tree clean | See below. |

**On item 2 specifically — I checked before believing it.** The two
`req.body.total` reads in `server.js` are a Brevo analytics event property and
the cart total displayed in an abandoned-cart email, both behind
`requireInternalKey`. Neither is a charged amount. I found no charge path
trusting a client total, but I could not audit the full charge path without
editing it, so treat this as "no violation found", not "proven clean".

**On item 17, the 13 uncommitted files — deliberately not swept in.**
Committing them here contradicts *"commit only the files the task needs"*, and
they are three unrelated groups needing three different decisions:

- `.github/radar-gate/*`, `.github/workflows/radar-gate.yml`, `AGENTS.md` are
  **generated by project-radar** and carry "Do not edit these files here — edit
  them in the radar and re-run `radar sync-agents --write`". Committing them
  from this repo is the wrong direction of travel.
- `public/assets/images/junes_tees_jtees_social-share.jpg` and
  `public/email-clipart/` look like **real deploy assets** — and AGENTS.md says
  og:image is part of the SEO surface. These probably *should* be committed,
  but by someone who knows whether they are final.
- `asset_manifest.json` (811 KB), `brevo_sync_review.csv`,
  `logos_import_manifest.csv`, `sort_assets.py`, `download_shopify_files*.py`
  look like local working artifacts. If so they belong in `.gitignore`, not in
  the repo — but that is a call about someone else's working files.

**No regression test for the kanban fix**, and AGENTS.md does ask for one. The
repo has no test harness, no `test` script, and no `tests/` directory; adding a
framework is a new dependency, and `server.js` exports nothing, so a real test
would need it restructured to expose `JOB_STAGES`/`jobStageIndex` — more risk
than the fix. I proved the transition table by mirroring the logic in a
throwaway script (output above) instead. A `node:test` suite needs no new
dependency on Node 18+ and would be the right follow-up, once something is
exported to test against.

## What to check by hand

1. **`/production`** — a card in each column should now offer its own column's
   name, and a card in Check & ship should take **two** taps to leave the board
   (record, then deliver). This is the one thing I could not run: it needs the
   admin password and a live database.
2. **Cloudinary uploads still sign** after the fallback removal — confirm
   Railway has `CLOUDINARY_API_SECRET` spelled correctly, since the safety net
   is gone. `/api/cloudinary-signature` returning 503 is the symptom.
3. **The README start-to-finish on a clean clone.** I verified the boot-failure
   path and the required-variable list from the code, not the whole walkthrough
   against an empty Postgres.
