### PR TITLE
Sign unsubscribe links with their own secret

### DIFF
--- a/server.js
+++ b/server.js
@@ -485,9 +485,41 @@ function unsubHeaders(to) {
   };
 }
 
+/* The secret unsubscribe links are signed with, or '' when none is configured.
+   This used to be JT_INTERNAL_KEY with a hardcoded 'jtees' fallback. Two
+   problems with that, and the fallback was the smaller one:
+
+   JT_INTERNAL_KEY is the shared secret for design.jtees.net and travels in
+   query strings to that host (jt-cron.php?key=, jt-catalog.php?key=), so it
+   lands in its access logs — it is the secret most likely to be rotated here.
+   But an unsubscribe token has to stay valid for as long as the email sits in
+   somebody's inbox, so rotating the shared key would silently invalidate every
+   unsubscribe link already delivered. A dead one-click unsubscribe is exactly
+   what gets bulk mail spam-foldered (RFC 8058, see above), and nothing would
+   surface it until deliverability fell off weeks later.
+
+   UNSUB_TOKEN_SECRET is seeded with the current JT_INTERNAL_KEY value, so
+   every link already in an inbox stays valid and the shared key can then be
+   rotated freely. The JT_INTERNAL_KEY read below is the migration path: it
+   keeps signing working on a deploy that lands before the variable is set, and
+   can be dropped once UNSUB_TOKEN_SECRET is set everywhere. */
+function unsubSecret() {
+  return process.env.UNSUB_TOKEN_SECRET?.trim() || process.env.JT_INTERNAL_KEY?.trim() || '';
+}
+
 function unsubToken(email) {
-  return crypto.createHmac('sha256', process.env.JT_INTERNAL_KEY || 'jtees')
+  const secret = unsubSecret();
+  // No secret means no signable token. Never fall back to a guessable
+  // constant — that makes a valid token forgeable for any address on the list.
+  if (!secret) return '';
+  return crypto.createHmac('sha256', secret)
     .update(String(email).toLowerCase()).digest('hex').slice(0, 32);
+}
+
+/** Constant-time check of an unsubscribe token. Never true without a secret. */
+function unsubTokenValid(email, token) {
+  const expected = unsubToken(email);
+  return expected !== '' && hexEqual(token, expected);
 }
 
 function unsubFooter(to) {
@@ -6789,7 +6821,7 @@ async function doUnsubscribe(email, source) {
 app.post('/api/unsubscribe', async (req, res) => {
   const email = String(req.query.e || req.body.e || '').trim().toLowerCase();
   const token = String(req.query.t || req.body.t || '');
-  if (!isValidEmail(email) || token !== unsubToken(email)) {
+  if (!isValidEmail(email) || !unsubTokenValid(email, token)) {
     return res.status(400).json({ error: 'bad token' });
   }
   try {
@@ -6813,7 +6845,7 @@ app.get('/api/unsubscribe', async (req, res) => {
       <p style="margin-top:26px;"><a href="https://www.jtees.net" style="color:#1848B8;">Back to jtees.net</a></p>
       <p style="color:#9ca3af;font-size:12px;margin-top:30px;">June&rsquo;s Tees &amp; Things &middot; Chicago, IL</p>
     </div>`;
-  if (!isValidEmail(email) || token !== unsubToken(email)) {
+  if (!isValidEmail(email) || !unsubTokenValid(email, token)) {
     return res.status(400).send(page('That link is not valid',
       'Please use the unsubscribe link from a recent email, or reply to any of our emails and we will remove you.'));
   }
@@ -7781,6 +7813,18 @@ function validateEnv() {
   }
   if (!process.env.ADMIN_PASSWORD?.trim()) {
     console.warn('WARNING: ADMIN_PASSWORD is not set — admin routes will be inaccessible.');
+  }
+  // Warn-only for the same reason as the two above: unsubscribe signing
+  // degrades marketing email, not the storefront or order receipts, which are
+  // transactional and never carry an unsubscribe token.
+  if (!unsubSecret()) {
+    console.warn('WARNING: neither UNSUB_TOKEN_SECRET nor JT_INTERNAL_KEY is set — ' +
+      'marketing email will ship unsubscribe links that cannot be honoured.');
+  } else if (!process.env.UNSUB_TOKEN_SECRET?.trim()) {
+    console.warn('WARNING: UNSUB_TOKEN_SECRET is not set — unsubscribe links are still ' +
+      'signed with JT_INTERNAL_KEY, so rotating that shared key would invalidate every ' +
+      'unsubscribe link already delivered. Set UNSUB_TOKEN_SECRET to the current ' +
+      'JT_INTERNAL_KEY value to decouple them without breaking existing links.');
   }
 }
 validateEnv();

--- a/server.js
+++ b/server.js
@@ -498,13 +498,39 @@ function unsubHeaders(to) {
    what gets bulk mail spam-foldered (RFC 8058, see above), and nothing would
    surface it until deliverability fell off weeks later.
 
-   UNSUB_TOKEN_SECRET is seeded with the current JT_INTERNAL_KEY value, so
-   every link already in an inbox stays valid and the shared key can then be
-   rotated freely. The JT_INTERNAL_KEY read below is the migration path: it
-   keeps signing working on a deploy that lands before the variable is set, and
-   can be dropped once UNSUB_TOKEN_SECRET is set everywhere. */
+   UNSUB_TOKEN_SECRET is a dedicated secret that has never travelled in a query
+   string. New mail is signed with it; links delivered before it existed were
+   signed with JT_INTERNAL_KEY and are still accepted, so nothing already in an
+   inbox breaks. It also keeps signing working on a deploy that lands before
+   the variable is set. */
 function unsubSecret() {
   return process.env.UNSUB_TOKEN_SECRET?.trim() || process.env.JT_INTERNAL_KEY?.trim() || '';
+}
+
+/* Every secret a delivered link could legitimately carry, newest first.
+
+   JT_INTERNAL_KEY is here only to honour links sent before UNSUB_TOKEN_SECRET
+   existed. Two consequences worth knowing before touching either variable:
+
+   - Accepting it means anyone who can read design.jtees.net's access logs can
+     still forge an unsubscribe token. That is exactly today's situation, so it
+     is not a regression — but it is why this entry should be deleted once mail
+     signed with the old key has aged out of people's inboxes.
+   - This tracks whatever JT_INTERNAL_KEY currently *is*. Rotating the shared
+     key therefore closes this window early and breaks those older links. Drop
+     this entry deliberately before rotating, rather than discovering it. */
+function unsubSecrets() {
+  const dedicated = process.env.UNSUB_TOKEN_SECRET?.trim();
+  const legacy = process.env.JT_INTERNAL_KEY?.trim();
+  const secrets = [];
+  if (dedicated) secrets.push(dedicated);
+  if (legacy && legacy !== dedicated) secrets.push(legacy);
+  return secrets;
+}
+
+function signUnsub(email, secret) {
+  return crypto.createHmac('sha256', secret)
+    .update(String(email).toLowerCase()).digest('hex').slice(0, 32);
 }
 
 function unsubToken(email) {
@@ -512,14 +538,18 @@ function unsubToken(email) {
   // No secret means no signable token. Never fall back to a guessable
   // constant — that makes a valid token forgeable for any address on the list.
   if (!secret) return '';
-  return crypto.createHmac('sha256', secret)
-    .update(String(email).toLowerCase()).digest('hex').slice(0, 32);
+  return signUnsub(email, secret);
 }
 
-/** Constant-time check of an unsubscribe token. Never true without a secret. */
+/** Constant-time check against every accepted secret. Never true without one. */
 function unsubTokenValid(email, token) {
-  const expected = unsubToken(email);
-  return expected !== '' && hexEqual(token, expected);
+  let ok = false;
+  // No early exit: every candidate is checked so the time taken does not
+  // reveal which secret matched.
+  for (const secret of unsubSecrets()) {
+    if (hexEqual(token, signUnsub(email, secret))) ok = true;
+  }
+  return ok;
 }
 
 function unsubFooter(to) {
@@ -7823,8 +7853,13 @@ function validateEnv() {
   } else if (!process.env.UNSUB_TOKEN_SECRET?.trim()) {
     console.warn('WARNING: UNSUB_TOKEN_SECRET is not set — unsubscribe links are still ' +
       'signed with JT_INTERNAL_KEY, so rotating that shared key would invalidate every ' +
-      'unsubscribe link already delivered. Set UNSUB_TOKEN_SECRET to the current ' +
-      'JT_INTERNAL_KEY value to decouple them without breaking existing links.');
+      'unsubscribe link already delivered. Set UNSUB_TOKEN_SECRET to decouple them.');
+  } else if (process.env.JT_INTERNAL_KEY?.trim()) {
+    // Not a problem — just the one state that has to end deliberately, since
+    // nothing else will ever remind you.
+    console.log('unsubscribe: signing with UNSUB_TOKEN_SECRET; still honouring older ' +
+      'JT_INTERNAL_KEY links. Remove that fallback once pre-migration mail has aged ' +
+      'out, and before rotating JT_INTERNAL_KEY.');
   }
 }
 validateEnv();

--- a/tests/unsub-token.test.js
+++ b/tests/unsub-token.test.js
@@ -40,38 +40,64 @@ function extract(name) {
 function load(env) {
   const sandbox = { crypto, process: { env }, Buffer, module: {}, exports: {} };
   vm.createContext(sandbox);
-  const code = ['hexEqual', 'unsubSecret', 'unsubToken', 'unsubTokenValid']
-    .map(extract).join('\n\n');
+  const code = ['hexEqual', 'unsubSecret', 'unsubSecrets', 'signUnsub',
+                'unsubToken', 'unsubTokenValid'].map(extract).join('\n\n');
   vm.runInContext(
-    `${code}\nmodule.exports = { unsubSecret, unsubToken, unsubTokenValid };`,
+    `${code}\nmodule.exports = { unsubSecret, unsubSecrets, unsubToken, unsubTokenValid };`,
     sandbox);
   return sandbox.module.exports;
 }
 
 const EMAIL = 'customer@example.com';
 const SHARED = 'the-current-shared-internal-key';
+const DEDICATED = 'a-fresh-dedicated-unsubscribe-secret';
 
-test('a link signed with JT_INTERNAL_KEY still verifies once UNSUB_TOKEN_SECRET ' +
-     'is seeded with the same value', () => {
-  // This is the whole migration guarantee. If it ever fails, setting the new
-  // variable silently breaks every unsubscribe link already delivered, which
-  // is the RFC 8058 breakage that gets bulk mail spam-foldered.
+test('a link delivered before the migration still verifies afterwards', () => {
+  // The whole migration guarantee, in the shape production actually has:
+  // UNSUB_TOKEN_SECRET is a NEW random value, not a copy of JT_INTERNAL_KEY.
+  // If this fails, every unsubscribe link already in an inbox dies on deploy,
+  // which is the RFC 8058 breakage that gets bulk mail spam-foldered.
   const before = load({ JT_INTERNAL_KEY: SHARED });
-  const after = load({ UNSUB_TOKEN_SECRET: SHARED, JT_INTERNAL_KEY: SHARED });
+  const after = load({ UNSUB_TOKEN_SECRET: DEDICATED, JT_INTERNAL_KEY: SHARED });
 
   const delivered = before.unsubToken(EMAIL);
   assert.ok(delivered, 'expected a token to be issued');
-  assert.strictEqual(after.unsubToken(EMAIL), delivered);
-  assert.ok(after.unsubTokenValid(EMAIL, delivered));
+  assert.ok(after.unsubTokenValid(EMAIL, delivered),
+    'a link sent before the migration must still unsubscribe');
 });
 
-test('rotating JT_INTERNAL_KEY does not affect links once UNSUB_TOKEN_SECRET is set', () => {
-  const before = load({ UNSUB_TOKEN_SECRET: SHARED, JT_INTERNAL_KEY: SHARED });
-  const rotated = load({ UNSUB_TOKEN_SECRET: SHARED, JT_INTERNAL_KEY: 'rotated-shared-key' });
+test('new mail is signed with the dedicated secret, not the shared key', () => {
+  const { unsubToken, unsubTokenValid } = load({
+    UNSUB_TOKEN_SECRET: DEDICATED, JT_INTERNAL_KEY: SHARED });
+  const issued = unsubToken(EMAIL);
+  const sharedSigned = crypto.createHmac('sha256', SHARED)
+    .update(EMAIL).digest('hex').slice(0, 32);
+  assert.notStrictEqual(issued, sharedSigned);
+  assert.ok(unsubTokenValid(EMAIL, issued));
+});
 
-  const delivered = before.unsubToken(EMAIL);
-  assert.ok(rotated.unsubTokenValid(EMAIL, delivered),
-    'a delivered link must survive rotation of the shared inter-service key');
+test('seeding the new secret with the old value also works', () => {
+  // The alternative migration, kept working so either choice is safe.
+  const before = load({ JT_INTERNAL_KEY: SHARED });
+  const after = load({ UNSUB_TOKEN_SECRET: SHARED, JT_INTERNAL_KEY: SHARED });
+  assert.ok(after.unsubTokenValid(EMAIL, before.unsubToken(EMAIL)));
+  // Spread into this realm's Array — the sandbox returns a foreign one.
+  assert.deepStrictEqual([...after.unsubSecrets()], [SHARED],
+    'an identical value must not be checked twice');
+});
+
+test('closing the grace window stops honouring old links', () => {
+  // What removing the JT_INTERNAL_KEY fallback is supposed to do.
+  const legacy = load({ JT_INTERNAL_KEY: SHARED }).unsubToken(EMAIL);
+  const closed = load({ UNSUB_TOKEN_SECRET: DEDICATED });
+  assert.strictEqual(closed.unsubTokenValid(EMAIL, legacy), false);
+});
+
+test('rotating JT_INTERNAL_KEY does not affect links signed with the dedicated secret', () => {
+  const before = load({ UNSUB_TOKEN_SECRET: DEDICATED, JT_INTERNAL_KEY: SHARED });
+  const rotated = load({ UNSUB_TOKEN_SECRET: DEDICATED, JT_INTERNAL_KEY: 'rotated-key' });
+  assert.ok(rotated.unsubTokenValid(EMAIL, before.unsubToken(EMAIL)),
+    'current-generation links must survive rotation of the shared key');
 });
 
 test('UNSUB_TOKEN_SECRET takes precedence over JT_INTERNAL_KEY', () => {

--- a/tests/unsub-token.test.js
+++ b/tests/unsub-token.test.js
@@ -1,0 +1,130 @@
+/* Regression tests for unsubscribe-link signing (server.js).
+ *
+ * Run: node --test tests/
+ * Uses only the built-in node:test runner, so this adds no dependency.
+ *
+ * The bug these cover: unsubToken() used to fall back to a hardcoded 'jtees'
+ * when JT_INTERNAL_KEY was unset, which makes a valid unsubscribe token
+ * forgeable for any address on the list. It also keyed unsubscribe links on the
+ * secret shared with design.jtees.net, so rotating that key would have
+ * invalidated every unsubscribe link already sitting in a customer's inbox.
+ *
+ * These pull the real functions out of server.js rather than restating them,
+ * so the tests cannot quietly drift from the code they are guarding. server.js
+ * boots a listener and a DB pool on require, which is why it is not imported.
+ */
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+const crypto = require('node:crypto');
+
+const SERVER = path.join(__dirname, '..', 'server.js');
+const src = fs.readFileSync(SERVER, 'utf8');
+
+/** Lift one top-level `function name(...) { ... }` out of the source. */
+function extract(name) {
+  const start = src.indexOf(`function ${name}(`);
+  assert.notStrictEqual(start, -1, `function ${name} not found in server.js`);
+  let depth = 0;
+  for (let i = src.indexOf('{', start); i < src.length; i++) {
+    if (src[i] === '{') depth++;
+    else if (src[i] === '}' && --depth === 0) return src.slice(start, i + 1);
+  }
+  throw new Error(`unbalanced braces reading ${name} from server.js`);
+}
+
+/** Evaluate the real signing functions against a given environment. */
+function load(env) {
+  const sandbox = { crypto, process: { env }, Buffer, module: {}, exports: {} };
+  vm.createContext(sandbox);
+  const code = ['hexEqual', 'unsubSecret', 'unsubToken', 'unsubTokenValid']
+    .map(extract).join('\n\n');
+  vm.runInContext(
+    `${code}\nmodule.exports = { unsubSecret, unsubToken, unsubTokenValid };`,
+    sandbox);
+  return sandbox.module.exports;
+}
+
+const EMAIL = 'customer@example.com';
+const SHARED = 'the-current-shared-internal-key';
+
+test('a link signed with JT_INTERNAL_KEY still verifies once UNSUB_TOKEN_SECRET ' +
+     'is seeded with the same value', () => {
+  // This is the whole migration guarantee. If it ever fails, setting the new
+  // variable silently breaks every unsubscribe link already delivered, which
+  // is the RFC 8058 breakage that gets bulk mail spam-foldered.
+  const before = load({ JT_INTERNAL_KEY: SHARED });
+  const after = load({ UNSUB_TOKEN_SECRET: SHARED, JT_INTERNAL_KEY: SHARED });
+
+  const delivered = before.unsubToken(EMAIL);
+  assert.ok(delivered, 'expected a token to be issued');
+  assert.strictEqual(after.unsubToken(EMAIL), delivered);
+  assert.ok(after.unsubTokenValid(EMAIL, delivered));
+});
+
+test('rotating JT_INTERNAL_KEY does not affect links once UNSUB_TOKEN_SECRET is set', () => {
+  const before = load({ UNSUB_TOKEN_SECRET: SHARED, JT_INTERNAL_KEY: SHARED });
+  const rotated = load({ UNSUB_TOKEN_SECRET: SHARED, JT_INTERNAL_KEY: 'rotated-shared-key' });
+
+  const delivered = before.unsubToken(EMAIL);
+  assert.ok(rotated.unsubTokenValid(EMAIL, delivered),
+    'a delivered link must survive rotation of the shared inter-service key');
+});
+
+test('UNSUB_TOKEN_SECRET takes precedence over JT_INTERNAL_KEY', () => {
+  const { unsubSecret } = load({ UNSUB_TOKEN_SECRET: 'dedicated', JT_INTERNAL_KEY: 'shared' });
+  assert.strictEqual(unsubSecret(), 'dedicated');
+});
+
+test('JT_INTERNAL_KEY is still honoured on a deploy that lands before the new var is set', () => {
+  const { unsubSecret, unsubToken } = load({ JT_INTERNAL_KEY: SHARED });
+  assert.strictEqual(unsubSecret(), SHARED);
+  assert.match(unsubToken(EMAIL), /^[0-9a-f]{32}$/);
+});
+
+test('no secret configured issues no token and validates nothing', () => {
+  // The regression itself: this case used to sign with 'jtees'.
+  const { unsubSecret, unsubToken, unsubTokenValid } = load({});
+  assert.strictEqual(unsubSecret(), '');
+  assert.strictEqual(unsubToken(EMAIL), '');
+  assert.strictEqual(unsubTokenValid(EMAIL, ''), false,
+    'an empty token must never validate — it is what a forged link would carry');
+  assert.strictEqual(unsubTokenValid(EMAIL, 'anything'), false);
+});
+
+test('blank and whitespace-only secrets count as unset', () => {
+  assert.strictEqual(load({ UNSUB_TOKEN_SECRET: '   ', JT_INTERNAL_KEY: '' }).unsubSecret(), '');
+  assert.strictEqual(
+    load({ UNSUB_TOKEN_SECRET: '  ', JT_INTERNAL_KEY: SHARED }).unsubSecret(), SHARED,
+    'a blank dedicated secret must fall through, not disable signing');
+});
+
+test('a token minted with the old hardcoded fallback no longer validates', () => {
+  const legacy = crypto.createHmac('sha256', 'jtees')
+    .update(EMAIL).digest('hex').slice(0, 32);
+  const { unsubTokenValid } = load({ JT_INTERNAL_KEY: SHARED });
+  assert.strictEqual(unsubTokenValid(EMAIL, legacy), false);
+});
+
+test('one address\'s token does not unsubscribe another address', () => {
+  const { unsubToken, unsubTokenValid } = load({ JT_INTERNAL_KEY: SHARED });
+  assert.strictEqual(unsubTokenValid('someone.else@example.com', unsubToken(EMAIL)), false);
+});
+
+test('address matching stays case-insensitive', () => {
+  const { unsubToken, unsubTokenValid } = load({ JT_INTERNAL_KEY: SHARED });
+  assert.ok(unsubTokenValid('Customer@Example.COM', unsubToken(EMAIL)),
+    'mail clients vary the case they echo back; the link must still work');
+});
+
+test('malformed tokens are rejected rather than throwing', () => {
+  const { unsubTokenValid } = load({ JT_INTERNAL_KEY: SHARED });
+  // hexEqual compares length first, so a short or long value must not blow up
+  // timingSafeEqual — a 500 here would be a broken unsubscribe page.
+  for (const bad of ['', 'z', 'not-hex', 'a'.repeat(31), 'a'.repeat(33), 'A'.repeat(32)]) {
+    assert.strictEqual(unsubTokenValid(EMAIL, bad), false, `rejected: ${JSON.stringify(bad)}`);
+  }
+});


### PR DESCRIPTION
Closes #24

## `UNSUB_TOKEN_SECRET` is already set in Railway ✅

It was set to a **fresh random value**, not a copy of `JT_INTERNAL_KEY` — which is the better choice, since the shared key has been leaking into access logs and reusing its value would let anyone with log access forge unsubscribe tokens.

That does mean verification has to accept both secrets during the transition, which the second commit adds. Verified by running the real signing functions against the real production values — the script printed only these booleans, and no secret was displayed, logged or committed:

```
link already in an inbox still works after deploy : true
newly issued link works                           : true
new links differ from old (dedicated secret used) : true
forged jtees token rejected                       : true
```

## What changed

**Unsubscribe links are signed with their own secret.** `unsubToken` now reads `UNSUB_TOKEN_SECRET`, falling back to `JT_INTERNAL_KEY`, and signs nothing at all when neither is set. The hardcoded `'jtees'` fallback is gone.

**Verification accepts both secrets during the transition.** New mail is signed with `UNSUB_TOKEN_SECRET`; links delivered before it existed were signed with `JT_INTERNAL_KEY` and are still honoured, so nothing already in an inbox breaks. All candidates are checked without an early exit, so timing doesn't reveal which one matched.

**Token checks are constant-time and fail closed.** A new `unsubTokenValid` reuses the existing `hexEqual` helper (`server.js:1054`) instead of the plain `!==` the two `/api/unsubscribe` handlers used, and returns `false` whenever no secret is configured.

**Boot warns about both bad states** — no secret at all, and the migration not finished — following the warn-vs-crash tiering `validateEnv()` already documents.

**Regression tests** in `tests/unsub-token.test.js`, built-in `node --test`, no new dependency.

## First, the finding that reframes the issue

The issue says the fallback "guards `/admin/sso` and a few internal endpoints." **It does not, and no admin surface was ever exposed by it.** There was exactly one `|| 'jtees'` in the tree — `unsubToken` — and every other consumer of the key already failed closed: `/admin/sso` (`|| ''` → 401), `requireInternalKey` (→ 403), `syncQuoteToLumise` and `getCatalog` (no-op), the cron sweep (never scheduled).

I also settled the question the original agent stopped on: **`JT_INTERNAL_KEY` is set in Railway production**, so the fallback was dead code on the live site. Checked with `railway variables`.

So the reported bug was real but not live. What made this worth doing is the thing underneath it.

## Why this approach

`JT_INTERNAL_KEY` is the shared secret for design.jtees.net and travels **in query strings** (`jt-cron.php?key=`, `jt-catalog.php?key=`), so it sits in that host's access logs. It is the secret most likely to need rotating. But an unsubscribe token has to stay valid for as long as the email sits in someone's inbox.

Those two lifetimes are incompatible. **Rotating the shared key would have silently invalidated every unsubscribe link already delivered** — one-click unsubscribe starts returning 400, which is the RFC 8058 breakage the comment at `server.js:475` says was fixed to stop this shop's mail being spam-foldered. Nothing would have surfaced it until deliverability fell off weeks later, and the cause would have looked unrelated to the rotation that caused it.

Accepting both secrets is what makes this safe: links already in an inbox keep working, new mail moves to a secret that has never been in a query string, and afterwards `JT_INTERNAL_KEY` can rotate without touching unsubscribe. There are tests pinning each of those.

**Considered and rejected:** removing the fallback alone — safe, but leaves the rotation trap. Seeding `UNSUB_TOKEN_SECRET` with the current `JT_INTERNAL_KEY` value — simpler, and the tests still cover it, but it would keep a log-exposed value as the signing secret. A hard boot crash on a missing secret — rejected because `validateEnv()` already documents the opposite rule: a missing var that degrades one feature warns, it doesn't take the storefront down over an email-only misconfiguration.

## Verification

Thirteen tests pass. More usefully, I checked they have teeth — they fail against `main`, and the specific forgery is demonstrable:

```
OLD, unset key: server expects 402bf7c37f57b011d7da13a29d5747ce
OLD, unset key: attacker sends 402bf7c37f57b011d7da13a29d5747ce
OLD  -> forged link accepted: true
NEW, unset key: same forged token accepted: false
```

The tests lift the real functions out of `server.js` with a brace-matched extract rather than restating them, so they can't drift from the code. `server.js` boots a listener and DB pool on require, which is why it isn't imported directly.

```
node --test tests/unsub-token.test.js
```

## About the boundary — please read this bit

**This change is outside the agent boundary and I was authorized to make it anyway.** `server.js` is auth/validation logic in the file that holds every API route. I stopped, put the options on #24 with a recommendation, and the owner picked this one and told me to implement it. Flagging it here so it isn't mistaken for an agent quietly reaching outside its lane.

Two things worth knowing regardless:

- **radar-gate would not have caught it.** Its `BLOCKED_PATHS` are Next.js-shaped (`app/api/`, `lib/auth*`, `route.ts`) and match nothing in this Express monolith — `blocked_reason('server.js')` returns `None`. A green check here is not evidence this stayed in bounds. Filed as alwinte5-rgb/project-radar#16.
- **`.env.example` could not be updated.** The gate's `FORBIDDEN_FILES` pattern `(^|/)\.env(\.|$)` matches `.env.example` too, so any PR touching it is refused outright — which means "document the missing env var," the thing the original note asked for, is structurally impossible for an agent to deliver in any repo. Filed as alwinte5-rgb/project-radar#15. **`UNSUB_TOKEN_SECRET` and `JT_INTERNAL_KEY` are therefore still undocumented in `.env.example`** and need adding by hand.

## What I did not do

- Did not touch `.env.example` (refused by the gate, above).
- **Did not close the grace window.** `JT_INTERNAL_KEY` is still accepted so pre-migration links work. It should be removed once that mail has aged out of inboxes — and **before** rotating `JT_INTERNAL_KEY`, because the fallback tracks whatever that variable currently is, so rotating closes the window early and breaks those older links. The boot log states this on every start; there's a test covering the closed state.
- Did not rotate `JT_INTERNAL_KEY`. Its value was read locally to verify the migration end to end, but never printed, logged or committed — only the booleans above came out.
- Did not run the server end to end. It needs `DATABASE_URL` and a live Postgres; I tested the signing functions directly instead.

## Check by hand after merging

1. Take an unsubscribe link from an email sent *before* this deploy and click it — it must still work. I verified this against the real production values, but only through the signing functions, not a real click.
2. Send yourself a marketing email and confirm the new footer link and Gmail's list-unsubscribe both work.
3. Confirm the boot log shows the "still honouring older JT_INTERNAL_KEY links" line and **no** warning.
