### PR TITLE
Make failed photo uploads visible instead of silent

### DIFF
--- a/server.js
+++ b/server.js
@@ -1833,6 +1833,36 @@ function turnstileWidget() {
     <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>`;
 }
 
+/**
+ * The status line shared by every photo-upload widget, as client-side source.
+ *
+ * Defined once and interpolated into both the quote builder and the review
+ * form so the two cannot drift, and kept pure — counts in, string out, no DOM —
+ * because that is what makes it testable without a browser. See
+ * `tests/upload-status.test.js`.
+ *
+ * The bug it exists to prevent: the review form set an error message in its
+ * `.catch()` and then immediately called its redraw, which overwrote the
+ * message with the attached-photo count. With nothing attached that count is
+ * the empty string, so a failed upload left the status line BLANK. The photo
+ * vanished, the form still submitted, and the customer was told nothing. A
+ * failure has to be part of what the redraw renders, not something written
+ * beside it and lost on the next paint.
+ */
+function uploadStatusScript() {
+  return `
+      /* pending: in flight. done: attached. failed: gave up. reason: the most
+         recent human-readable cause, or '' if there is nothing to add. */
+      function uploadStatus(pending, done, failed, reason){
+        var parts = [];
+        if (pending) parts.push('Uploading ' + pending + ' photo' + (pending > 1 ? 's' : '') + '\\u2026');
+        if (done)    parts.push(done + ' photo' + (done > 1 ? 's' : '') + ' attached');
+        if (failed)  parts.push(failed + ' photo' + (failed > 1 ? 's' : '') +
+                                ' would not upload' + (reason ? ' \\u2014 ' + reason : ''));
+        return parts.join(' \\u00b7 ');
+      }`;
+}
+
 function rejectBots(req, res, next) {
   // Block requests that bypass Cloudflare entirely — set REQUIRE_CLOUDFLARE=true in Railway
   if (!req.headers['cf-ray']) {
@@ -3320,7 +3350,8 @@ app.get(['/quote/new', '/quote/:code/edit'], requireAdmin, async (req, res) => {
         <label>Notes for the customer</label><textarea name="notes" rows="2" placeholder="Optional">${val(E.notes)}</textarea>
       </div>
 
-      <button type="submit">${existing ? 'Save changes' : 'Create quote &amp; get the message'}</button>
+      <p class="muted" id="qfstat" style="margin-top:10px;font-size:12.5px"></p>
+      <button type="submit" id="qfgo">${existing ? 'Save changes' : 'Create quote &amp; get the message'}</button>
     </form>
     <p style="margin-top:14px"><a class="muted" href="/quotes">View all quotes →</a></p>
     <script>
@@ -3477,11 +3508,49 @@ app.get(['/quote/new', '/quote/:code/edit'], requireAdmin, async (req, res) => {
       var CLOUD = ${JSON.stringify(process.env.CLOUDINARY_NAME || '')};
       var CKEY  = ${JSON.stringify(process.env.CLOUDINARY_API_KEY || '')};
 
+${uploadStatusScript()}
+
       /* Upload through the existing signed-upload endpoint so the API secret
          never reaches the browser. Files go to the allow-listed
-         "quote_requests" folder. */
+         "quote_requests" folder.
+
+         Every failure path here has to end up in upFailed and go through
+         saySoon(). This form had no in-flight tracking at all: the save button
+         stayed live while uploads were still running, so saving quickly meant
+         the hidden field had not been written yet and the photos were dropped
+         with nothing said. A ✕ in a 58px thumbnail was the only sign, and it
+         did not stop the save. */
+      var upPending = 0, upFailed = 0, upReason = '';
+      var qfstat = document.getElementById('qfstat');
+      var qfgo   = document.getElementById('qfgo');
+
+      function saySoon(){
+        var attached = 0;
+        document.querySelectorAll('.im').forEach(function(h){
+          try { attached += h.value ? JSON.parse(h.value).length : 0; } catch (e) {}
+        });
+        qfstat.textContent = uploadStatus(upPending, attached, upFailed, upReason);
+        qfstat.style.color = upFailed ? '#b45309' : '#6b7280';
+        qfgo.disabled = upPending > 0;
+        qfgo.style.opacity = upPending > 0 ? '.6' : '';
+        /* The button says what it is about to do. Saving with photos missing
+           is allowed — a quote is worth more than its reference shots — but it
+           must not look like the photos went with it. */
+        qfgo.textContent = (!upPending && upFailed)
+          ? ${JSON.stringify(existing ? 'Save changes' : 'Create quote')} + ' without the missing photo' + (upFailed > 1 ? 's' : '')
+          : ${JSON.stringify(existing ? 'Save changes' : 'Create quote & get the message')};
+      }
+
       function uploadFiles(L, files){
-        if (!CLOUD || !CKEY || !files.length) return;
+        if (!files.length) return;
+        if (!CLOUD || !CKEY) {
+          /* Silently returning is how this hid: the admin picked files and
+             absolutely nothing happened, on a form that otherwise works. */
+          upFailed += files.length;
+          upReason = 'photo uploads are not configured on this server';
+          saySoon();
+          return;
+        }
         var hidden = L.querySelector('.im');
         var thumbs = L.querySelector('.thumbs');
         Array.prototype.forEach.call(files, function(file){
@@ -3489,11 +3558,20 @@ app.get(['/quote/new', '/quote/:code/edit'], requireAdmin, async (req, res) => {
           ph.style.cssText = 'width:58px;height:58px;border-radius:8px;background:#eef1f8;display:flex;align-items:center;justify-content:center;font-size:10px;color:#6b7280';
           ph.textContent = '…';
           thumbs.appendChild(ph);
+          upPending++; saySoon();
           var ts = Math.round(Date.now()/1000);
           fetch('/api/cloudinary-signature', {
             method:'POST', headers:{'Content-Type':'application/json'},
             body: JSON.stringify({ folder:'quote_requests', timestamp: ts })
-          }).then(function(r){return r.json();}).then(function(sig){
+          }).then(function(r){
+            /* A 503 from this endpoint is still JSON — {error:'Cloudinary not
+               configured'} — so parsing alone never throws, and the missing
+               signature was only noticed two steps later when Cloudinary
+               rejected the upload. Check the status here. */
+            if (!r.ok) throw new Error('signature unavailable');
+            return r.json();
+          }).then(function(sig){
+            if (!sig.signature) throw new Error('signature unavailable');
             var fd = new FormData();
             fd.append('file', file);
             fd.append('api_key', CKEY);
@@ -3510,8 +3588,11 @@ app.get(['/quote/new', '/quote/:code/edit'], requireAdmin, async (req, res) => {
             ph.textContent = '';
           }).catch(function(e){
             ph.textContent = '✕'; ph.style.color = '#b71c1c';
+            upFailed++;
+            upReason = /signature/.test(e && e.message || '')
+              ? 'the server would not sign the upload' : 'the upload was rejected';
             console.error('upload failed', e);
-          });
+          }).then(function(){ upPending--; saySoon(); });
         });
       }
 
@@ -6582,12 +6663,14 @@ app.get('/review/:token', async (req, res) => {
           <label>Name to show <span style="text-transform:none;font-weight:400">(first name and initial is fine)</span></label>
           <input name="name" value="${escEmail(r.name || '')}" maxlength="60">
 
-          <label style="margin-top:14px">Add a photo <span style="text-transform:none;font-weight:400">(optional)</span></label>
-          <p class="muted" style="margin:-2px 0 6px;font-size:13px">A picture of your order says more than we ever could.</p>
-          <input type="file" id="rvfi" accept="image/*" multiple style="padding:8px;font-size:13px">
+          <div id="rvphoto">
+            <label style="margin-top:14px">Add a photo <span style="text-transform:none;font-weight:400">(optional)</span></label>
+            <p class="muted" style="margin:-2px 0 6px;font-size:13px">A picture of your order says more than we ever could.</p>
+            <input type="file" id="rvfi" accept="image/*" multiple style="padding:8px;font-size:13px">
+            <div id="rvthumbs" style="display:flex;flex-wrap:wrap;gap:6px;margin-top:8px"></div>
+            <p class="muted" id="rvstat" style="margin-top:6px;font-size:12.5px"></p>
+          </div>
           <input type="hidden" name="images" id="rvim" value="">
-          <div id="rvthumbs" style="display:flex;flex-wrap:wrap;gap:6px;margin-top:8px"></div>
-          <p class="muted" id="rvstat" style="margin-top:6px;font-size:12.5px"></p>
 
           ${turnstileWidget()}
           <button type="submit" id="rvgo" style="width:100%;margin-top:14px">Send my review</button>
@@ -6605,36 +6688,61 @@ app.get('/review/:token', async (req, res) => {
         /* Photo upload. Signed server-side so the API secret never reaches the
            browser, and the submit button is held while uploads are in flight so
            a review cannot be sent with half its photos missing. */
+${uploadStatusScript()}
+
         var CLOUD = ${JSON.stringify(process.env.CLOUDINARY_NAME || '')};
         var CKEY  = ${JSON.stringify(process.env.CLOUDINARY_API_KEY || '')};
-        var shots = [], pending = 0;
+        var shots = [], pending = 0, failed = 0, reason = '';
         var fi = document.getElementById('rvfi');
         var go = document.getElementById('rvgo');
         var stat = document.getElementById('rvstat');
 
-        if (!CLOUD || !CKEY) { fi.parentNode.style.display = 'none'; }
+        /* Hide the photo field, NOT fi.parentNode — the file input sits
+           directly inside <form>, so hiding its parent hid the rating, the
+           text boxes and the send button along with it. An unset
+           CLOUDINARY_NAME would have taken the entire review page down and
+           left customers looking at a heading with no form under it. */
+        if (!CLOUD || !CKEY) { document.getElementById('rvphoto').style.display = 'none'; }
 
         function say(){
-          stat.textContent = pending ? 'Uploading ' + pending + ' photo' + (pending>1?'s':'') + '…'
-                          : (shots.length ? shots.length + ' photo' + (shots.length>1?'s':'') + ' attached' : '');
+          stat.textContent = uploadStatus(pending, shots.length, failed, reason);
+          stat.style.color = failed ? '#b45309' : '';
           go.disabled = pending > 0;
           go.style.opacity = pending > 0 ? '.6' : '';
+          /* Say what the button will actually do. A review is worth more than
+             its photo, so a failure never blocks sending — but it must not be
+             sent believing the photo went too. */
+          go.textContent = (!pending && failed)
+            ? 'Send my review without the photo' + (failed > 1 ? 's' : '')
+            : 'Send my review';
           document.getElementById('rvim').value = JSON.stringify(shots);
         }
 
         fi.onchange = function(){
           Array.prototype.forEach.call(fi.files, function(file){
-            if (!/^image\\//.test(file.type)) return;
+            /* Both of these used to drop the file on the floor — the type
+               check said nothing at all, and the size message was written
+               straight to the status line, where the next say() erased it. */
+            if (!/^image\\//.test(file.type)) {
+              failed++; reason = 'only image files can be attached'; say(); return;
+            }
             if (file.size > 10 * 1024 * 1024) {            // 10MB is plenty for a phone photo
-              stat.textContent = file.name + ' is too large (10MB max)';
-              return;
+              failed++; reason = 'photos must be under 10MB'; say(); return;
             }
             pending++; say();
             var ts = Math.round(Date.now()/1000);
             fetch('/api/cloudinary-signature', {
               method: 'POST', headers: {'Content-Type':'application/json'},
               body: JSON.stringify({ folder: 'review_photos', timestamp: ts })
-            }).then(function(r){ return r.json(); }).then(function(sig){
+            }).then(function(r){
+              /* A 503 here is JSON too — {error:'Cloudinary not configured'} —
+                 so parsing alone never throws and the missing signature was
+                 only noticed when Cloudinary rejected the upload two steps
+                 later. Check the status. */
+              if (!r.ok) throw new Error('signature unavailable');
+              return r.json();
+            }).then(function(sig){
+              if (!sig.signature) throw new Error('signature unavailable');
               var fd = new FormData();
               fd.append('file', file);
               fd.append('api_key', CKEY);
@@ -6644,15 +6752,20 @@ app.get('/review/:token', async (req, res) => {
               return fetch('https://api.cloudinary.com/v1_1/'+CLOUD+'/image/upload',
                 { method:'POST', body: fd });
             }).then(function(r){ return r.json(); }).then(function(d){
-              if (d.secure_url) {
-                shots.push(d.secure_url);
-                var im = document.createElement('img');
-                im.src = d.secure_url.replace('/upload/','/upload/c_fill,w_150,h_150,q_auto,f_auto/');
-                im.style.cssText = 'width:64px;height:64px;object-fit:cover;border-radius:8px';
-                document.getElementById('rvthumbs').appendChild(im);
-              }
-            }).catch(function(){
-              stat.textContent = 'That photo would not upload — you can still send the review.';
+              /* No else meant a rejection that still came back 200 vanished
+                 without even reaching the catch. */
+              if (!d.secure_url) throw new Error('upload rejected');
+              shots.push(d.secure_url);
+              var im = document.createElement('img');
+              im.src = d.secure_url.replace('/upload/','/upload/c_fill,w_150,h_150,q_auto,f_auto/');
+              im.style.cssText = 'width:64px;height:64px;object-fit:cover;border-radius:8px';
+              document.getElementById('rvthumbs').appendChild(im);
+            }).catch(function(e){
+              /* Counted, not written to the status line — say() renders it, so
+                 it survives the next repaint instead of being wiped by it. */
+              failed++;
+              reason = /signature/.test(e && e.message || '')
+                ? 'our photo service is down right now' : 'the upload was rejected';
             }).then(function(){ pending--; say(); });
           });
           fi.value = '';

--- a/tests/upload-status.test.js
+++ b/tests/upload-status.test.js
@@ -1,0 +1,138 @@
+/* Regression tests for the photo-upload status line (server.js).
+ *
+ * Run: node --test tests/*.test.js   (the files, not the directory — on
+ * current Node a positional argument is a glob, so `tests/` fails)
+ *
+ * The bug these exist to prevent, which is issue #31:
+ *
+ * The review form wrote its error message straight onto the status element in
+ * a `.catch()`, and then the next handler in the chain called its redraw,
+ * which overwrote that element with the attached-photo count. With nothing
+ * attached, that count is the empty string — so a failed upload cleared the
+ * message it had just written and left the line BLANK. The photo was gone, the
+ * form still submitted, and the customer was told nothing at all. That was the
+ * whole of the visible feedback during the 503 outage: nothing.
+ *
+ * The fix makes failure part of what the redraw RENDERS rather than something
+ * written beside it, which is why the status line is now a pure function of
+ * (pending, done, failed, reason) and why it is worth testing on its own. If
+ * a failure can never be represented in the output, no amount of care in the
+ * upload chain can make it visible.
+ *
+ * This lifts the real function out of server.js rather than restating it, and
+ * runs it in the host realm — a fresh vm context would give returned values a
+ * different Array/String prototype and make deepStrictEqual fail on identical
+ * output. server.js boots a listener and a DB pool on require, which is why it
+ * is not imported.
+ */
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const SERVER = path.join(__dirname, '..', 'server.js');
+const src = fs.readFileSync(SERVER, 'utf8');
+
+/**
+ * Lift `function uploadStatus(...) {...}` out of the source.
+ *
+ * It lives inside the string that `uploadStatusScript()` returns — it is
+ * client-side code that never runs in Node — but it is still literal text in
+ * server.js, so the same extraction the other suites use finds it. Anchored on
+ * the shortest unique text rather than on the body, so a rewrite is judged on
+ * what it does instead of dying on a missing anchor.
+ */
+function load() {
+  const start = src.indexOf('function uploadStatus(');
+  assert.notStrictEqual(start, -1, 'function uploadStatus not found in server.js');
+  let depth = 0;
+  for (let i = src.indexOf('{', start); i < src.length; i++) {
+    if (src[i] === '{') depth++;
+    else if (src[i] === '}' && --depth === 0) {
+      const code = src.slice(start, i + 1);
+      /* The source is a template literal, so \u escapes reached us doubled.
+         Undo exactly that one layer to get what the browser is served. */
+      return vm.runInThisContext(`(function(){ ${code.replace(/\\\\u/g, '\\u')}
+        return uploadStatus; })()`);
+    }
+  }
+  throw new Error('unbalanced braces reading uploadStatus from server.js');
+}
+
+const uploadStatus = load();
+
+/* ── The bug ────────────────────────────────────────────────────────────── */
+
+test('a failure is never invisible', () => {
+  /* The exact shape of #31: one photo tried, none attached, nothing pending.
+     This returned '' before the fix, which is what made the outage silent. */
+  const out = uploadStatus(0, 0, 1, '');
+  assert.notStrictEqual(out, '', 'a failed upload must not render as an empty status line');
+  assert.match(out, /would not upload/);
+});
+
+test('a failure stays visible even when other photos succeeded', () => {
+  /* The half-failed case: two attached, one lost. Reporting only the two is
+     how a form ends up looking successful while dropping a photo. */
+  const out = uploadStatus(0, 2, 1, '');
+  assert.match(out, /2 photos attached/);
+  assert.match(out, /1 photo would not upload/);
+});
+
+test('every combination of counts that includes a failure mentions it', () => {
+  for (const pending of [0, 1, 2]) {
+    for (const done of [0, 1, 2]) {
+      for (const failed of [1, 2]) {
+        assert.match(uploadStatus(pending, done, failed, ''), /would not upload/,
+          `failure lost at pending=${pending} done=${done} failed=${failed}`);
+      }
+    }
+  }
+});
+
+/* ── What it says the rest of the time ──────────────────────────────────── */
+
+test('nothing happening says nothing', () => {
+  assert.strictEqual(uploadStatus(0, 0, 0, ''), '');
+});
+
+test('work in flight is reported', () => {
+  assert.match(uploadStatus(1, 0, 0, ''), /Uploading 1 photo/);
+  assert.match(uploadStatus(3, 0, 0, ''), /Uploading 3 photos/);
+});
+
+test('a plain success says only that', () => {
+  const out = uploadStatus(0, 1, 0, '');
+  assert.strictEqual(out, '1 photo attached');
+  assert.doesNotMatch(out, /would not upload/);
+});
+
+test('a reason is appended when there is one, and not when there is not', () => {
+  assert.match(uploadStatus(0, 0, 1, 'photos must be under 10MB'),
+    /would not upload — photos must be under 10MB/);
+  assert.doesNotMatch(uploadStatus(0, 0, 1, ''), /—/);
+});
+
+test('singular and plural both read correctly', () => {
+  assert.strictEqual(uploadStatus(1, 0, 0, ''), 'Uploading 1 photo…');
+  assert.strictEqual(uploadStatus(2, 0, 0, ''), 'Uploading 2 photos…');
+  assert.strictEqual(uploadStatus(0, 1, 0, ''), '1 photo attached');
+  assert.strictEqual(uploadStatus(0, 2, 0, ''), '2 photos attached');
+  assert.match(uploadStatus(0, 0, 1, ''), /^1 photo would not upload$/);
+  assert.match(uploadStatus(0, 0, 2, ''), /^2 photos would not upload$/);
+});
+
+test('all three states at once are all present', () => {
+  const out = uploadStatus(1, 2, 3, 'the upload was rejected');
+  for (const want of [/Uploading 1 photo/, /2 photos attached/,
+                      /3 photos would not upload/, /the upload was rejected/]) {
+    assert.match(out, want);
+  }
+});
+
+test('the parts are separated readably rather than run together', () => {
+  /* Two facts jammed into one sentence read as one confusing fact. */
+  assert.match(uploadStatus(0, 1, 1, ''), /attached\s*·\s*1 photo would not upload/);
+});


### PR DESCRIPTION
Closes #31.

When a photo upload failed, both upload forms carried on submitting and
reporting success with the photo silently gone. That is what made the
Cloudinary 503 outage invisible for as long as it lasted — nothing anywhere
said a word, to the customer or to the shop.

## The root cause, which is smaller and worse than it sounds

The review form did try to tell the customer. It set the message in its
`.catch()`:

```js
.catch(function(){
  stat.textContent = 'That photo would not upload — you can still send the review.';
}).then(function(){ pending--; say(); });      // ← say() overwrites it immediately
```

`say()` unconditionally rewrites that same element with the attached-photo
count. With nothing attached, that count is the empty string. **So the error
erased itself on the very next tick and the status line went blank.** The
message existed, was correct, and was never once seen.

The fix is structural rather than a bigger string: failures are now *counted*
and the redraw *renders* them, so a failure is part of the state rather than
something written beside it and lost on the next paint.

## What changed

**A shared status line.** `uploadStatusScript()` (beside `turnstileWidget()`)
emits one pure `uploadStatus(pending, done, failed, reason)` used by both
widgets, so they cannot drift. Pure because that makes it testable without a
browser — `tests/upload-status.test.js`, 10 tests. I checked they catch the
real bug by making failures unrepresentable again: 7 fail, including
`a failure is never invisible`.

**Failures are detected at all now.** Three paths silently swallowed them:

- A 503 from `/api/cloudinary-signature` is *still valid JSON*
  (`{error:'Cloudinary not configured'}`), so `r.json()` never threw. The
  missing signature was only noticed two steps later when Cloudinary rejected
  the upload. Both widgets now check `r.ok` and that a signature came back.
- The review form's `if (d.secure_url) {...}` had **no else**, so a rejection
  that still returned 200 vanished without even reaching the `.catch()`.
- Wrong file type was `return` with no message, and the too-large message was
  written straight to the status line where the next redraw wiped it.

**The quote builder had no in-flight tracking at all.** Its save button stayed
live while uploads ran, so saving quickly wrote the hidden field before the
URLs landed and the photos were dropped — a ✕ in a 58px thumbnail was the only
sign, and it did not stop the save. It now holds submit while uploads are in
flight, the way the review form already did.

**Both submit buttons say what they will actually do.** With failures
outstanding they read "…without the missing photos" rather than the normal
label. Sending is still allowed — a review is worth more than its photo, and
the playbook says validation should fail open — but it can no longer be sent
*believing* the photos went too, which is the actual complaint in #31.

**Unconfigured Cloudinary is now stated, not mimed.** The quote builder used to
`return` silently, so an admin picked files and nothing whatsoever happened on
a form that otherwise works. It now says photo uploads are not configured.

## The bug I did not go looking for

The review form hid its photo field with `fi.parentNode.style.display='none'`.
**`fi.parentNode` is the `<form>`.** I confirmed this against `origin/main` by
rendering the page and walking the tag stack:

```
origin/main: #rvfi immediate parent = form
origin/main hides it with fi.parentNode.style: true
```

So with `CLOUDINARY_NAME` unset, the entire review form — rating, text boxes,
send button — disappears, leaving a customer looking at a heading with nothing
under it. It has not fired in production because `CLOUDINARY_NAME` is set; only
the *secret* was missing during the outage. It is a live landmine one variable
away, and it is the same shape as the bug that just cost us: a config gap
manifesting as a silently missing feature. The photo field now sits in its own
`#rvphoto` wrapper and only that is hidden.

## How I verified it

`node --check` cannot see any of this — browser code inside a template literal
is just string content to Node, and an unbalanced brace there parses fine on
the server and breaks only in the customer's browser. (It did catch one thing:
I wrote backticks around a word in a comment *inside* a template literal, which
terminated it.)

So I booted the app against a stubbed `pg`, rendered both pages, and parsed
every inline `<script>` with `vm.Script`. Both render 200 and both parse. Then
I unset `CLOUDINARY_NAME` and re-rendered — the review form, rating input and
send button are all still there, and the quote builder says uploads are not
configured. Suite: 39/39.

## What I did NOT do

- **No browser click-through of an actual failing upload.** Everything above is
  render-and-parse plus unit tests on the status logic; I did not drive a real
  file picker against a real 503 and watch the message appear. The DOM wiring
  is the part still taken on inspection.
- **`public/` static pages were not audited** for the same pattern — I only
  covered the two widgets in `server.js`, which are the ones #31 names.
- **This touches two route handlers**, so it is outside the written boundary,
  though the gate passes it clean (nothing here reads a credential). Flagging
  it because the boundary is not only what the gate can see.

## What to check by hand

1. On `/quote/new`, attach a photo and hit save immediately — the button should
   be held until the upload lands.
2. To see the failure path end to end, block `/api/cloudinary-signature` in
   devtools and attach a photo on `/review/<token>`: the status line should say
   the photo would not upload *and stay saying it*, and the button should read
   "Send my review without the photo".
