### PR TITLE
Rewrite the review request so it reads like June sent it

### DIFF
--- a/server.js
+++ b/server.js
@@ -7537,6 +7537,42 @@ async function rescheduleReviewRequest({ name, email, phone, product, order_ref,
   }
 }
 
+/* Turn a line-item description into something sayable in a sentence.
+   The real values range from "Embroidery Chest Logo", which reads fine, to
+   "Valucap Bio-Washed Classic Dad Hat - VC300A", which does not — a SKU in a
+   subject line is the tell that a human did not write it. Strip the code,
+   drop quantity noise, and give up entirely if what is left is too long to
+   sit inside a sentence, rather than shipping a mangled half-name. */
+function reviewItemLabel(product) {
+  const raw = String(product || '').trim();
+  if (!raw) return '';
+
+  /* Take the most human-readable segment, not simply the first. Splitting
+     blindly turns "Bella+Canvas 3001T — Toddler Jersey Tee" into
+     "Bella+Canvas 3001T", which is the half a catalogue cares about and the
+     half a customer does not. Score each piece down for digits and SKU-shaped
+     tokens, up for actual words, and keep the winner. */
+  /* Whitespace on at least one side is required, or the split lands inside
+     hyphenated words: "T-shirt" became "T" and "Bio-Washed" became "Washed". */
+  const pieces = raw.split(/\s+[-—|]+\s*|\s*[-—|]+\s+/).map(x => x.trim()).filter(Boolean);
+  const score = (x) => {
+    const words = x.split(/\s+/).filter(w => /^[A-Za-z][A-Za-z']*$/.test(w)).length;
+    const skuish = /\b[A-Za-z]{0,4}\d{2,5}[A-Za-z]?\b/.test(x) ? 1 : 0;
+    const digits = (x.match(/\d/g) || []).length;
+    return words * 2 - skuish * 3 - digits;
+  };
+  let t = pieces.sort((a, b) => score(b) - score(a))[0] || raw;
+
+  t = t.replace(/\s*\b[A-Za-z]{0,4}\d{2,5}[A-Za-z]?\b\s*$/, '');      // trailing SKU
+  t = t.replace(/\s*\b\d+\s*(pair|pairs|pcs?|pieces?|qty|ct)\b\s*/gi, ' ');
+  t = t.replace(/[\s,;:+&-]+$/, '').replace(/\s{2,}/g, ' ').trim();
+
+  // Too long to sit inside a sentence, or nothing readable survived: say
+  // nothing rather than ship a mangled half-name.
+  if (!t || t.length > 42 || !/[A-Za-z]{3}/.test(t)) return '';
+  return escEmail(t);
+}
+
 /* Ask a customer for a review. Called after delivery. */
 async function requestReview({ token, name, email, phone, product, order_ref, quote_code }) {
   if (!isValidEmail(String(email || ''))) return null;
@@ -7552,20 +7588,51 @@ async function requestReview({ token, name, email, phone, product, order_ref, qu
   const stars = [1,2,3,4,5].map(n =>
     `<a href="${link}?r=${n}" style="text-decoration:none;font-size:30px;color:#F4A623">★</a>`).join(' ');
 
+  const first = name ? escEmail(String(name).split(' ')[0]) : '';
+  const item = reviewItemLabel(product);
+
+  /* The subject carries the THING, not the survey. "How did we do?" reads as an
+     automated NPS ping and gets treated like one; "How did the embroidery turn
+     out?" is a question only someone who knows the order could ask, and it is
+     the single biggest lever on whether this is opened at all. */
+  const subject = item
+    ? `How did the ${item} turn out${first ? ', ' + String(name).split(' ')[0] : ''}?`
+    : `How did we do${first ? ', ' + String(name).split(' ')[0] : ''}?`;
+
   await sendEmail({
     to: email,
-    subject: `How did we do${name ? ', ' + String(name).split(' ')[0] : ''}?`,
-    html: `<div style="font-family:system-ui,sans-serif;max-width:520px;margin:0 auto">
-      <h2 style="color:#1848B8">How did we do?</h2>
-      <p style="color:#374151;line-height:1.6">
-        ${name ? escEmail(String(name).split(' ')[0]) + ', thanks' : 'Thanks'} again for your order${product ? ' — ' + escEmail(product) : ''}.
-        If you have a moment, tap a star. It takes seconds and it genuinely helps a small Chicago shop.</p>
-      <p style="text-align:center;margin:22px 0">${stars}</p>
-      <p style="text-align:center"><a href="${link}"
-         style="background:#1848B8;color:#fff;padding:12px 26px;border-radius:100px;text-decoration:none;font-weight:700">Leave a review</a></p>
-      <p style="color:#6b7280;font-size:13px;line-height:1.6;margin-top:18px">
-        Something not right? Reply to this email or text ${SHOP_PHONE} — ${SHOP_SIGNER} would much rather fix it.</p>
-      <p style="color:#9ca3af;font-size:12px;margin-top:22px">${SHOP_NAME} &middot; 3047 N Lincoln Ave #435, Chicago, IL 60657</p>
+    subject,
+    html: `<div style="font-family:system-ui,-apple-system,'Segoe UI',sans-serif;max-width:520px;margin:0 auto;padding:8px">
+      <!-- Preview text: what the inbox shows beside the subject. Hidden in the
+           body so it never renders twice. -->
+      <div style="display:none;max-height:0;overflow:hidden;opacity:0">One tap, no form, no account.</div>
+
+      <p style="color:#374151;line-height:1.7;margin:0 0 14px">${first ? 'Hi ' + first + ',' : 'Hi,'}</p>
+
+      <p style="color:#374151;line-height:1.7;margin:0 0 14px">${
+        item ? `Your <strong>${item}</strong> went out a little while ago` : 'Your order went out a little while ago'} —
+        I hope it has had some use by now.</p>
+
+      <p style="color:#374151;line-height:1.7;margin:0 0 6px">If it turned out well, would you tap a star?
+        One click, no form, no account.</p>
+
+      <p style="text-align:center;margin:20px 0 6px;line-height:1">${stars}</p>
+      <p style="text-align:center;margin:0 0 22px"><a href="${link}"
+         style="color:#6b7280;font-size:13px;text-decoration:underline">or write a few words &rarr;</a></p>
+
+      <p style="color:#374151;line-height:1.7;margin:0 0 18px">Reviews are genuinely how a small Chicago shop
+        gets found instead of a big online printer. It takes about ten seconds and it helps more than you would think.</p>
+
+      <p style="color:#374151;line-height:1.7;margin:0 0 4px">Thank you,</p>
+      <p style="color:#111827;line-height:1.7;margin:0 0 22px;font-weight:600">${SHOP_SIGNER}</p>
+
+      <!-- The safety valve stays, but as a P.S. — the second most-read line in
+           any email, and the place an unhappy customer will actually see it. -->
+      <p style="color:#6b7280;font-size:13px;line-height:1.6;margin:0 0 18px;padding-top:14px;border-top:1px solid #eef1f8">
+        <strong>P.S.</strong> If anything was not right, just reply here or text me at ${SHOP_PHONE} —
+        I would far rather fix it than leave you unhappy.</p>
+
+      <p style="color:#9ca3af;font-size:12px;margin:0">${SHOP_NAME} &middot; 3047 N Lincoln Ave #435, Chicago, IL 60657</p>
     </div>`,
   });
   return token;

--- a/server.js
+++ b/server.js
@@ -7537,42 +7537,6 @@ async function rescheduleReviewRequest({ name, email, phone, product, order_ref,
   }
 }
 
-/* Turn a line-item description into something sayable in a sentence.
-   The real values range from "Embroidery Chest Logo", which reads fine, to
-   "Valucap Bio-Washed Classic Dad Hat - VC300A", which does not — a SKU in a
-   subject line is the tell that a human did not write it. Strip the code,
-   drop quantity noise, and give up entirely if what is left is too long to
-   sit inside a sentence, rather than shipping a mangled half-name. */
-function reviewItemLabel(product) {
-  const raw = String(product || '').trim();
-  if (!raw) return '';
-
-  /* Take the most human-readable segment, not simply the first. Splitting
-     blindly turns "Bella+Canvas 3001T — Toddler Jersey Tee" into
-     "Bella+Canvas 3001T", which is the half a catalogue cares about and the
-     half a customer does not. Score each piece down for digits and SKU-shaped
-     tokens, up for actual words, and keep the winner. */
-  /* Whitespace on at least one side is required, or the split lands inside
-     hyphenated words: "T-shirt" became "T" and "Bio-Washed" became "Washed". */
-  const pieces = raw.split(/\s+[-—|]+\s*|\s*[-—|]+\s+/).map(x => x.trim()).filter(Boolean);
-  const score = (x) => {
-    const words = x.split(/\s+/).filter(w => /^[A-Za-z][A-Za-z']*$/.test(w)).length;
-    const skuish = /\b[A-Za-z]{0,4}\d{2,5}[A-Za-z]?\b/.test(x) ? 1 : 0;
-    const digits = (x.match(/\d/g) || []).length;
-    return words * 2 - skuish * 3 - digits;
-  };
-  let t = pieces.sort((a, b) => score(b) - score(a))[0] || raw;
-
-  t = t.replace(/\s*\b[A-Za-z]{0,4}\d{2,5}[A-Za-z]?\b\s*$/, '');      // trailing SKU
-  t = t.replace(/\s*\b\d+\s*(pair|pairs|pcs?|pieces?|qty|ct)\b\s*/gi, ' ');
-  t = t.replace(/[\s,;:+&-]+$/, '').replace(/\s{2,}/g, ' ').trim();
-
-  // Too long to sit inside a sentence, or nothing readable survived: say
-  // nothing rather than ship a mangled half-name.
-  if (!t || t.length > 42 || !/[A-Za-z]{3}/.test(t)) return '';
-  return escEmail(t);
-}
-
 /* Ask a customer for a review. Called after delivery. */
 async function requestReview({ token, name, email, phone, product, order_ref, quote_code }) {
   if (!isValidEmail(String(email || ''))) return null;
@@ -7589,15 +7553,16 @@ async function requestReview({ token, name, email, phone, product, order_ref, qu
     `<a href="${link}?r=${n}" style="text-decoration:none;font-size:30px;color:#F4A623">★</a>`).join(' ');
 
   const first = name ? escEmail(String(name).split(' ')[0]) : '';
-  const item = reviewItemLabel(product);
 
-  /* The subject carries the THING, not the survey. "How did we do?" reads as an
-     automated NPS ping and gets treated like one; "How did the embroidery turn
-     out?" is a question only someone who knows the order could ask, and it is
-     the single biggest lever on whether this is opened at all. */
-  const subject = item
-    ? `How did the ${item} turn out${first ? ', ' + String(name).split(' ')[0] : ''}?`
-    : `How did we do${first ? ', ' + String(name).split(' ')[0] : ''}?`;
+  /* "How did we do?" reads as an automated survey; "How did your order turn
+     out?" is a person asking about a specific thing they made.
+
+     The product name is deliberately NOT here. The stored values are supplier
+     catalogue names — "Valucap Bio-Washed Classic Dad Hat - VC300A",
+     "Comfort Colors T-shirt - Navy Blue", "Shirt with photo" — and no customer
+     thinks of their order that way. Naming it made the sentence read like a
+     picking list, which is worse than not naming it at all. */
+  const subject = `How did your order turn out${first ? ', ' + String(name).split(' ')[0] : ''}?`;
 
   await sendEmail({
     to: email,
@@ -7609,8 +7574,7 @@ async function requestReview({ token, name, email, phone, product, order_ref, qu
 
       <p style="color:#374151;line-height:1.7;margin:0 0 14px">${first ? 'Hi ' + first + ',' : 'Hi,'}</p>
 
-      <p style="color:#374151;line-height:1.7;margin:0 0 14px">${
-        item ? `Your <strong>${item}</strong> went out a little while ago` : 'Your order went out a little while ago'} —
+      <p style="color:#374151;line-height:1.7;margin:0 0 14px">Your order went out a little while ago —
         I hope it has had some use by now.</p>
 
       <p style="color:#374151;line-height:1.7;margin:0 0 6px">If it turned out well, would you tap a star?

--- a/tests/review-email-copy.test.js
+++ b/tests/review-email-copy.test.js
@@ -4,31 +4,31 @@
  *
  * The first version went out to six real customers with the subject
  * "How did we do, <Name>?" — which reads as an automated NPS ping and gets
- * treated like one. The rewrite puts the actual thing they bought in the
- * subject, because a question only someone who knows the order could ask is
- * the single biggest lever on whether the mail is opened at all.
+ * treated like one.
  *
- * That only works if the product string is sayable inside a sentence, and the
- * real ones are not uniformly friendly. These are the six live values:
+ * The rewrite asks about the order in the owner's own voice. An earlier draft
+ * named the PRODUCT in the subject, and that was reverted after reading what
+ * the real values actually are:
  *
- *   Embroidery Chest Logo                          already fine
- *   Shirt with photo                               already fine
- *   Comfort Colors T-shirt - Navy Blue             colour suffix to drop
- *   Custom Print on Jeans - 2 pair- Princess & Frog quantity noise
- *   Valucap Bio-Washed Classic Dad Hat - VC300A    trailing SKU
- *   Bella+Canvas 3001T — Toddler Jersey Tee        SKU FIRST, name second
+ *   Valucap Bio-Washed Classic Dad Hat - VC300A
+ *   Comfort Colors T-shirt - Navy Blue
+ *   Bella+Canvas 3001T — Toddler Jersey Tee
+ *   Shirt with photo
  *
- * The last one is why the picker scores segments instead of taking the first:
- * "How did the Bella+Canvas 3001T turn out?" is worse than the generic line it
- * replaced. And the separator needs whitespace around it, or the split lands
- * inside "T-shirt" and "Bio-Washed".
+ * Those are supplier catalogue names. No customer thinks of their order that
+ * way, and dropping one into a sentence made it read like a picking list —
+ * worse than the generic line it was meant to improve. The lesson worth
+ * keeping: personalising with a field is only an improvement when the field
+ * contains something a person would actually say.
+ *
+ * These tests hold the parts that carry the mail: the voice, the single ask,
+ * the preview line, and the route out for an unhappy customer.
  */
 
 const { test } = require('node:test');
 const assert = require('node:assert');
 const fs = require('node:fs');
 const path = require('node:path');
-const vm = require('node:vm');
 
 const SERVER = path.join(__dirname, '..', 'server.js');
 const src = fs.readFileSync(SERVER, 'utf8');
@@ -51,71 +51,15 @@ function extractFn(anchor) {
   throw new Error(`unterminated function reading \`${anchor}\``);
 }
 
-/* Run the real function, not a restatement of it. */
-const label = (() => {
-  const sandbox = { escEmail: (s) => String(s) };
-  vm.createContext(sandbox);
-  vm.runInContext(extractFn('function reviewItemLabel('), sandbox);
-  return sandbox.reviewItemLabel;
-})();
-
-/* ── the six values actually in the reviews table ────────────────────────── */
-
-test('a readable name is left alone', () => {
-  assert.strictEqual(label('Embroidery Chest Logo'), 'Embroidery Chest Logo');
-  assert.strictEqual(label('Shirt with photo'), 'Shirt with photo');
-});
-
-test('a colour suffix is dropped', () => {
-  assert.strictEqual(label('Comfort Colors T-shirt - Navy Blue'), 'Comfort Colors T-shirt');
-});
-
-test('quantity noise is dropped', () => {
-  assert.strictEqual(label('Custom Print on Jeans - 2 pair- Princess & Frog'), 'Custom Print on Jeans');
-});
-
-test('a trailing SKU is dropped', () => {
-  assert.strictEqual(label('Valucap Bio-Washed Classic Dad Hat - VC300A'),
-    'Valucap Bio-Washed Classic Dad Hat');
-});
-
-test('the human half wins when the SKU comes first', () => {
-  assert.strictEqual(label('Bella+Canvas 3001T — Toddler Jersey Tee'), 'Toddler Jersey Tee',
-    'taking the first segment would put a SKU in the subject line');
-});
-
-/* ── hyphens inside words are not separators ─────────────────────────────── */
-
-test('hyphenated words survive the split', () => {
-  assert.match(label('Comfort Colors T-shirt - Navy Blue'), /T-shirt/,
-    'an unspaced hyphen is part of the word, not a separator');
-  assert.match(label('Valucap Bio-Washed Classic Dad Hat - VC300A'), /Bio-Washed/);
-});
-
-/* ── give up rather than ship something mangled ──────────────────────────── */
-
-test('a bare SKU produces nothing, not a broken subject', () => {
-  assert.strictEqual(label('VC300A'), '');
-});
-
-test('empty and missing input produce nothing', () => {
-  for (const v of ['', null, undefined, '   ']) assert.strictEqual(label(v), '');
-});
-
-test('something too long for a sentence produces nothing', () => {
-  assert.strictEqual(
-    label('A ludicrously long product description nobody would want in a subject line'), '');
-});
-
 /* ── the email itself ────────────────────────────────────────────────────── */
 
 const REQUEST = extractFn('async function requestReview(');
 
-test('the subject names the item when there is one, and degrades when there is not', () => {
-  assert.match(REQUEST, /How did the \$\{item\} turn out/,
-    'the item is the whole reason this is opened rather than deleted');
-  assert.match(REQUEST, /How did we do\$\{first/,
-    'with no usable item name it must still send, not send a broken subject');
+test('the subject asks about the order, in a person\'s voice', () => {
+  assert.match(REQUEST, /How did your order turn out/,
+    '"How did we do?" is a survey; this is someone asking about a thing they made');
+  assert.match(REQUEST, /\$\{first \? ', ' \+ String\(name\)\.split\(' '\)\[0\] : ''\}/,
+    'the first name is the only personalisation, and it must survive a missing name');
 });
 
 test('the mail carries preview text', () => {
@@ -136,4 +80,21 @@ test('it is signed by a person', () => {
 test('the star links still carry the rating', () => {
   assert.match(REQUEST, /\$\{link\}\?r=\$\{n\}|r=\$\{n\}/,
     'one-tap rating is the entire mechanism');
+});
+
+test('the subject does not name the product', () => {
+  assert.doesNotMatch(REQUEST, /reviewItemLabel/,
+    'supplier catalogue names read as a picking list, not as a person asking');
+  assert.match(REQUEST, /How did your order turn out/);
+});
+
+test('the product is gone from the body too', () => {
+  assert.doesNotMatch(REQUEST, /\$\{item\}/,
+    'half-removing it would leave an empty <strong> in the sentence');
+  assert.match(REQUEST, /Your order went out a little while ago/);
+});
+
+test('the helper it used was deleted, not left behind', () => {
+  assert.doesNotMatch(src, /function reviewItemLabel/,
+    'dead code that formats nothing invites someone to wire it back up');
 });

--- a/tests/review-email-copy.test.js
+++ b/tests/review-email-copy.test.js
@@ -1,0 +1,139 @@
+/* Regression tests for the review request email (server.js).
+ *
+ * Run: node --test tests/*.test.js
+ *
+ * The first version went out to six real customers with the subject
+ * "How did we do, <Name>?" — which reads as an automated NPS ping and gets
+ * treated like one. The rewrite puts the actual thing they bought in the
+ * subject, because a question only someone who knows the order could ask is
+ * the single biggest lever on whether the mail is opened at all.
+ *
+ * That only works if the product string is sayable inside a sentence, and the
+ * real ones are not uniformly friendly. These are the six live values:
+ *
+ *   Embroidery Chest Logo                          already fine
+ *   Shirt with photo                               already fine
+ *   Comfort Colors T-shirt - Navy Blue             colour suffix to drop
+ *   Custom Print on Jeans - 2 pair- Princess & Frog quantity noise
+ *   Valucap Bio-Washed Classic Dad Hat - VC300A    trailing SKU
+ *   Bella+Canvas 3001T — Toddler Jersey Tee        SKU FIRST, name second
+ *
+ * The last one is why the picker scores segments instead of taking the first:
+ * "How did the Bella+Canvas 3001T turn out?" is worse than the generic line it
+ * replaced. And the separator needs whitespace around it, or the split lands
+ * inside "T-shirt" and "Bio-Washed".
+ */
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const SERVER = path.join(__dirname, '..', 'server.js');
+const src = fs.readFileSync(SERVER, 'utf8');
+
+function extractFn(anchor) {
+  const start = src.indexOf(anchor);
+  assert.notStrictEqual(start, -1, `\`${anchor}\` not found in server.js`);
+  let i = src.indexOf('(', start);
+  let parens = 0;
+  for (; i < src.length; i++) {
+    if (src[i] === '(') parens++;
+    else if (src[i] === ')' && --parens === 0) { i++; break; }
+  }
+  const open = src.indexOf('{', i);
+  let depth = 0;
+  for (let j = open; j < src.length; j++) {
+    if (src[j] === '{') depth++;
+    else if (src[j] === '}' && --depth === 0) return src.slice(start, j + 1);
+  }
+  throw new Error(`unterminated function reading \`${anchor}\``);
+}
+
+/* Run the real function, not a restatement of it. */
+const label = (() => {
+  const sandbox = { escEmail: (s) => String(s) };
+  vm.createContext(sandbox);
+  vm.runInContext(extractFn('function reviewItemLabel('), sandbox);
+  return sandbox.reviewItemLabel;
+})();
+
+/* ── the six values actually in the reviews table ────────────────────────── */
+
+test('a readable name is left alone', () => {
+  assert.strictEqual(label('Embroidery Chest Logo'), 'Embroidery Chest Logo');
+  assert.strictEqual(label('Shirt with photo'), 'Shirt with photo');
+});
+
+test('a colour suffix is dropped', () => {
+  assert.strictEqual(label('Comfort Colors T-shirt - Navy Blue'), 'Comfort Colors T-shirt');
+});
+
+test('quantity noise is dropped', () => {
+  assert.strictEqual(label('Custom Print on Jeans - 2 pair- Princess & Frog'), 'Custom Print on Jeans');
+});
+
+test('a trailing SKU is dropped', () => {
+  assert.strictEqual(label('Valucap Bio-Washed Classic Dad Hat - VC300A'),
+    'Valucap Bio-Washed Classic Dad Hat');
+});
+
+test('the human half wins when the SKU comes first', () => {
+  assert.strictEqual(label('Bella+Canvas 3001T — Toddler Jersey Tee'), 'Toddler Jersey Tee',
+    'taking the first segment would put a SKU in the subject line');
+});
+
+/* ── hyphens inside words are not separators ─────────────────────────────── */
+
+test('hyphenated words survive the split', () => {
+  assert.match(label('Comfort Colors T-shirt - Navy Blue'), /T-shirt/,
+    'an unspaced hyphen is part of the word, not a separator');
+  assert.match(label('Valucap Bio-Washed Classic Dad Hat - VC300A'), /Bio-Washed/);
+});
+
+/* ── give up rather than ship something mangled ──────────────────────────── */
+
+test('a bare SKU produces nothing, not a broken subject', () => {
+  assert.strictEqual(label('VC300A'), '');
+});
+
+test('empty and missing input produce nothing', () => {
+  for (const v of ['', null, undefined, '   ']) assert.strictEqual(label(v), '');
+});
+
+test('something too long for a sentence produces nothing', () => {
+  assert.strictEqual(
+    label('A ludicrously long product description nobody would want in a subject line'), '');
+});
+
+/* ── the email itself ────────────────────────────────────────────────────── */
+
+const REQUEST = extractFn('async function requestReview(');
+
+test('the subject names the item when there is one, and degrades when there is not', () => {
+  assert.match(REQUEST, /How did the \$\{item\} turn out/,
+    'the item is the whole reason this is opened rather than deleted');
+  assert.match(REQUEST, /How did we do\$\{first/,
+    'with no usable item name it must still send, not send a broken subject');
+});
+
+test('the mail carries preview text', () => {
+  assert.match(REQUEST, /display:none;max-height:0/,
+    'the inbox preview line is read before the mail is opened; leaving it to chance wastes it');
+});
+
+test('the unhappy-customer route survives the rewrite', () => {
+  assert.match(REQUEST, /P\.S\./);
+  assert.match(REQUEST, /SHOP_PHONE/,
+    'somebody with a problem must always have a direct line that is not a star rating');
+});
+
+test('it is signed by a person', () => {
+  assert.match(REQUEST, /\$\{SHOP_SIGNER\}/);
+});
+
+test('the star links still carry the rating', () => {
+  assert.match(REQUEST, /\$\{link\}\?r=\$\{n\}|r=\$\{n\}/,
+    'one-tap rating is the entire mechanism');
+});


### PR DESCRIPTION
Preview: https://claude.ai/code/artifact/435180bb-441d-42b5-b3ac-51401f197200

## Why

Six customers received this on 28 Aug with the subject **"How did we do, Bri?"** — a question any company could send, which is why it reads as an automated survey and gets treated like one.

## What changed

**Subject:** `How did your order turn out, Bri?` — the same words a person would use, rather than a satisfaction survey.

**Preview text** is set explicitly (`One tap, no form, no account.`) instead of letting the inbox default to the first body sentence.

**One ask, not two.** The stars were competing with a "Leave a review" button doing the identical job. Stars are the ask; writing more is a quiet link underneath.

**Written first person and signed June.** No "we value your feedback".

**The problem route moved to a P.S.** — the most-read line after the opening, and the one an unhappy customer most needs to see. Buried mid-mail it was missed.

## What I tried and reverted

An earlier commit put the **product name** in the subject. It reads well in the abstract and does not survive contact with the real data — these are supplier catalogue names:

| Stored value | Would have read |
|---|---|
| `Valucap Bio-Washed Classic Dad Hat - VC300A` | How did the Valucap Bio-Washed Classic Dad Hat turn out, Caroline? |
| `Comfort Colors T-shirt - Navy Blue` | How did the Comfort Colors T-shirt turn out, Derek? |
| `Shirt with photo` | How did the Shirt with photo turn out, Peter? |

Nobody thinks of their own order that way; it read like a picking list. Reverted on the owner's call, and `reviewItemLabel()` plus its parsing tests are **deleted** rather than left behind — dead formatting code invites someone to wire it back up.

The general lesson, worth keeping: a field is only worth personalising with when it holds something a person would actually say.

## Not done, deliberately

**The six who already got the old version have not been re-asked.** A second request days after the first reads as pestering — a judgement call about customers, not a technical one. One-line backfill if wanted.

**No incentive or discount for leaving a review.** Offering value in exchange conflicts with Google's review policy and the FTC Consumer Reviews Rule. If you want one, the safe shape is an offer to *everyone who buys*, independent of whether they review.

## Tests

`tests/review-email-copy.test.js` holds the voice, the single ask, the preview line, the P.S., and that the product name stays out. Suite: **143 passing**.