### PR TITLE
Queue the review ask on complete as well as shipped

### DIFF
--- a/server.js
+++ b/server.js
@@ -7397,10 +7397,21 @@ app.post('/api/order-notification', requireInternalKey, async (req, res) => {
   }
 });
 
-// "Your order shipped"
-/* Review requests ride on the shipped notice: the designer calls this when June
-   marks an order shipped, so the ask lands a sensible number of days later
-   rather than needing its own trigger. */
+// "Your order shipped" — and the review ask that rides on it.
+/* The designer calls this when an order reaches a milestone the customer would
+   recognise. `status` says which one:
+
+     shipped   → the customer gets the "on the way" notice, and a review is queued
+     complete  → review only, no notice
+
+   Both queue the ask because `shipped` alone never fires in practice: as of
+   2026-08-27 no order had ever carried that status — the statuses on file were
+   cancel x3 and complete x1 — so the review queue had stayed empty since the
+   day it was written. An ask that depends on a status nobody sets is an ask
+   that never happens.
+
+   `status` is optional and defaults to 'shipped', so a designer build that
+   predates this keeps its old behaviour exactly. */
 app.post('/api/order-shipped', requireInternalKey, async (req, res) => {
   try {
     const b = req.body || {};
@@ -7408,7 +7419,11 @@ app.post('/api/order-shipped', requireInternalKey, async (req, res) => {
     if (!isValidEmail(email)) return res.status(400).json({ error: 'bad email' });
     const name = String(b.name || '').trim();
     const tracking = String(b.tracking || '').trim();
-    await sendEmail({
+    const status = String(b.status || 'shipped').trim().toLowerCase();
+    /* Only a real shipment gets the shipping notice. Telling someone their
+       order "just left our shop" because it was marked complete is a message
+       they will read as a mistake, and rightly. */
+    if (status === 'shipped') await sendEmail({
       to: email,
       subject: `Your order #${b.order_id} is on the way 📦`,
       html: orderShell({
@@ -7429,10 +7444,17 @@ app.post('/api/order-shipped', requireInternalKey, async (req, res) => {
        sweep sends it when the date arrives. */
     if (isValidEmail(String(b.email || ''))) {
       const days = Math.max(0, parseInt(process.env.JT_REVIEW_DELAY_DAYS || '7', 10));
+      /* One ask per order, however many milestones it passes. An order that
+         goes complete and then shipped calls this twice, and the token is
+         random so ON CONFLICT (token) cannot stop the second — the guard has
+         to be the order itself. Rows already sent are excluded so a genuine
+         repeat order can still be asked later. */
       await pool.query(
         `INSERT INTO reviews (token, name, email, phone, product, order_ref, requested_at)
-         VALUES ($1,$2,$3,$4,$5,$6, NOW() + ($7 || ' days')::interval)
-         ON CONFLICT (token) DO NOTHING`,
+         SELECT $1,$2,$3,$4,$5,$6, NOW() + ($7 || ' days')::interval
+          WHERE NOT EXISTS (
+            SELECT 1 FROM reviews
+             WHERE order_ref = $6 AND sent_at IS NULL AND submitted_at IS NULL)`,
         [reviewToken(), b.name || '', String(b.email), b.phone || '',
          Array.isArray(b.items) && b.items[0] ? b.items[0].name : '',
          String(b.order_id || ''), String(days)]

--- a/tests/review-trigger.test.js
+++ b/tests/review-trigger.test.js
@@ -1,0 +1,80 @@
+/* Regression tests for when a review request gets queued (server.js).
+ *
+ * Run: node --test tests/*.test.js
+ *
+ * The whole review system — template, star links, the 4-5 star handoff to
+ * Google, the hourly sweep, the approval screen — sat finished and idle from
+ * the day it shipped. On 2026-08-27 the reviews table held 0 rows: nothing
+ * queued, nothing sent, no reviews collected.
+ *
+ * The cause was a single status. The only thing that queued an ask was an
+ * order transitioning to `shipped`, and the Lumise orders table had never
+ * contained that status — cancel x3 and complete x1 were the only values
+ * anyone had ever set. A trigger nobody fires is not a feature.
+ *
+ * So `complete` now queues an ask too, while the "your order is on the way"
+ * notice stays exclusive to a real shipment. Two things must both hold, and
+ * each is easy to break by accident:
+ *
+ *   1. `complete` must NOT send a shipping notice. Telling a customer their
+ *      order "just left our shop" because someone marked it complete reads as
+ *      a mistake, and it is one.
+ *   2. An order passing BOTH milestones must produce ONE ask. The review token
+ *      is random, so `ON CONFLICT (token)` cannot deduplicate — the guard has
+ *      to key on the order.
+ */
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const SERVER = path.join(__dirname, '..', 'server.js');
+const src = fs.readFileSync(SERVER, 'utf8');
+
+/** The /api/order-shipped handler, start to its closing `});`. */
+const HANDLER = (() => {
+  const start = src.indexOf("app.post('/api/order-shipped'");
+  assert.notStrictEqual(start, -1, '/api/order-shipped handler not found');
+  const end = src.indexOf('\n});', start);
+  assert.notStrictEqual(end, -1, 'handler end not found');
+  return src.slice(start, end);
+})();
+
+test('the shipping notice is sent only for an actual shipment', () => {
+  assert.match(HANDLER, /if \(status === 'shipped'\) await sendEmail\(/,
+    'a `complete` milestone must not tell the customer their order is on the way');
+});
+
+test('status defaults to shipped, so an older designer build is unaffected', () => {
+  assert.match(HANDLER, /String\(b\.status \|\| 'shipped'\)/,
+    'a payload with no status must behave exactly as it did before');
+});
+
+test('status is compared lowercased', () => {
+  assert.match(HANDLER, /\.toLowerCase\(\)/,
+    '"Shipped" from the admin must not silently skip the notice');
+});
+
+test('the review is queued regardless of which milestone arrived', () => {
+  const queueAt = HANDLER.indexOf('INSERT INTO reviews');
+  const notifyAt = HANDLER.indexOf("if (status === 'shipped')");
+  assert.notStrictEqual(queueAt, -1, 'the review queue must still be here');
+  assert.ok(queueAt > notifyAt, 'sanity: the queue follows the notice');
+  const tail = HANDLER.slice(notifyAt);
+  const queueBlock = tail.slice(tail.indexOf("if (isValidEmail(String(b.email"));
+  assert.doesNotMatch(queueBlock.slice(0, queueBlock.indexOf('INSERT INTO reviews')), /status === 'shipped'/,
+    'the review queue must not be nested inside the shipped-only branch');
+});
+
+test('one ask per order, however many milestones it passes', () => {
+  assert.match(HANDLER, /WHERE NOT EXISTS \(\s*SELECT 1 FROM reviews/,
+    'complete-then-shipped calls this twice; the random token cannot deduplicate it');
+  assert.match(HANDLER, /order_ref = \$6 AND sent_at IS NULL AND submitted_at IS NULL/,
+    'the guard must key on the order, and must not block a genuine repeat order later');
+});
+
+test('an already-sent ask does not block a future one', () => {
+  assert.match(HANDLER, /sent_at IS NULL/,
+    'excluding sent rows is what lets a returning customer be asked again');
+});


### PR DESCRIPTION
## Why

The reviews table has held **0 rows since the day the system shipped** — nothing queued, nothing sent, no reviews collected. The template, the star links, the 4–5 star handoff to Google, the hourly sweep and the approval screen were all finished and idle.

One status caused it. The only thing that queued an ask was an order reaching `shipped`, and the Lumise orders table has never contained that status:

```
orders by status:   cancel: 3    complete: 1
```

A trigger nobody fires is not a feature.

## What changed

`complete` now queues a review too. Two things had to stay true:

- **`complete` must not send a shipping notice.** Telling a customer their order "just left our shop" because someone marked it complete reads as a mistake, so `sendEmail` is now gated on `status === 'shipped'` while the review queue runs for either milestone.
- **Both milestones must produce one ask.** An order going complete → shipped calls this endpoint twice, and the review token is random so `ON CONFLICT (token)` cannot deduplicate. The guard keys on `order_ref` instead, excluding already-sent rows so a genuine repeat order can still be asked later.

`status` is optional and defaults to `'shipped'`, so a designer build that predates this behaves exactly as before. Comparison is lowercased so `Shipped` from the admin doesn't silently skip the notice.

## Paired change

`alwinte5-rgb/lumise-designer` sends the new `status` field and fires on both milestones. Merge that one too, or this only takes effect for orders marked shipped.

## Not done

Quote customers still have no review path — they pay through jtees checkout and never touch an order status. That is a separate change and I have not made it here.

## Tests

6 new in `tests/review-trigger.test.js`. Suite: **98 passing**.