### PR TITLE
Restore the CLUDINARY_API_SECRET fallback (unbreaks signed uploads)

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,30 @@ below is needed to get the app running locally.
 - **Cloudinary** — `CLOUDINARY_CLOUD_NAME`, `CLOUDINARY_API_KEY`,
   `CLOUDINARY_API_SECRET`. Uploads are signed server-side via
   `/api/cloudinary-signature`; the secret never reaches the browser.
+
+  **The secret is stored on Railway under a misspelt name,
+  `CLUDINARY_API_SECRET`, and the server deliberately reads both spellings.**
+  Do not tidy that fallback away. PR #7 did, and it took signed uploads down:
+  the correctly-spelled variable had never been set, so
+  `/api/cloudinary-signature` started answering **503 `Cloudinary not
+  configured`** and every photo upload silently stopped attaching, while the
+  quote and review forms carried on submitting and reporting success.
+  `tests/cloudinary-secret.test.js` now fails if the fallback is removed.
+
+  To retire the typo safely: add `CLOUDINARY_API_SECRET` on Railway with the
+  same value, redeploy, confirm the check below returns `200`, then delete
+  `CLUDINARY_API_SECRET` and the fallback together.
+
+  ```bash
+  curl -s -o /dev/null -w '%{http_code}\n' -X POST \
+    https://jtees.net/api/cloudinary-signature \
+    -H 'Content-Type: application/json' -d '{"folder":"quote_requests"}'
+  ```
+
+  `200` is healthy, `503` means neither spelling is set. Note the cloud name
+  and API key come from a separate public endpoint (`/api/config`) and can
+  look perfectly correct while the secret is absent — which is why this failure
+  is easy to look straight at and call fine.
 - **Resend** — `RESEND_API_KEY`, the fallback when Brevo sending fails.
 - **Clover** — `CLOVER_*`, card payments and the payment webhook.
 - **HubSpot** — `HUBSPOT_*`, legacy contact sync.

--- a/server.js
+++ b/server.js
@@ -10,10 +10,16 @@ const { Resend } = require('resend');
 const axios      = require('axios');
 const cloudinary = require('cloudinary').v2;
 
+/* CLUDINARY_API_SECRET is a typo, and it is the name the secret is actually
+   stored under on Railway. #7 removed this fallback as a tidy-up and took
+   signed uploads down with it: the correctly-spelled variable has never been
+   set, so `/api/cloudinary-signature` began answering 503 and every photo
+   upload silently stopped attaching. Keep both spellings until the Railway
+   variable is renamed — see README, "Cloudinary". */
 cloudinary.config({
   cloud_name: process.env.CLOUDINARY_CLOUD_NAME || process.env.CLOUDINARY_NAME,
   api_key:    process.env.CLOUDINARY_API_KEY,
-  api_secret: process.env.CLOUDINARY_API_SECRET,
+  api_secret: process.env.CLOUDINARY_API_SECRET || process.env.CLUDINARY_API_SECRET,
 });
 
 const app = express();
@@ -2075,7 +2081,8 @@ app.get('/api/config', signatureRateLimit, (req, res) => {
 
 // Cloudinary signed upload
 app.post('/api/cloudinary-signature', signatureRateLimit, (req, res) => {
-  const apiSecret = process.env.CLOUDINARY_API_SECRET;
+  // Both spellings, for the reason given at cloudinary.config() above.
+  const apiSecret = process.env.CLOUDINARY_API_SECRET || process.env.CLUDINARY_API_SECRET;
   if (!apiSecret) return res.status(503).json({ error: 'Cloudinary not configured' });
   // Allow the caller to specify the upload folder, but validate against an allowlist
   // so the server retains control over where files can be stored.

--- a/tests/cloudinary-secret.test.js
+++ b/tests/cloudinary-secret.test.js
@@ -1,0 +1,112 @@
+/* Regression tests for how the Cloudinary API secret is resolved (server.js).
+ *
+ * Run: node --test tests/*.test.js   (the files, not the directory — on
+ * current Node a positional argument is a glob, so `tests/` fails)
+ *
+ * The outage these exist to prevent, in full, because it has happened once and
+ * the shape of it is what matters:
+ *
+ * The secret is stored on Railway under a misspelt name, CLUDINARY_API_SECRET.
+ * server.js read both spellings, so it worked. PR #7 removed the misspelt one
+ * as a tidy-up — the correctly-spelled variable had never been set, so signing
+ * broke on deploy. `/api/cloudinary-signature` began answering 503 and every
+ * photo upload silently stopped attaching, while the quote and review forms
+ * carried on submitting and reporting success. Nothing failed loudly, no test
+ * covered it, and it was found by curling production.
+ *
+ * So: the fallback is load-bearing until the Railway variable is renamed, and
+ * these tests are what says so to whoever next tries to tidy it away. If you
+ * are here because one of these failed, read the note at cloudinary.config()
+ * in server.js before deleting anything.
+ *
+ * These lift the real expressions out of server.js rather than restating them,
+ * so the tests cannot quietly drift from the code they are guarding. server.js
+ * boots a listener and a DB pool on require, which is why it is not imported.
+ */
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const SERVER = path.join(__dirname, '..', 'server.js');
+const src = fs.readFileSync(SERVER, 'utf8');
+
+/**
+ * Lift one `const NAME = ...;` statement, found by its opening text. Anchored
+ * on the shortest text that is still unique in the file, NOT on the expression
+ * itself — anchored on the expression, deleting the fallback would make the
+ * anchor vanish and the suite would die with "not found" rather than failing
+ * on what it asserts, which reports a rewrite instead of a regression.
+ */
+function extractConst(anchor) {
+  const start = src.indexOf(anchor);
+  assert.notStrictEqual(start, -1, `\`${anchor}\` not found in server.js`);
+  let depth = 0, tick = false;
+  for (let i = start; i < src.length; i++) {
+    const c = src[i];
+    if (c === '`' && src[i - 1] !== '\\') tick = !tick;
+    else if (!tick && '([{'.includes(c)) depth++;
+    else if (!tick && ')]}'.includes(c)) depth--;
+    else if (!tick && c === ';' && depth === 0) return src.slice(start, i + 1);
+  }
+  throw new Error(`unterminated statement reading \`${anchor}\``);
+}
+
+/* The route's resolution, exactly as server.js writes it. */
+const API_SECRET_SRC = extractConst('const apiSecret =');
+
+/* The config block's, pulled out of the cloudinary.config({...}) call. */
+const CONFIG_SECRET_SRC = (() => {
+  const m = /api_secret:\s*([^\n]+?),?\n/.exec(
+    src.slice(src.indexOf('cloudinary.config({')));
+  assert.ok(m, 'api_secret not found in the cloudinary.config() call');
+  return m[1].replace(/,\s*$/, '');
+})();
+
+/** Resolve a secret expression against a fabricated environment. */
+function resolve(expr, env) {
+  const sandbox = { process: { env } };
+  vm.createContext(sandbox);
+  return vm.runInContext(`(${expr})`, sandbox);
+}
+
+const VALUE = 'the-actual-cloudinary-api-secret';
+
+/* Both places that resolve the secret, held to the same rule. They drifted
+   apart once already — #7 changed both, but nothing would have caught it
+   changing only one, and a config block that signs while the route 503s
+   (or vice versa) is a genuinely confusing failure to debug. */
+const SITES = [
+  ['the /api/cloudinary-signature route', API_SECRET_SRC.replace(/^const apiSecret =\s*/, '').replace(/;$/, '')],
+  ['the cloudinary.config() call', CONFIG_SECRET_SRC],
+];
+
+for (const [where, expr] of SITES) {
+  test(`${where} accepts the correctly-spelled CLOUDINARY_API_SECRET`, () => {
+    assert.strictEqual(resolve(expr, { CLOUDINARY_API_SECRET: VALUE }), VALUE);
+  });
+
+  test(`${where} still accepts the misspelt CLUDINARY_API_SECRET`, () => {
+    /* The one the secret is actually stored under on Railway. Delete this
+       fallback and signed uploads stop working in production — that is not a
+       hypothetical, it is what #7 did. Rename the Railway variable first. */
+    assert.strictEqual(resolve(expr, { CLUDINARY_API_SECRET: VALUE }), VALUE,
+      'the misspelt fallback was removed — signed uploads will 503 in production');
+  });
+
+  test(`${where} prefers the correct spelling when both are set`, () => {
+    /* So renaming the Railway variable is a safe, reversible step: set the
+       correct one alongside the typo, confirm it works, then drop the typo. */
+    assert.strictEqual(
+      resolve(expr, { CLOUDINARY_API_SECRET: VALUE, CLUDINARY_API_SECRET: 'stale' }),
+      VALUE);
+  });
+
+  test(`${where} resolves to nothing when neither is set`, () => {
+    /* What makes the route answer 503 rather than signing with undefined and
+       handing the browser a signature Cloudinary will reject. */
+    assert.ok(!resolve(expr, {}), 'an unset secret must be falsy');
+  });
+}


### PR DESCRIPTION
Restores the `CLUDINARY_API_SECRET` fallback that #7 removed. Signed uploads
are broken in production right now and this is what unbreaks them.

**This PR is outside the agent boundary and radar-gate refuses it. That is
expected, and it was the repo owner's explicit decision to take it anyway.**
Details at the bottom — please read that section before merging.

## What was wrong

The Cloudinary API secret is stored on Railway under a misspelt name:
`CLUDINARY_API_SECRET`. `server.js` read both spellings, so it worked. #7
removed the misspelt one as a tidy-up — but the correctly-spelled variable had
never been set, so signing broke the moment that deployed.

Live, before this change:

```
$ curl -s -o /dev/null -w '%{http_code}\n' -X POST \
    https://jtees.net/api/cloudinary-signature \
    -H 'Content-Type: application/json' -d '{"folder":"quote_requests"}'
503
```

What that costs while it is unfixed: **every photo upload silently fails to
attach.** The quote form and the review form still submit and still report
success — the upload is the only part that fails, and it fails into a
`.catch()`. Quote requests have been arriving without their reference photos
and nothing has been saying so.

It is easy to look straight at this and call it fine, which is why it survived:
`/api/config` is a *separate, public* endpoint carrying only the cloud name and
API key. Both are set correctly and it returns a healthy 200. The secret is
server-only and never appears there.

## What changed

**The fallback is back, in both places #7 touched** — `cloudinary.config()` and
the `/api/cloudinary-signature` handler. Both now read
`CLOUDINARY_API_SECRET || CLUDINARY_API_SECRET`, correct spelling first, with a
comment at the config site explaining why the typo is load-bearing.

**`tests/cloudinary-secret.test.js` (new)** — eight tests, four against each
site, asserting that either spelling resolves, that the correct one wins when
both are set, and that neither set is falsy so the route still 503s rather than
signing with `undefined`. They lift the real expressions out of `server.js` and
evaluate them against fabricated environments, the pattern
`tests/unsub-token.test.js` already uses.

I verified they catch the regression by making the #7 edit again: two tests
fail, one per site, with `the misspelt fallback was removed — signed uploads
will 503 in production`. Both sites are covered because #7 changed both and
nothing would have caught it changing only one — a config block that signs
while the route 503s is a genuinely nasty thing to debug.

**README** — the Cloudinary section now says the fallback exists on purpose,
what removing it did, and gives the safe retirement path (add the correct name
alongside, confirm 200, then drop both the typo and the fallback together).

Full suite: 21/21.

## Why this rather than renaming the variable

Renaming on Railway is one dashboard edit, needs no code, and would let the
typo die. I recommended it and the owner chose this instead, so this is the
route being taken. The two are not exclusive — the README documents the rename
as a safe follow-up, and because the correct spelling is checked first, setting
it on Railway later makes the fallback dead code that can be deleted with the
tests still green.

## The gate refuses this, and cannot be waived

```
REFUSED -- these lines are outside the boundary, whatever file they were put in:
  server.js
      reads a credential
      api_secret: process.env.CLOUDINARY_API_SECRET || process.env.CLUDINARY_API_SECRET,
```

Two things worth knowing before you try to clear it:

1. **`ACCEPTED.md` does not work on this finding.** The gate's own message
   suggests accepting a CRITICAL in writing, but `content_out_of_bounds`
   returns the blocking exit code *before* `review()` and `load_accepted()` are
   ever reached. A written acceptance has no effect on a content-boundary
   breach.
2. So this needs an **admin merge over the red check**, or a change to the
   gate's `BLOCKED_CONTENT` credential rule.

I did not touch the gate to make my own PR pass. That seemed like exactly the
wrong thing to do quietly, and it is a separate decision from this fix.

## What to check by hand

1. After merge and deploy, re-run the curl above and confirm **200**.
2. Then attach a photo to a real quote request and confirm it arrives — a 200
   proves the signature, not the round trip.
3. **Worth a look while you are in there:** the two inline upload widgets read
   `process.env.CLOUDINARY_NAME` only, while `/api/config` reads
   `CLOUDINARY_CLOUD_NAME || CLOUDINARY_NAME`. If Railway has only
   `CLOUDINARY_CLOUD_NAME` set, those widgets get an empty cloud name and
   disable themselves before signing is ever reached. It presumably works today
   since uploads worked before #7, but it is the same class of bug sitting one
   variable over, and I did not change it.
