### PR TITLE
Offer the Google link at every rating, not just 4 and 5

### DIFF
--- a/server.js
+++ b/server.js
@@ -7245,8 +7245,9 @@ app.get('/review/:token', async (req, res) => {
       return res.send(quotePage('Thank you', `
         <div class="card"><h1>Thanks — we have your review</h1>
         <p class="muted" style="margin-top:8px">You rated us ${STAR(r.rating || 0)}. We appreciate you taking the time.</p>
-        ${(r.rating >= 4 && GOOGLE_REVIEW_URL) ? `<p style="margin-top:14px">
-          <a class="btn" href="${escEmail(GOOGLE_REVIEW_URL)}" target="_blank" rel="noopener">Share it on Google →</a></p>` : ''}
+        ${GOOGLE_REVIEW_URL ? `<p style="margin-top:14px">
+          <a class="btn${r.rating >= 4 ? '' : ' btn-ghost'}" href="${escEmail(GOOGLE_REVIEW_URL)}"
+             target="_blank" rel="noopener">Share it on Google →</a></p>` : ''}
         </div>`));
     }
 
@@ -7433,7 +7434,9 @@ app.post('/review/:token', orderRateLimit, verifyTurnstile, async (req, res) => 
             `<img src="${escEmail(u.replace('/upload/', '/upload/c_fill,w_260,h_260,q_auto,f_auto/'))}"
                   width="130" style="border-radius:8px;margin:0 6px 6px 0">`).join('')}</p>` : ''}
           ${rating <= 3 ? `<p style="background:#fdecea;padding:12px;border-radius:8px;color:#b71c1c">
-            Not published. Worth reaching out before this becomes a public review elsewhere.</p>` : `
+            <b>Reach out today.</b> Nothing is published on jtees.net without your approval, but they were
+            offered the Google link like everyone else — so this may go public. You have heard it first,
+            which is the whole point of getting this email.</p>` : `
             <p><a href="${PUBLIC_BASE_URL}/admin/reviews">Approve it for the website →</a></p>`}
         </div>`,
       }).catch(e => console.error('review alert failed:', e.message));
@@ -7445,16 +7448,34 @@ app.post('/review/:token', orderRateLimit, verifyTurnstile, async (req, res) => 
         <p class="muted" style="margin-top:8px">${extra}</p>
       </div>`);
 
-    if (rating >= 4 && GOOGLE_REVIEW_URL) {
+    /* Everyone is offered Google, whatever they rated.
+       This used to appear only at 4+, which is review gating: Google's review
+       policy forbids selectively soliciting positive reviews, and the FTC
+       Consumer Reviews Rule (in force 2024-10-21) treats it as a deceptive
+       practice. It also did not work as intended — an unhappy customer who
+       wants to post publicly simply goes to Google directly, so the gate
+       suppressed nothing and only cost the shop the chance to respond first.
+
+       What DOES help is already happening above: the alert lands with June the
+       moment the rating is submitted, before anything is posted anywhere. The
+       warmth of the wording differs by rating, which is honest; the path is
+       offered either way, which is the part that matters. */
+    if (GOOGLE_REVIEW_URL) {
+      const happy = rating >= 4;
       return res.send(quotePage('Thank you', `
         <div class="card" style="text-align:center">
           <div style="font-size:34px;color:#F4A623">${STAR(rating)}</div>
-          <h1 style="margin-top:8px">Thank you!</h1>
-          <p class="muted" style="margin:8px 0 16px">Would you mind sharing that on Google? It genuinely helps
-            people find a small shop like ours.</p>
-          <a class="btn" href="${escEmail(GOOGLE_REVIEW_URL)}" target="_blank" rel="noopener"
-             style="width:100%">Post it on Google →</a>
-          <p class="muted" style="margin-top:12px;font-size:12px">Takes about 20 seconds.</p>
+          <h1 style="margin-top:8px">${happy ? 'Thank you!' : 'Thank you for telling us'}</h1>
+          <p class="muted" style="margin:8px 0 16px">${happy
+            ? 'Would you mind sharing that on Google? It genuinely helps people find a small shop like ours.'
+            : `${SHOP_SIGNER} will be in touch personally to put this right — and if you would like to post
+               publicly as well, the link is here.`}</p>
+          <a class="btn${happy ? '' : ' btn-ghost'}" href="${escEmail(GOOGLE_REVIEW_URL)}"
+             target="_blank" rel="noopener" style="width:100%">${
+            happy ? 'Post it on Google →' : 'Post a review on Google →'}</a>
+          <p class="muted" style="margin-top:12px;font-size:12px">${happy
+            ? 'Takes about 20 seconds.'
+            : `Or reply to our email, or text ${SHOP_PHONE}.`}</p>
         </div>`));
     }
     res.send(thanks(rating >= 4

--- a/tests/review-google-ungated.test.js
+++ b/tests/review-google-ungated.test.js
@@ -1,0 +1,112 @@
+/* Regression tests for who is offered the Google review link (server.js).
+ *
+ * Run: node --test tests/*.test.js
+ *
+ * The link used to appear only at 4-5 stars. That is review gating:
+ *
+ *   - Google's review policy forbids selectively soliciting positive reviews.
+ *   - The FTC Consumer Reviews Rule, in force 2024-10-21, treats it as a
+ *     deceptive practice. Fashion Nova paid $4.2M for hiding sub-4-star reviews.
+ *
+ * It also did not achieve anything. An unhappy customer who wants to post
+ * publicly goes to Google directly; the gate suppressed no reviews and only
+ * cost the shop the chance to hear about a problem first.
+ *
+ * What actually protects the shop is the alert, which fires on EVERY rating the
+ * moment it is submitted — before anything is posted anywhere. That is the
+ * property worth defending, and the reason a low rating must never be quietly
+ * swallowed to avoid an awkward email.
+ *
+ * These tests exist because the gate is an easy thing to reintroduce: it looks
+ * like a kindness to the shop right up until it is a penalty.
+ */
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const SERVER = path.join(__dirname, '..', 'server.js');
+const src = fs.readFileSync(SERVER, 'utf8');
+
+function extractFn(anchor) {
+  const start = src.indexOf(anchor);
+  assert.notStrictEqual(start, -1, `\`${anchor}\` not found in server.js`);
+  let i = src.indexOf('(', start);
+  let parens = 0;
+  for (; i < src.length; i++) {
+    if (src[i] === '(') parens++;
+    else if (src[i] === ')' && --parens === 0) { i++; break; }
+  }
+  const open = src.indexOf('{', i);
+  let depth = 0;
+  for (let j = open; j < src.length; j++) {
+    if (src[j] === '{') depth++;
+    else if (src[j] === '}' && --depth === 0) return src.slice(start, j + 1);
+  }
+  throw new Error(`unterminated function reading \`${anchor}\``);
+}
+
+const SUBMIT = extractFn("app.post('/review/:token'");
+const LANDING = extractFn("app.get('/review/:token'");
+
+/* ── the gate must not come back ─────────────────────────────────────────── */
+
+test('the Google link is not conditioned on the rating', () => {
+  assert.doesNotMatch(src, /rating >= 4 && GOOGLE_REVIEW_URL/,
+    'showing the link only to happy customers is review gating — Google policy and FTC rule');
+  assert.doesNotMatch(src, /r\.rating >= 4 && GOOGLE_REVIEW_URL/,
+    'the already-submitted page gates it too if this comes back');
+});
+
+test('the link is gated only on being configured at all', () => {
+  assert.match(SUBMIT, /if \(GOOGLE_REVIEW_URL\) \{/,
+    'the only legitimate condition is whether a URL exists to send them to');
+});
+
+test('a 1-star customer is offered the same link', () => {
+  const block = SUBMIT.slice(SUBMIT.indexOf('if (GOOGLE_REVIEW_URL)'));
+  assert.match(block, /Post a review on Google/,
+    'the unhappy path must reach Google too, not dead-end on an apology');
+  assert.match(block, /const happy = rating >= 4;/,
+    'rating may change the WORDING, never whether the path is offered');
+});
+
+/* ── the alert is what actually protects the shop ────────────────────────── */
+
+test('every rating alerts the shop, not just the good ones', () => {
+  const alert = SUBMIT.slice(SUBMIT.indexOf('sendEmail({'));
+  assert.match(alert, /rating >= 4 \? '⭐' : '⚠️'/,
+    'the alert is sent for all ratings and only its subject marker differs');
+  assert.doesNotMatch(SUBMIT.slice(0, SUBMIT.indexOf('sendEmail({')), /if \(rating >= 4\)[\s\S]{0,80}sendEmail/,
+    'the alert must never be conditioned on a good rating');
+});
+
+test('the alert reaches the shop, and replies reach the customer', () => {
+  const alert = SUBMIT.slice(SUBMIT.indexOf('sendEmail({'));
+  assert.match(alert, /to: SHOP_EMAIL/);
+  assert.match(alert, /replyTo: r\.email/,
+    'following up is the point; June must be able to just hit reply');
+});
+
+test('a low rating tells June it may go public', () => {
+  assert.match(SUBMIT, /Reach out today/,
+    'the old copy said "not published", which stopped being true when the gate came off');
+  assert.match(SUBMIT, /offered the Google link like everyone else/,
+    'June needs to know the customer can post, so the follow-up is urgent rather than optional');
+});
+
+/* ── publication is still June's decision ────────────────────────────────── */
+
+test('nothing is published on the shop site without approval', () => {
+  const approved = extractFn('async function approvedReviews(');
+  assert.match(approved, /approved = TRUE/,
+    'the Google decision is the customer\'s; what appears on jtees.net stays June\'s');
+  assert.doesNotMatch(approved, /rating >= 4|rating > 3/,
+    'approval is a judgement, not a rating threshold — a 3-star review may be worth publishing');
+});
+
+test('the landing page still pre-selects the star that was clicked', () => {
+  assert.match(LANDING, /parseInt\(req\.query\.r, 10\)/,
+    'one-tap rating is the mechanism; losing it would drop the response rate');
+});


### PR DESCRIPTION
## Why

The "Post it on Google" button appeared only at 4–5 stars. That is **review gating**:

- Google's review policy forbids selectively soliciting positive reviews.
- The FTC Consumer Reviews Rule, in force **2024-10-21**, treats it as a deceptive practice — civil penalties up to $51,744 per violation. Fashion Nova paid $4.2M for hiding sub-4-star reviews.

I raised this earlier and the decision at the time was to keep it. The owner has now reversed that, which also removes the exposure.

Worth saying plainly: the gate was never doing the job it looked like it was doing. An unhappy customer who wants to post publicly goes to Google directly — the gate suppressed no reviews at all. What it actually cost was nothing, and what protects the shop is something else entirely.

## What protects the shop, and already did

The alert to June fires on **every** rating, the moment it is submitted, before anything is posted anywhere. `replyTo` is set to the customer, so following up is one keystroke. That is the real mechanism, and it is untouched.

## What changed

- The link is now conditioned only on `GOOGLE_REVIEW_URL` existing, at both the post-submit page and the already-submitted page.
- **Wording still differs by rating, the path does not.** 4–5 stars gets *"Would you mind sharing that on Google?"*; 1–3 gets *"June will be in touch personally to put this right — and if you would like to post publicly as well, the link is here"*, plus the reply/text route. Being warmer to a happy customer is honest; withholding the path is not.
- The low-rating alert copy said *"Not published. Worth reaching out before this becomes a public review elsewhere."* That stopped being true the moment the gate came off. It now reads *"Reach out today… they were offered the Google link like everyone else, so this may go public. You have heard it first, which is the whole point of getting this email."*

## Unchanged

Publication on jtees.net is still June's approval at any rating — `approved` defaults `FALSE` and `approvedReviews()` filters on approval with **no** rating condition, so a 3-star review can still be published if she wants it. The customer decides about Google; June decides about her own site.

## Tests

8 in `tests/review-google-ungated.test.js`, written to make the gate hard to reintroduce — it looks like a kindness to the shop right up until it is a penalty. Suite: **143 passing** (this branch is off main; PR #43 is not merged into it).