### PR TITLE
Announce Stripe payments the quote ledger does not claim, and send receipts

### DIFF
--- a/server.js
+++ b/server.js
@@ -4316,6 +4316,18 @@ app.get(['/q/:code/pay/card', '/q/:code/pay/balance'], async (req, res) => {
     form.set('cancel_url', `${PUBLIC_BASE_URL}/q/${q.code}`);
     form.set('client_reference_id', q.code);
     if (q.email) form.set('customer_email', q.email);
+    /* Makes Stripe email its own receipt. Worth having even though the app
+       sends a "Payment received" note of its own: the Stripe receipt is the
+       one with the card's last four and a permanent receipt URL, it is what a
+       customer means when they ask for "a receipt", and it does not depend on
+       this app being up — which mattered on 2026-08-16, when every email the
+       app sent was accepted and silently discarded for three days.
+
+       In live mode receipt_email sends regardless of the Dashboard's
+       "Successful payments" toggle, so this is not waiting on a setting. Where
+       the address is only collected at Checkout there is nothing to set here,
+       and that toggle is what covers those. */
+    if (q.email) form.set('payment_intent_data[receipt_email]', q.email);
     form.set('line_items[0][quantity]', '1');
     form.set('line_items[0][price_data][currency]', 'usd');
     form.set('line_items[0][price_data][unit_amount]', String(Math.round(amount * 100)));
@@ -4384,6 +4396,42 @@ async function alertShop(subject, innerHtml) {
     subject,
     html: `<div style="font-family:system-ui,sans-serif;max-width:560px">${innerHtml}</div>`,
   }).catch((e) => console.error('shop alert failed:', e.message));
+}
+
+/* A payment Stripe took that the quote ledger did not claim. Never throws —
+   an alert must not fail a webhook and make Stripe retry a settled payment. */
+async function alertUnbankedPayment(session, reason) {
+  try {
+    const gross = round2((session.amount_total || 0) / 100);
+    const ref   = String(session.client_reference_id || '').trim();
+    const email = session.customer_details?.email || '';
+    const name  = session.customer_details?.name || '';
+
+    /* The charge carries the receipt URL, not the session, so it costs one
+       lookup. Best-effort: a missing receipt link must not cost the alert. */
+    let receiptUrl = '';
+    const pi = typeof session.payment_intent === 'string' ? session.payment_intent : null;
+    if (pi && process.env.STRIPE_SECRET_KEY) {
+      try {
+        const r = await fetch(
+          `https://api.stripe.com/v1/payment_intents/${encodeURIComponent(pi)}?expand[]=latest_charge`,
+          { headers: { Authorization: 'Bearer ' + process.env.STRIPE_SECRET_KEY },
+            signal: AbortSignal.timeout(8000) });
+        if (r.ok) receiptUrl = (await r.json())?.latest_charge?.receipt_url || '';
+      } catch { /* leave it blank */ }
+    }
+
+    const dash = pi ? `https://dashboard.stripe.com/payments/${encodeURIComponent(pi)}` : '';
+    await alertShop(`💳 Stripe payment received — ${money(gross)}${ref ? ` (ref ${ref})` : ''}`,
+      `<h2 style="color:#1848B8">A payment came in outside the quote flow</h2>
+       <p><b>${money(gross)}</b>${name ? ` from ${escEmail(name)}` : ''}${email ? ` &lt;${escEmail(email)}&gt;` : ''}.</p>
+       <p style="color:#6b7280">Reference: <b>${escEmail(ref || '(none)')}</b> — not banked against a quote
+          (${escEmail(reason)}). If this is a design-studio order, it is tracked there, not on a quote.</p>
+       ${receiptUrl ? `<p><a href="${receiptUrl}">Customer receipt</a> — forward this if they ask for one.</p>` : ''}
+       ${dash ? `<p><a href="${dash}">Open in Stripe →</a></p>` : ''}`);
+  } catch (e) {
+    console.error('unbanked payment alert failed:', e.message);
+  }
 }
 
 async function bankStripeSession(session) {
@@ -4541,6 +4589,19 @@ app.post('/webhooks/stripe', async (req, res) => {
         console.log(`Stripe ${event.type} for ${obj.client_reference_id}: ` +
           (out.duplicate ? 'already banked (redirect won the race)' :
            out.ok ? `banked ${money(out.paid)}` : `skipped — ${out.reason}`));
+
+        /* A completed session that did NOT bank to a quote is still money that
+           arrived, and it used to end here as one log line nobody reads.
+           That is how the $35.75 payment for order #10 on 2026-08-11 was only
+           ever visible by opening the Stripe dashboard: the design studio sends
+           client_reference_id as the order number ("10"), QUOTE_CODE_RE wants
+           six characters, so it failed the test and fell out of the flow.
+
+           Not banking it is correct — an order is not a quote and has its own
+           ledger. Saying nothing is not. Tell the shop, and hand over the
+           Stripe receipt URL so a customer asking "where is my receipt" can be
+           answered from the email rather than from the dashboard. */
+        if (!out.ok && !out.duplicate) await alertUnbankedPayment(obj, out.reason);
         break;
       }
 

--- a/server.js
+++ b/server.js
@@ -4403,9 +4403,20 @@ async function alertShop(subject, innerHtml) {
 async function alertUnbankedPayment(session, reason) {
   try {
     const gross = round2((session.amount_total || 0) / 100);
-    const ref   = String(session.client_reference_id || '').trim();
     const email = session.customer_details?.email || '';
     const name  = session.customer_details?.name || '';
+
+    /* What this money belongs to, in the order the sources are trustworthy.
+       The design studio stamps metadata.order_id on both its checkout sessions
+       AND its balance Payment Links — and a Payment Link carries no
+       client_reference_id at all, so on a balance payment the metadata is the
+       only thing that identifies the order. Without reading it the alert would
+       say "reference (none)" for exactly the payments hardest to place. */
+    const orderId = String(session.metadata?.order_id || '').trim();
+    const ref = String(session.client_reference_id || '').trim();
+    const label = orderId ? `design studio order #${orderId}`
+                : ref     ? `reference ${ref}`
+                          : 'no reference';
 
     /* The charge carries the receipt URL, not the session, so it costs one
        lookup. Best-effort: a missing receipt link must not cost the alert. */
@@ -4422,11 +4433,12 @@ async function alertUnbankedPayment(session, reason) {
     }
 
     const dash = pi ? `https://dashboard.stripe.com/payments/${encodeURIComponent(pi)}` : '';
-    await alertShop(`💳 Stripe payment received — ${money(gross)}${ref ? ` (ref ${ref})` : ''}`,
+    await alertShop(`💳 Stripe payment received — ${money(gross)}${orderId ? ` (order #${orderId})` : ref ? ` (ref ${ref})` : ''}`,
       `<h2 style="color:#1848B8">A payment came in outside the quote flow</h2>
        <p><b>${money(gross)}</b>${name ? ` from ${escEmail(name)}` : ''}${email ? ` &lt;${escEmail(email)}&gt;` : ''}.</p>
-       <p style="color:#6b7280">Reference: <b>${escEmail(ref || '(none)')}</b> — not banked against a quote
-          (${escEmail(reason)}). If this is a design-studio order, it is tracked there, not on a quote.</p>
+       <p style="color:#6b7280">This is <b>${escEmail(label)}</b> — not banked against a quote
+          (${escEmail(reason)}). Design studio orders keep their own ledger on design.jtees.net;
+          this note exists so the money is never only visible in Stripe.</p>
        ${receiptUrl ? `<p><a href="${receiptUrl}">Customer receipt</a> — forward this if they ask for one.</p>` : ''}
        ${dash ? `<p><a href="${dash}">Open in Stripe →</a></p>` : ''}`);
   } catch (e) {

--- a/tests/stripe-payment-visibility.test.js
+++ b/tests/stripe-payment-visibility.test.js
@@ -107,3 +107,23 @@ test('the receipt address is only set when one is actually known', () => {
   assert.match(src, /if \(q\.email\) form\.set\('payment_intent_data\[receipt_email\]', q\.email\);/,
     'sending an empty receipt_email would error the session and take card payment down');
 });
+
+/* Balance payments arrive through a Stripe Payment Link, which carries no
+   client_reference_id at all — metadata.order_id is the only identifier on
+   them. An alert that reads only client_reference_id would say "no reference"
+   for precisely the payments hardest to place by hand. */
+test('the alert identifies a design-studio order from metadata', () => {
+  assert.match(ALERT_SRC, /session\.metadata\?\.order_id/,
+    'metadata.order_id is the only identifier on a Payment Link balance payment');
+});
+
+test('the subject line names the order when there is one', () => {
+  assert.match(ALERT_SRC, /order #\$\{orderId\}/,
+    'the shop should be able to place the payment from the subject line alone');
+});
+
+test('it still falls back to client_reference_id, then to saying so plainly', () => {
+  assert.match(ALERT_SRC, /ref\s*\?/);
+  assert.match(ALERT_SRC, /'no reference'/,
+    'an unidentifiable payment must still be announced, not dropped');
+});

--- a/tests/stripe-payment-visibility.test.js
+++ b/tests/stripe-payment-visibility.test.js
@@ -1,0 +1,109 @@
+/* Regression tests for payments Stripe took that the quote ledger did not claim,
+ * and for the receipt Stripe sends (server.js).
+ *
+ * Run: node --test tests/*.test.js
+ *
+ * What these exist to prevent:
+ *
+ * `bankStripeSession` requires client_reference_id to match QUOTE_CODE_RE
+ * (six characters) and returns `{ok:false, reason:'no quote code'}` otherwise.
+ * The design studio on design.jtees.net sends the ORDER NUMBER as
+ * client_reference_id — "10" — so its payments failed that test and the whole
+ * event ended as one console.log nobody reads. A real $35.75 order payment on
+ * 2026-08-11 was therefore visible only by opening the Stripe dashboard.
+ *
+ * Not banking an order against a quote is correct; an order has its own
+ * ledger. Staying silent about the money is the bug, and it is the same shape
+ * as the 08-16 outage: the code decided nothing was wrong and said nothing.
+ *
+ * The receipt half: of the first seven live charges, zero had a receipt
+ * emailed (`receipt_number` was null on every one) because the Dashboard's
+ * "Successful payments" toggle was off. Setting receipt_email makes Stripe
+ * send one in live mode regardless of that toggle, so customers stop having to
+ * ask.
+ */
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const SERVER = path.join(__dirname, '..', 'server.js');
+const src = fs.readFileSync(SERVER, 'utf8');
+
+function extractFn(anchor) {
+  const start = src.indexOf(anchor);
+  assert.notStrictEqual(start, -1, `\`${anchor}\` not found in server.js`);
+  const open = src.indexOf('{', start);
+  let depth = 0;
+  for (let i = open; i < src.length; i++) {
+    if (src[i] === '{') depth++;
+    else if (src[i] === '}' && --depth === 0) return src.slice(start, i + 1);
+  }
+  throw new Error(`unterminated function reading \`${anchor}\``);
+}
+
+/* ── the quote-code test that drops order payments ────────────────────────── */
+
+const QUOTE_CODE_RE = (() => {
+  const m = /const QUOTE_CODE_RE = (\/.*\/);/.exec(src);
+  assert.ok(m, 'QUOTE_CODE_RE not found');
+  const sandbox = {};
+  vm.createContext(sandbox);
+  return vm.runInContext(`(${m[1]})`, sandbox);
+})();
+
+test('a design-studio order number is NOT a quote code', () => {
+  assert.strictEqual(QUOTE_CODE_RE.test('10'), false,
+    'if this ever passes, order payments would be banked against a quote that does not exist');
+  assert.strictEqual(QUOTE_CODE_RE.test('7'), false);
+});
+
+test('a real quote code still passes', () => {
+  for (const code of ['731EAC', 'A7BFAD', 'AE6162']) {
+    assert.strictEqual(QUOTE_CODE_RE.test(code), true, `${code} must remain a valid quote code`);
+  }
+});
+
+/* ── the alert that closes the silence ───────────────────────────────────── */
+
+const ALERT_SRC = extractFn('async function alertUnbankedPayment(');
+
+test('an unbanked payment raises an alert instead of only a log line', () => {
+  assert.match(src, /if \(!out\.ok && !out\.duplicate\) await alertUnbankedPayment\(obj, out\.reason\);/,
+    'the checkout.session.completed branch must alert when the payment did not bank');
+});
+
+test('the alert names the amount and the reference it arrived under', () => {
+  assert.match(ALERT_SRC, /amount_total/);
+  assert.match(ALERT_SRC, /client_reference_id/,
+    'the reference is how the shop finds the order this money belongs to');
+});
+
+test('the alert carries the Stripe receipt URL', () => {
+  assert.match(ALERT_SRC, /receipt_url/,
+    'a customer asking for a receipt should be answerable from the alert, not the dashboard');
+});
+
+test('a duplicate delivery does not re-alert', () => {
+  assert.match(src, /!out\.duplicate/,
+    'Stripe retries webhooks; the redirect also races them — neither may double-notify');
+});
+
+test('the alert can never fail the webhook', () => {
+  assert.match(ALERT_SRC, /catch \(e\) \{[\s\S]*console\.error\('unbanked payment alert failed/,
+    'a throwing alert would make Stripe retry a payment that already settled');
+});
+
+/* ── the receipt ─────────────────────────────────────────────────────────── */
+
+test('checkout sets receipt_email so Stripe sends its own receipt', () => {
+  assert.match(src, /payment_intent_data\[receipt_email\]/,
+    'without this, receipts depend entirely on a Dashboard toggle that was off for the first 7 live charges');
+});
+
+test('the receipt address is only set when one is actually known', () => {
+  assert.match(src, /if \(q\.email\) form\.set\('payment_intent_data\[receipt_email\]', q\.email\);/,
+    'sending an empty receipt_email would error the session and take card payment down');
+});


### PR DESCRIPTION
## What I found

I audited every live charge on the account. All 7 came through the app's own Checkout — there are **no Payment Links (0 defined) and no invoices (0)**, so nothing is arriving from a channel outside the app. But one was invisible anyway:

```
2026-08-11  $35.75  app Checkout (client_reference_id = "10")
```

That's a **design-studio order**, not a quote. `design.jtees.net` sends the order number as `client_reference_id`; `QUOTE_CODE_RE` is `/^[A-Z0-9]{6}$/`, so `"10"` fails it and `bankStripeSession` returns `{ok:false, reason:'no quote code'}`. The webhook then ended the event with a single `console.log`. That payment was only ever visible by opening the Stripe dashboard.

Not banking an order against a quote is correct — an order has its own ledger. Staying silent about the money is not, and it is the same shape as the 08-16 outage: the code decided nothing was wrong and said nothing.

Separately, of those 7 charges, **zero had a receipt emailed** (`receipt_number` null on every one) — the Dashboard's "Successful payments" toggle is off.

## What changed

- **`alertUnbankedPayment()`** — when a checkout session completes but does not bank to a quote, the shop gets an email with the amount, the reference it arrived under, the customer's name/email, a **Stripe receipt URL** (so "where's my receipt?" is answerable from the alert), and a dashboard link. Guarded by `!out.duplicate` so webhook retries and the redirect race can't double-notify, and it can never throw — a failing alert would make Stripe retry a settled payment.
- **`payment_intent_data[receipt_email]`** on checkout session creation. In live mode `receipt_email` sends a receipt **regardless** of the Dashboard toggle, so receipts stop depending on a setting — and on this app being up, which mattered on 08-16.

## Tests

9 new in `tests/stripe-payment-visibility.test.js`, including a lock on `QUOTE_CODE_RE` rejecting order numbers and accepting real quote codes. Suite: **55 passing**.

## Not covered here

The design studio lives in `alwinte5-rgb/lumise-designer`. Its own checkout would need the same `receipt_email` treatment for order receipts to be automatic; enabling the Dashboard toggle covers it in the meantime.