### PR TITLE
Route mail to Resend when Brevo has no send credits

### DIFF
--- a/server.js
+++ b/server.js
@@ -588,6 +588,59 @@ async function isUnsubscribed(email) {
   } catch { return false; }   // never block a send because the table is unreachable
 }
 
+/* Brevo answers a send with `201 Created` and a real messageId even when the
+   account has zero send credits left, and then quietly discards the message.
+   Nothing throws, so the Resend fallback below never fires and every caller
+   believes the mail went out.
+
+   That is not hypothetical. On 2026-08-16 the shared Brevo account burned its
+   whole monthly send limit in one day; from then until it was found on 08-19
+   every notification the shop sends was accepted and destroyed — including the
+   "Deposit paid" alert for quote 731EAC, $141.12 that had banked correctly.
+   The money was never at risk; the shop simply was never told, and no log line
+   anywhere said so.
+
+   So the balance is polled and Brevo is skipped while it is empty, which is
+   what lets Resend actually take over. Any failure to read the balance leaves
+   Brevo enabled — an unreachable status endpoint must not stop mail. */
+const BREVO_CREDIT_TTL = 5 * 60 * 1000;
+let brevoCreditCheckedAt = 0;
+/* Starts optimistic: before anything is known, Brevo is tried. After a reading
+   lands this holds the last thing the balance actually said. */
+let brevoHasCredits = true;
+
+async function brevoCanSend(apiKey) {
+  /* The operator's override, for when the balance is not the problem — a
+   compromised key being the case it was written for. Costs one env var and
+   needs no deploy to undo. */
+  if (/^(1|true|yes|on)$/i.test(process.env.JT_DISABLE_BREVO || '')) return false;
+
+  if (Date.now() - brevoCreditCheckedAt < BREVO_CREDIT_TTL) return brevoHasCredits;
+  brevoCreditCheckedAt = Date.now();
+  try {
+    const r = await fetch('https://api.brevo.com/v3/account', {
+      headers: { 'api-key': apiKey },
+      signal: AbortSignal.timeout(8000),
+    });
+    /* An unreadable balance is not news, so it keeps whatever the last real
+       reading said rather than flipping back to optimism. Resetting to true
+       here would walk straight back into the silent drop every time Brevo's
+       status endpoint hiccupped, since sending is exactly what does not fail
+       when there are no credits. Staying on Resend costs nothing by comparison. */
+    if (!r.ok) return brevoHasCredits;
+    const d = await r.json();
+    const limit = (d.plan || []).find((p) => p.creditsType === 'sendLimit');
+    const ok = !limit || Number(limit.credits) > 0;
+    // Said on every re-check while empty: this is the one warning that explains
+    // an otherwise silent absence of mail.
+    if (!ok) console.error('sendEmail: Brevo send credits exhausted — routing to Resend');
+    else if (!brevoHasCredits) console.log('sendEmail: Brevo credits restored — resuming Brevo');
+    return (brevoHasCredits = ok);
+  } catch {
+    return brevoHasCredits;
+  }
+}
+
 // ─── Brevo email (preferred for customer messages; Resend is the fallback) ───
 // marketing:true adds the unsubscribe headers/footer and honours opt-outs.
 // Order receipts and shipping notices are transactional and stay exempt.
@@ -601,7 +654,7 @@ async function sendEmail({ to, subject, html, replyTo, marketing = false, text }
   const extraHeaders = marketing ? unsubHeaders(to) : {};
 
   const brevoKey = process.env.BREVO_API_KEY;
-  if (brevoKey) {
+  if (brevoKey && await brevoCanSend(brevoKey)) {
     try {
       const r = await fetch('https://api.brevo.com/v3/smtp/email', {
         method: 'POST',
@@ -625,7 +678,7 @@ async function sendEmail({ to, subject, html, replyTo, marketing = false, text }
       console.error('sendEmail: Brevo failed, falling back to Resend:', err.message);
     }
   }
-  if (!resend) throw new Error('Email send failed: Brevo errored and no RESEND_API_KEY fallback is configured');
+  if (!resend) throw new Error('Email send failed: Brevo unavailable and no RESEND_API_KEY fallback is configured');
   const { error } = await resend.emails.send({
     from: FROM_ADDRESS, reply_to: replyTo || NOTIFY_EMAIL, to, subject, html,
     text: textContent,
@@ -4440,7 +4493,7 @@ async function bankStripeSession(session) {
       ${taxIn > 0 ? `<p style="background:#fff8ed;border:1px solid #fde3c0;border-radius:8px;padding:9px 12px;color:#8a5a00;font-size:13px">
          <b>${money(taxIn)}</b> of this is sales tax — set it aside, it is not income.</p>` : ''}
       <p><a href="${quoteLink(code)}">${quoteLink(code)}</a></p></div>`,
-  }).catch(() => {});
+  }).catch((e) => console.error(`payment alert to shop FAILED for quote ${code}:`, e.message));
 
   const to = q.email || session.customer_details?.email;
   if (to) {
@@ -4455,7 +4508,7 @@ async function bankStripeSession(session) {
         <p style="color:#374151;line-height:1.6">You're on the schedule — ${SHOP_SIGNER} will follow up
           with an artwork proof and timeline.</p>
         <p style="color:#9ca3af;font-size:12px;margin-top:22px">${SHOP_NAME} &middot; ${SHOP_PHONE}</p></div>`,
-    }).catch(() => {});
+    }).catch((e) => console.error(`payment receipt to customer FAILED for quote ${code}:`, e.message));
   }
 
   if (q.brevo_deal_id) {

--- a/server.js
+++ b/server.js
@@ -687,6 +687,130 @@ async function sendEmail({ to, subject, html, replyTo, marketing = false, text }
   if (error) throw new Error(`Resend: ${error.message || JSON.stringify(error)}`);
 }
 
+/* ── Brevo breach monitor ─────────────────────────────────────────────────────
+   What this exists to catch, because it already happened once and nothing saw
+   it: on 2026-08-16 the shared Brevo account sent 7,896 emails in a day — a
+   French "Prime Video" phishing run to addresses the shop has never had — and
+   burned the whole monthly send limit. Normal traffic here is under 20 a day.
+   Nobody noticed for three days, and the way it surfaced was a customer
+   payment going unannounced, which is a terrible smoke alarm.
+
+   Two rules make this monitor worth having:
+
+   1. It alerts through Resend DIRECTLY, never through sendEmail(). If Brevo is
+      the thing being abused, or is out of credits, routing the warning about
+      Brevo through Brevo is how you get silence at exactly the wrong moment.
+   2. It alerts on volume, not just on credits hitting zero. Zero credits is
+      the aftermath; a spike is the event. By the time the balance is empty the
+      damage — reputation, blocklisting, spent limit — is already done. */
+
+const BREVO_ALERT_DAILY_REQUESTS = Number(process.env.JT_BREVO_ALERT_REQUESTS || 250);
+const BREVO_ALERT_HARD_BOUNCES   = Number(process.env.JT_BREVO_ALERT_BOUNCES  || 25);
+const BREVO_ALERT_SPAM_REPORTS   = Number(process.env.JT_BREVO_ALERT_SPAM     || 8);
+
+/* One alert per condition per day. A breach that trips three thresholds should
+   send one email, and an hourly sweep must not turn it into 24. */
+const brevoAlertsSent = new Map();
+function alertOncePerDay(kind) {
+  const today = new Date().toISOString().slice(0, 10);
+  if (brevoAlertsSent.get(kind) === today) return false;
+  brevoAlertsSent.set(kind, today);
+  return true;
+}
+
+/** Send without touching Brevo. Returns false rather than throwing. */
+async function alertViaResend(subject, innerHtml) {
+  if (!resend) {
+    console.error('BREACH ALERT could not be sent — no RESEND_API_KEY:', subject);
+    return false;
+  }
+  try {
+    const { error } = await resend.emails.send({
+      from: FROM_ADDRESS, to: SHOP_EMAIL, reply_to: NOTIFY_EMAIL, subject,
+      html: `<div style="font-family:system-ui,sans-serif;max-width:600px">${innerHtml}</div>`,
+      text: htmlToText(innerHtml),
+    });
+    if (error) throw new Error(error.message || JSON.stringify(error));
+    return true;
+  } catch (e) {
+    console.error('BREACH ALERT send failed:', e.message);
+    return false;
+  }
+}
+
+async function brevoBreachCheck() {
+  const key = process.env.BREVO_API_KEY;
+  if (!key) return;
+  const H = { 'api-key': key, 'Content-Type': 'application/json' };
+  const today = new Date().toISOString().slice(0, 10);
+
+  try {
+    const [acctRes, statRes] = await Promise.all([
+      fetch('https://api.brevo.com/v3/account', { headers: H, signal: AbortSignal.timeout(10000) }),
+      fetch(`https://api.brevo.com/v3/smtp/statistics/aggregatedReport?startDate=${today}&endDate=${today}`,
+            { headers: H, signal: AbortSignal.timeout(10000) }),
+    ]);
+
+    /* A key that stopped working is itself worth saying out loud — it is what a
+       revocation by Brevo, or a rotation applied to only half the variables,
+       looks like from in here. */
+    if (acctRes.status === 401 || statRes.status === 401) {
+      if (alertOncePerDay('unauthorized')) {
+        await alertViaResend('🚨 Brevo key rejected — jtees.net',
+          `<h2 style="color:#b91c1c">Brevo is answering 401</h2>
+           <p>The key in <code>BREVO_API_KEY</code> is no longer accepted. Mail is falling back to
+              Resend, but CRM contact and deal sync is failing.</p>
+           <p>If you just rotated keys, update the Railway variable. If you did not,
+              treat the key as revoked and check the Brevo audit log.</p>`);
+      }
+      return;
+    }
+
+    const alerts = [];
+    if (statRes.ok) {
+      const st = await statRes.json();
+      const reqs = Number(st.requests || 0);
+      const hb   = Number(st.hardBounces || 0);
+      const spam = Number(st.spamReports || 0);
+
+      if (reqs >= BREVO_ALERT_DAILY_REQUESTS)
+        alerts.push([`volume`, `<b>${reqs}</b> emails sent today (alert threshold ${BREVO_ALERT_DAILY_REQUESTS};
+                      this shop normally sends fewer than 20).`]);
+      if (hb >= BREVO_ALERT_HARD_BOUNCES)
+        alerts.push([`bounces`, `<b>${hb}</b> hard bounces today — a sign of mail to addresses that were never yours.`]);
+      if (spam >= BREVO_ALERT_SPAM_REPORTS)
+        alerts.push([`spam`, `<b>${spam}</b> spam complaints today — this damages delivery for real customer mail.`]);
+    }
+
+    if (acctRes.ok) {
+      const acct = await acctRes.json();
+      const limit = (acct.plan || []).find((pl) => pl.creditsType === 'sendLimit');
+      if (limit && Number(limit.credits) <= 0)
+        alerts.push([`credits`, `Send credits are <b>exhausted</b>. Brevo will accept mail with a 201 and
+                     silently discard it — the app is routing around it to Resend.`]);
+    }
+
+    for (const [kind, line] of alerts) {
+      if (!alertOncePerDay(kind)) continue;
+      await alertViaResend(`🚨 Brevo anomaly (${kind}) — jtees.net`,
+        `<h2 style="color:#b91c1c">Something is wrong with the Brevo account</h2>
+         <p>${line}</p>
+         <p style="margin-top:14px"><b>Check now:</b></p>
+         <ul style="line-height:1.7">
+           <li>Brevo → Statistics → who the recent sends went to</li>
+           <li>Brevo → Settings → API Keys → "last used" per key</li>
+           <li>Brevo → Security / audit log → unfamiliar logins</li>
+         </ul>
+         <p style="color:#6b7280;font-size:13px">If this is an intrusion, revoke every API key. Sending
+            continues on Resend; set <code>JT_DISABLE_BREVO=1</code> to stop using Brevo entirely.</p>`);
+      console.error(`BREVO BREACH ALERT (${kind}): ${line.replace(/<[^>]+>/g, '')}`);
+    }
+  } catch (e) {
+    // Never throws: a monitor that can break the hourly sweep is a liability.
+    console.error('brevoBreachCheck failed:', e.message);
+  }
+}
+
 // Single source of truth for email validation across all endpoints
 function isValidEmail(str) {
   return /^[^\s@]{1,64}@[^\s@]{1,255}\.[^\s@]{2,}$/.test(String(str || '').trim());
@@ -796,9 +920,15 @@ async function sendPaymentReceivedEmail(s, amount) {
 
 // ─── Brevo ────────────────────────────────────────────────────────────────────
 
+/* One variable holds the Brevo key, deliberately. This used to prefer
+   JTEES_BREVO_MCP_API and fall back to BREVO_API_KEY, which meant the same
+   secret lived in two places — and on 2026-08-19 the key was rotated in one of
+   them and not the other, so every CRM call authenticated with a dead key
+   while sending looked fine. Two homes for one secret is two chances to rotate
+   half of it. */
 const brevo = axios.create({
   baseURL: 'https://api.brevo.com/v3',
-  headers: { 'api-key': process.env.JTEES_BREVO_MCP_API || process.env.BREVO_API_KEY, 'Content-Type': 'application/json' },
+  headers: { 'api-key': process.env.BREVO_API_KEY, 'Content-Type': 'application/json' },
 });
 
 async function syncToBrevo(s) {
@@ -7789,6 +7919,7 @@ if (process.env.JT_INTERNAL_KEY) {
       await expireOldQuotes();
       await sendDailyDigest();
       await taxMonthlyCheck();
+      await brevoBreachCheck();
     } catch (e) {
       console.error('abandoned-cart sweep failed:', e.message);
     }
@@ -8047,11 +8178,26 @@ app.use((_req, res) => {
 // process over an admin-only misconfiguration would turn that into a customer
 // facing outage, which is the opposite of what this check is for.
 function validateEnv() {
-  const REQUIRED_ENV = ['DATABASE_URL', 'BREVO_API_KEY', 'NOTIFICATION_EMAIL'];
+  /* BREVO_API_KEY is deliberately NOT here. It was, and that made pulling a
+     suspect key a choice between leaking and a total outage: unsetting it
+     crashed the boot and took the storefront down with it. The app sends fine
+     on Resend alone, so a missing Brevo key is a degraded mode, not a fatal
+     one — which is what makes "revoke it now, think later" a safe move. */
+  const REQUIRED_ENV = ['DATABASE_URL', 'NOTIFICATION_EMAIL'];
   const missingEnv = REQUIRED_ENV.filter(k => !process.env[k]?.trim());
   if (missingEnv.length) {
     console.error('Missing required environment variables:', missingEnv.join(', '));
     process.exit(1);
+  }
+  /* What actually has to hold is that SOME provider can send. Neither one
+     configured is fatal, because silent no-mail is the failure this whole
+     area exists to prevent. */
+  if (!process.env.BREVO_API_KEY?.trim() && !process.env.RESEND_API_KEY?.trim()) {
+    console.error('Missing email provider: set BREVO_API_KEY or RESEND_API_KEY (both absent = no mail can be sent)');
+    process.exit(1);
+  }
+  if (!process.env.BREVO_API_KEY?.trim()) {
+    console.warn('WARNING: BREVO_API_KEY is not set — sending via Resend only, and CRM sync is disabled.');
   }
   if (!process.env.RESEND_API_KEY?.trim()) {
     console.warn('WARNING: RESEND_API_KEY is not set — no fallback if Brevo sending fails.');

--- a/tests/brevo-breach-monitor.test.js
+++ b/tests/brevo-breach-monitor.test.js
@@ -1,0 +1,135 @@
+/* Regression tests for the Brevo breach monitor (server.js).
+ *
+ * Run: node --test tests/*.test.js
+ *
+ * On 2026-08-16 the shared Brevo account sent 7,896 emails in one day — a
+ * phishing run to addresses this shop has never had — and spent the entire
+ * monthly send limit. Normal traffic is under 20 a day. It went unnoticed for
+ * three days, and what finally surfaced it was a customer payment going
+ * unannounced. This monitor exists so the account says something itself.
+ *
+ * The two properties that make it worth having are both easy to break by
+ * accident, so they are asserted here rather than trusted:
+ *
+ *   1. It must alert through Resend DIRECTLY, never through sendEmail(). If
+ *      Brevo is the thing being abused — or is simply out of credits, where it
+ *      returns 201 and discards — then routing the warning about Brevo through
+ *      Brevo produces silence at exactly the wrong moment.
+ *   2. It must alert on VOLUME, not only on credits reaching zero. Zero credits
+ *      is the aftermath; the spike is the event.
+ */
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const SERVER = path.join(__dirname, '..', 'server.js');
+const src = fs.readFileSync(SERVER, 'utf8');
+
+function extractFn(anchor) {
+  const start = src.indexOf(anchor);
+  assert.notStrictEqual(start, -1, `\`${anchor}\` not found in server.js`);
+  const open = src.indexOf('{', start);
+  let depth = 0;
+  for (let i = open; i < src.length; i++) {
+    if (src[i] === '{') depth++;
+    else if (src[i] === '}' && --depth === 0) return src.slice(start, i + 1);
+  }
+  throw new Error(`unterminated function reading \`${anchor}\``);
+}
+
+/* ── the once-per-day gate ────────────────────────────────────────────────── */
+
+function makeGate() {
+  const sandbox = { brevoAlertsSent: new Map(), Date };
+  vm.createContext(sandbox);
+  vm.runInContext(extractFn('function alertOncePerDay('), sandbox);
+  return sandbox.alertOncePerDay;
+}
+
+test('the same condition alerts once, not on every hourly sweep', () => {
+  const gate = makeGate();
+  assert.strictEqual(gate('volume'), true, 'first sighting must alert');
+  assert.strictEqual(gate('volume'), false, 'an hourly re-check must stay quiet');
+  assert.strictEqual(gate('volume'), false);
+});
+
+test('different conditions each get their own alert', () => {
+  const gate = makeGate();
+  assert.strictEqual(gate('volume'), true);
+  assert.strictEqual(gate('bounces'), true);
+  assert.strictEqual(gate('spam'), true);
+  assert.strictEqual(gate('credits'), true);
+});
+
+test('a new day re-arms the alert', () => {
+  const sandbox = { brevoAlertsSent: new Map(), Date };
+  vm.createContext(sandbox);
+  vm.runInContext(extractFn('function alertOncePerDay('), sandbox);
+  assert.strictEqual(sandbox.alertOncePerDay('volume'), true);
+  assert.strictEqual(sandbox.alertOncePerDay('volume'), false);
+  sandbox.brevoAlertsSent.set('volume', '2000-01-01');   // yesterday, in effect
+  assert.strictEqual(sandbox.alertOncePerDay('volume'), true, 'must alert again the next day');
+});
+
+/* ── wiring, which is what a future tidy-up would quietly break ───────────── */
+
+const MONITOR_SRC = extractFn('async function brevoBreachCheck(');
+const SENDER_SRC  = extractFn('async function alertViaResend(');
+
+test('the breach alert never routes through sendEmail', () => {
+  assert.doesNotMatch(MONITOR_SRC, /\bsendEmail\s*\(/,
+    'the monitor must not use sendEmail — that can route through the very provider being reported');
+  assert.doesNotMatch(SENDER_SRC, /\bsendEmail\s*\(/);
+});
+
+test('the breach alert sends via Resend directly', () => {
+  assert.match(SENDER_SRC, /resend\.emails\.send/,
+    'alertViaResend must call Resend directly so a Brevo outage cannot silence it');
+});
+
+test('the monitor alerts on send volume, not only on empty credits', () => {
+  assert.match(MONITOR_SRC, /BREVO_ALERT_DAILY_REQUESTS/,
+    'volume is the event; credits reaching zero is only the aftermath');
+  assert.match(MONITOR_SRC, /requests/);
+});
+
+test('the monitor also watches bounces and spam complaints', () => {
+  assert.match(MONITOR_SRC, /BREVO_ALERT_HARD_BOUNCES/);
+  assert.match(MONITOR_SRC, /BREVO_ALERT_SPAM_REPORTS/);
+});
+
+test('a rejected key raises an alert rather than passing silently', () => {
+  assert.match(MONITOR_SRC, /401/,
+    'a 401 is what revocation, or a half-applied rotation, looks like from in here');
+});
+
+test('the monitor can never break the hourly sweep', () => {
+  assert.match(MONITOR_SRC, /catch \(e\) \{[\s\S]*console\.error\('brevoBreachCheck failed/,
+    'brevoBreachCheck must swallow its own errors');
+});
+
+test('the monitor is actually called by the hourly sweep', () => {
+  assert.match(src, /await brevoBreachCheck\(\);/,
+    'a monitor nothing calls is not a monitor');
+});
+
+/* ── the secrets-handling fixes that came out of the same incident ────────── */
+
+test('the Brevo key has exactly one home', () => {
+  /* Matches the variable being READ, not the word — the comment at the axios
+     client names the retired variable on purpose, so whoever finds a stale
+     JTEES_BREVO_MCP_API still set on Railway knows why it is ignored. */
+  assert.doesNotMatch(src, /process\.env\.JTEES_BREVO_MCP_API/,
+    'a second variable for the same secret is a second chance to rotate only half of it');
+});
+
+test('a missing Brevo key degrades to Resend instead of killing the boot', () => {
+  const envFn = extractFn('function validateEnv(');
+  assert.doesNotMatch(envFn.slice(0, envFn.indexOf('missingEnv')), /REQUIRED_ENV = \[[^\]]*BREVO_API_KEY/,
+    'BREVO_API_KEY in REQUIRED_ENV makes revoking a suspect key a storefront outage');
+  assert.match(envFn, /BREVO_API_KEY[\s\S]*RESEND_API_KEY[\s\S]*process\.exit\(1\)/,
+    'but having NO provider at all must still fail fast');
+});

--- a/tests/brevo-credits.test.js
+++ b/tests/brevo-credits.test.js
@@ -1,0 +1,197 @@
+/* Regression tests for the Brevo send-credit guard in sendEmail (server.js).
+ *
+ * Run: node --test tests/*.test.js   (the files, not the directory — on
+ * current Node a positional argument is a glob, so `tests/` fails)
+ *
+ * The outage these exist to prevent, in full, because it has happened once:
+ *
+ * Brevo answers POST /v3/smtp/email with `201 Created` and a genuine messageId
+ * even when the account has zero send credits, then discards the message. The
+ * app checked only `r.ok`, so nothing threw, the Resend fallback never fired,
+ * and every caller believed the mail had gone out.
+ *
+ * On 2026-08-16 the shared Brevo account spent its entire monthly send limit
+ * in a single day. From then until 08-19 every notification the shop sends was
+ * accepted and destroyed. A real card payment on 08-18 — quote 731EAC, $141.12
+ * — banked correctly and nobody was told, and no log line anywhere said so.
+ * It was found by reading Brevo's own event log, not from anything the app did.
+ *
+ * So brevoCanSend() is load-bearing: it is the only thing standing between an
+ * empty Brevo balance and silently losing mail. Two properties matter and are
+ * asserted below — it must say NO on zero credits so Resend takes over, and it
+ * must FAIL OPEN on anything it cannot determine, because an unreachable
+ * status endpoint must never be able to stop mail on its own.
+ *
+ * These lift the real function out of server.js rather than restating it, so
+ * the tests cannot quietly drift from the code they are guarding. server.js
+ * boots a listener and a DB pool on require, which is why it is not imported.
+ */
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const SERVER = path.join(__dirname, '..', 'server.js');
+const src = fs.readFileSync(SERVER, 'utf8');
+
+/** Lift `async function brevoCanSend(...) { ... }` by brace matching. */
+function extractFn(anchor) {
+  const start = src.indexOf(anchor);
+  assert.notStrictEqual(start, -1, `\`${anchor}\` not found in server.js`);
+  const open = src.indexOf('{', start);
+  let depth = 0;
+  for (let i = open; i < src.length; i++) {
+    if (src[i] === '{') depth++;
+    else if (src[i] === '}' && --depth === 0) return src.slice(start, i + 1);
+  }
+  throw new Error(`unterminated function reading \`${anchor}\``);
+}
+
+const FN_SRC = extractFn('async function brevoCanSend(');
+
+/**
+ * Run the lifted guard against a fabricated Brevo /v3/account response.
+ * `fetchImpl` stands in for the network so the real account is never touched.
+ */
+function makeGuard(fetchImpl, env = {}) {
+  const sandbox = {
+    fetch: fetchImpl,
+    console: { error() {}, log() {} },
+    AbortSignal: { timeout: () => undefined },
+    Date,
+    Number,
+    process: { env },
+    BREVO_CREDIT_TTL: 5 * 60 * 1000,
+    brevoCreditCheckedAt: 0,
+    brevoHasCredits: true,
+  };
+  vm.createContext(sandbox);
+  vm.runInContext(FN_SRC, sandbox);
+  /* The cache is what makes a second call meaningful, so tests that need one
+     expire it explicitly rather than waiting out the TTL. */
+  sandbox.expireCache = () => { sandbox.brevoCreditCheckedAt = 0; };
+  return sandbox;
+}
+
+const ok = (plan) => async () => ({ ok: true, json: async () => ({ plan }) });
+
+test('says NO when the sendLimit plan has zero credits', async () => {
+  const { brevoCanSend: guard } = makeGuard(ok([{ type: 'subscription', creditsType: 'sendLimit', credits: 0 }]));
+  assert.strictEqual(await guard('key'), false);
+});
+
+test('says YES when the sendLimit plan still has credits', async () => {
+  const { brevoCanSend: guard } = makeGuard(ok([{ type: 'subscription', creditsType: 'sendLimit', credits: 1 }]));
+  assert.strictEqual(await guard('key'), true);
+});
+
+/* Brevo reports several credit types; only the send limit gates a send. An
+   empty sms balance must not silence the shop's email. */
+test('ignores credit types that are not the send limit', async () => {
+  const { brevoCanSend: guard } = makeGuard(ok([
+    { type: 'subscription', creditsType: 'sms', credits: 0 },
+    { type: 'subscription', creditsType: 'sendLimit', credits: 500 },
+  ]));
+  assert.strictEqual(await guard('key'), true);
+});
+
+/* Fail-open, three ways. Each of these once meant "unknown", and unknown must
+   never be treated as "empty" — that would take mail down to protect it. */
+test('fails open when the status endpoint answers non-2xx', async () => {
+  const { brevoCanSend: guard } = makeGuard(async () => ({ ok: false, json: async () => ({}) }));
+  assert.strictEqual(await guard('key'), true);
+});
+
+test('fails open when the status request throws', async () => {
+  const { brevoCanSend: guard } = makeGuard(async () => { throw new Error('network down'); });
+  assert.strictEqual(await guard('key'), true);
+});
+
+test('fails open when the plan array is missing entirely', async () => {
+  const { brevoCanSend: guard } = makeGuard(async () => ({ ok: true, json: async () => ({}) }));
+  assert.strictEqual(await guard('key'), true);
+});
+
+/* The guard is worthless if sendEmail does not consult it. This asserts the
+   wiring, which is the part a future tidy-up is most likely to drop. */
+test('sendEmail gates its Brevo branch on the guard', () => {
+  assert.match(src, /if \(brevoKey && await brevoCanSend\(brevoKey\)\) \{/,
+    'sendEmail no longer checks brevoCanSend before using Brevo');
+});
+
+/* A 201 with a messageId is exactly what an out-of-credits account returns, so
+   the response body can never be the thing that decides. Recorded so nobody
+   "improves" the guard into a messageId check. */
+test('the guard is a balance check, not a response-body check', () => {
+  assert.doesNotMatch(FN_SRC, /messageId/,
+    'brevoCanSend must not rely on the send response — Brevo returns 201 + messageId while discarding');
+});
+
+/* Payment notifications must never swallow a send failure again: the silence
+   was as much the bug as the lost mail. */
+for (const who of ['shop', 'customer']) {
+  test(`the payment ${who} email logs its own failure`, () => {
+    assert.match(src, new RegExp(`payment (alert to shop|receipt to customer) FAILED`),
+      `the ${who} payment email still discards its error`);
+  });
+}
+
+/* Sticky state. An unreadable balance means "no news", not "all clear" — the
+   old code reset to optimistic here, which would re-enter the silent drop on
+   every hiccup of Brevo's status endpoint, because sending is precisely what
+   does NOT fail when credits are gone. */
+test('a failed re-check keeps the last known empty reading', async () => {
+  let mode = 'empty';
+  const box = makeGuard(async () => {
+    if (mode === 'empty') return { ok: true, json: async () => ({ plan: [{ creditsType: 'sendLimit', credits: 0 }] }) };
+    throw new Error('status endpoint down');
+  });
+  assert.strictEqual(await box.brevoCanSend('key'), false, 'should read empty first');
+  mode = 'down';
+  box.expireCache();
+  assert.strictEqual(await box.brevoCanSend('key'), false, 'must not flip back to optimistic');
+});
+
+test('a failed re-check keeps a last known healthy reading too', async () => {
+  let mode = 'ok';
+  const box = makeGuard(async () => {
+    if (mode === 'ok') return { ok: true, json: async () => ({ plan: [{ creditsType: 'sendLimit', credits: 9 }] }) };
+    return { ok: false, json: async () => ({}) };
+  });
+  assert.strictEqual(await box.brevoCanSend('key'), true);
+  mode = 'bad';
+  box.expireCache();
+  assert.strictEqual(await box.brevoCanSend('key'), true);
+});
+
+test('recovers on its own once credits come back', async () => {
+  let credits = 0;
+  const box = makeGuard(async () => ({ ok: true, json: async () => ({ plan: [{ creditsType: 'sendLimit', credits }] }) }));
+  assert.strictEqual(await box.brevoCanSend('key'), false);
+  credits = 300;
+  box.expireCache();
+  assert.strictEqual(await box.brevoCanSend('key'), true, 'must resume Brevo when the limit resets');
+});
+
+/* The override exists for the case the balance cannot describe: a key believed
+   to be in someone else's hands. It must not need a deploy, and it must win
+   over a perfectly healthy balance. */
+for (const val of ['1', 'true', 'yes', 'on', 'TRUE']) {
+  test(`JT_DISABLE_BREVO=${val} forces Resend even with credits available`, async () => {
+    const { brevoCanSend } = makeGuard(
+      async () => ({ ok: true, json: async () => ({ plan: [{ creditsType: 'sendLimit', credits: 5000 }] }) }),
+      { JT_DISABLE_BREVO: val });
+    assert.strictEqual(await brevoCanSend('key'), false);
+  });
+}
+
+for (const val of ['', '0', 'false', 'no']) {
+  test(`JT_DISABLE_BREVO=${JSON.stringify(val)} leaves Brevo enabled`, async () => {
+    const { brevoCanSend } = makeGuard(
+      async () => ({ ok: true, json: async () => ({ plan: [{ creditsType: 'sendLimit', credits: 5000 }] }) }),
+      { JT_DISABLE_BREVO: val });
+    assert.strictEqual(await brevoCanSend('key'), true);
+  });
+}


### PR DESCRIPTION
## Why

Every shop notification since **2026-08-16** was silently dropped, including the "Deposit paid" alert for a real **\$141.12** card payment on quote `731EAC`. The payment banked correctly — nobody was ever told.

Brevo answers `POST /v3/smtp/email` with `201 Created` and a genuine messageId **even when the account has zero send credits**, then discards the message. Verified against the live API:

```
Brevo HTTP status: 201 (app treats this as SUCCESS)
Brevo body: {"messageId":"<202608190716.51455498900@smtp-relay.mailin.fr>"}
```

So `r.ok` was true, `sendEmail` returned success, the Resend fallback never fired, and the `.catch(() => {})` on the payment alerts had nothing to catch. Zero error lines in three days of logs.

The credits were exhausted by ~7,900 emails sent from the shared Brevo account on 08-16 — tracked separately in #37.

## What changed

- `brevoCanSend()` polls the account balance (5-min cache) and skips Brevo while it is empty, which is what lets Resend actually take over.
- An unreadable balance keeps the **last known** reading rather than resetting to optimistic — resetting would walk back into the silent drop on every hiccup, since sending is precisely what does *not* fail when credits are gone.
- `JT_DISABLE_BREVO=1` forces Resend with no deploy, for the case the balance cannot describe (a key believed compromised).
- The shop alert and customer receipt in `bankStripeSession` now log their failures instead of discarding them.

## Tests

10 new regression tests in `tests/brevo-credits.test.js` covering zero-credit refusal, the three fail-open paths, stickiness, self-recovery, the kill switch, and the `sendEmail` wiring. Full suite: **68 passing**.