### PR TITLE
Give unsubscribe-secret rotation a grace window

### DIFF
--- a/server.js
+++ b/server.js
@@ -527,10 +527,23 @@ function unsubSecret() {
      this entry deliberately before rotating, rather than discovering it. */
 function unsubSecrets() {
   const dedicated = process.env.UNSUB_TOKEN_SECRET?.trim();
+  /* The secret this one replaced. Rotating UNSUB_TOKEN_SECRET used to kill
+     every link already delivered under it in the same instant — there was
+     nowhere to keep the outgoing value, so a rotation done for good reasons
+     (the secret had leaked into another service's environment) silently broke
+     one-click unsubscribe for everything sent since the variable was
+     introduced. Gmail and Yahoo require that link to work for bulk senders,
+     and the failure does not surface as an error: it surfaces as deliverability
+     falling off weeks later, which is exactly the scar the block above records.
+
+     Verification only — never signing. Set it to the outgoing value when you
+     rotate, then delete it once mail signed with it has aged out. */
+  const previous = process.env.UNSUB_TOKEN_SECRET_PREVIOUS?.trim();
   const legacy = process.env.JT_INTERNAL_KEY?.trim();
   const secrets = [];
-  if (dedicated) secrets.push(dedicated);
-  if (legacy && legacy !== dedicated) secrets.push(legacy);
+  for (const s of [dedicated, previous, legacy]) {
+    if (s && !secrets.includes(s)) secrets.push(s);
+  }
   return secrets;
 }
 
@@ -7896,6 +7909,17 @@ function validateEnv() {
     console.log('unsubscribe: signing with UNSUB_TOKEN_SECRET; still honouring older ' +
       'JT_INTERNAL_KEY links. Remove that fallback once pre-migration mail has aged ' +
       'out, and before rotating JT_INTERNAL_KEY.');
+  }
+  /* Both of these are states that must END, and nothing but this line will
+     ever mention them again. */
+  if (process.env.UNSUB_TOKEN_SECRET_PREVIOUS?.trim()) {
+    console.log('unsubscribe: also honouring UNSUB_TOKEN_SECRET_PREVIOUS. Delete it ' +
+      'once mail signed with the old secret has aged out of inboxes — until then ' +
+      'the rotated-away secret still verifies.');
+  } else if (process.env.UNSUB_TOKEN_SECRET?.trim()) {
+    console.log('unsubscribe: no UNSUB_TOKEN_SECRET_PREVIOUS set. If you rotate ' +
+      'UNSUB_TOKEN_SECRET, put the outgoing value there in the same change or every ' +
+      'unsubscribe link already delivered stops working the moment it deploys.');
   }
 }
 validateEnv();

--- a/tests/unsub-token.test.js
+++ b/tests/unsub-token.test.js
@@ -155,3 +155,99 @@ test('malformed tokens are rejected rather than throwing', () => {
     assert.strictEqual(unsubTokenValid(EMAIL, bad), false, `rejected: ${JSON.stringify(bad)}`);
   }
 });
+
+/* ── Rotating UNSUB_TOKEN_SECRET ─────────────────────────────────────────────
+ *
+ * The secret was rotated in production on 2026-08-14, because the outgoing
+ * value had been pasted into another service's JT_INTERNAL_KEY slot and was
+ * sitting in an environment it had no business being in. Rotating was right.
+ *
+ * But at that moment there was nowhere to keep the outgoing value, so every
+ * unsubscribe link signed with it died the instant the new one deployed —
+ * silently, because a dead unsubscribe link raises nothing. Gmail and Yahoo
+ * require that link to work for bulk senders, so the bill arrives later as
+ * deliverability, which is the same scar the migration to a dedicated secret
+ * was written to avoid.
+ *
+ * UNSUB_TOKEN_SECRET_PREVIOUS is the grace window: verified, never signed with.
+ */
+
+const PREVIOUS = 'the-secret-that-was-just-rotated-away';
+
+test('a link signed with the rotated-away secret still verifies', () => {
+  // The whole point. Mail sent last week must keep working this week.
+  const before = load({ UNSUB_TOKEN_SECRET: PREVIOUS });
+  const token = before.unsubToken(EMAIL);
+
+  const after = load({ UNSUB_TOKEN_SECRET: DEDICATED, UNSUB_TOKEN_SECRET_PREVIOUS: PREVIOUS });
+  assert.ok(after.unsubTokenValid(EMAIL, token),
+    'rotating with the outgoing value in _PREVIOUS must not break delivered links');
+});
+
+test('without _PREVIOUS a rotation breaks every delivered link', () => {
+  // Stated as a test so the cost of omitting it is visible, not folklore.
+  const before = load({ UNSUB_TOKEN_SECRET: PREVIOUS });
+  const token = before.unsubToken(EMAIL);
+
+  const after = load({ UNSUB_TOKEN_SECRET: DEDICATED });
+  assert.strictEqual(after.unsubTokenValid(EMAIL, token), false);
+});
+
+test('new mail is signed with the current secret, never the previous one', () => {
+  const env = { UNSUB_TOKEN_SECRET: DEDICATED, UNSUB_TOKEN_SECRET_PREVIOUS: PREVIOUS };
+  const { unsubToken } = load(env);
+  const current = load({ UNSUB_TOKEN_SECRET: DEDICATED });
+  const old = load({ UNSUB_TOKEN_SECRET: PREVIOUS });
+  assert.strictEqual(unsubToken(EMAIL), current.unsubToken(EMAIL),
+    'signing must use the current secret');
+  assert.notStrictEqual(unsubToken(EMAIL), old.unsubToken(EMAIL));
+});
+
+test('dropping _PREVIOUS closes the window', () => {
+  const before = load({ UNSUB_TOKEN_SECRET: PREVIOUS });
+  const token = before.unsubToken(EMAIL);
+  const after = load({ UNSUB_TOKEN_SECRET: DEDICATED, UNSUB_TOKEN_SECRET_PREVIOUS: '' });
+  assert.strictEqual(after.unsubTokenValid(EMAIL, token), false,
+    'a blank _PREVIOUS must not be treated as a secret');
+});
+
+test('all three eras verify at once during a rotation', () => {
+  // Pre-migration mail (JT_INTERNAL_KEY), last week's (previous) and this
+  // week's (current) can all be in inboxes simultaneously.
+  const legacy = load({ JT_INTERNAL_KEY: SHARED }).unsubToken(EMAIL);
+  const older = load({ UNSUB_TOKEN_SECRET: PREVIOUS }).unsubToken(EMAIL);
+  const now = load({ UNSUB_TOKEN_SECRET: DEDICATED }).unsubToken(EMAIL);
+
+  const live = load({ UNSUB_TOKEN_SECRET: DEDICATED,
+                      UNSUB_TOKEN_SECRET_PREVIOUS: PREVIOUS,
+                      JT_INTERNAL_KEY: SHARED });
+  for (const [label, t] of [['pre-migration', legacy], ['pre-rotation', older], ['current', now]]) {
+    assert.ok(live.unsubTokenValid(EMAIL, t), `${label} link must still verify`);
+  }
+});
+
+test('the accepted list is deduplicated and ordered newest first', () => {
+  /* Array.from before comparing: load() has to build a sandbox because these
+     functions read a fabricated process.env, and an array created in a vm
+     context carries THAT context's Array.prototype. deepStrictEqual compares
+     prototypes, so without this it fails while printing two identical arrays. */
+  const { unsubSecrets } = load({ UNSUB_TOKEN_SECRET: DEDICATED,
+                                  UNSUB_TOKEN_SECRET_PREVIOUS: DEDICATED,
+                                  JT_INTERNAL_KEY: DEDICATED });
+  assert.deepStrictEqual(Array.from(unsubSecrets()), [DEDICATED],
+    'the same value set in three places is still one secret');
+
+  const { unsubSecrets: three } = load({ UNSUB_TOKEN_SECRET: DEDICATED,
+                                         UNSUB_TOKEN_SECRET_PREVIOUS: PREVIOUS,
+                                         JT_INTERNAL_KEY: SHARED });
+  assert.deepStrictEqual(Array.from(three()), [DEDICATED, PREVIOUS, SHARED]);
+});
+
+test('_PREVIOUS alone never signs', () => {
+  // A misconfiguration that sets only the previous slot must not quietly start
+  // signing new mail with a secret meant to be retired.
+  const { unsubSecret, unsubToken } = load({ UNSUB_TOKEN_SECRET_PREVIOUS: PREVIOUS });
+  assert.notStrictEqual(unsubSecret(), PREVIOUS,
+    'the retiring secret must never become the signing secret');
+  assert.strictEqual(unsubToken(EMAIL), '', 'no signing secret means no token');
+});


### PR DESCRIPTION
`UNSUB_TOKEN_SECRET` was rotated in production today, for a good reason: the
outgoing value had been sitting in the Lumise designer's `JT_INTERNAL_KEY` slot,
an environment it had no business being in.

The rotation was right. The problem is that there was **nowhere to put the
outgoing value**, so every unsubscribe link signed with it stopped working the
instant the new secret took effect — silently, because a dead unsubscribe link
raises nothing at all. Gmail and Yahoo require that link to work for bulk
senders, so the bill arrives later as deliverability, which is the exact scar
the comment block above `unsubSecrets()` already records.

## What changed

`UNSUB_TOKEN_SECRET_PREVIOUS` — accepted for **verification only, never for
signing**. The accepted list is now current → previous → legacy
`JT_INTERNAL_KEY`, deduplicated, newest first.

Two boot lines that did not exist:

- with it set: "also honouring UNSUB_TOKEN_SECRET_PREVIOUS. Delete it once mail
  signed with the old secret has aged out."
- without it: "If you rotate UNSUB_TOKEN_SECRET, put the outgoing value there in
  the same change or every unsubscribe link already delivered stops working the
  moment it deploys."

Both are states that have to end deliberately, and nothing else would ever
mention them.

## Tests

7 added to `tests/unsub-token.test.js` (36/36 pass), including
`without _PREVIOUS a rotation breaks every delivered link` — stated as a test so
the cost of skipping it is visible rather than folklore — and
`all three eras verify at once`, since pre-migration, pre-rotation and current
mail can all be in inboxes simultaneously.

Verified by mutation: removing the grace window turns 3 red, led by
`a link signed with the rotated-away secret still verifies`.

## The gate refuses this

```
REFUSED -- server.js: reads a credential
  const previous = process.env.UNSUB_TOKEN_SECRET_PREVIOUS?.trim();
```

Same finding as the Cloudinary fallback in #33 — reading an env var next to the
word SECRET. It is not waivable via `ACCEPTED.md` (`content_out_of_bounds`
returns before `load_accepted` is reached), so this needs an admin merge, which
is the same call already made on #33.

## What this does NOT fix

**The links already broken are still broken.** This adds the slot; it cannot
invent the value that used to be in it. If the outgoing secret was saved
anywhere, putting it in `UNSUB_TOKEN_SECRET_PREVIOUS` restores every link sent
between the dedicated secret being introduced and today's rotation. If it was
not saved, that window of mail keeps a dead unsubscribe link until it ages out
of inboxes, and the only mitigation is the List-Unsubscribe mailto and the
footer link on newer sends.
