### PR TITLE
Bill screens once per order, not inside the per-piece rate

### DIFF
--- a/ACCEPTED.md
+++ b/ACCEPTED.md
@@ -1,0 +1,20 @@
+# Accepted gate findings
+
+Rules the radar gate flags that this repository has consciously accepted, each
+with the reason on record. An acceptance is not a dismissal — the finding stays
+on the gate's report, ranked last, so it is still read on every pull request.
+
+Accept a rule here only when the flag is genuinely wrong for this codebase.
+Anything that is merely inconvenient belongs in a fix, not in this file.
+
+- `shell_exec`: The supplier sync spawns the S&S importer as a child process
+  from inside an HTTP handler (`server.js`, `runSupplierSync`). Every argument
+  is built locally and none of it can carry text that arrived over HTTP: the
+  executable is `process.execPath`, the script is `path.join(__dirname, 'tools',
+  'ssa-sync.js')`, and the only other argument is the literal `--apply`. The
+  request body is never read into the argv, and the child gets its credentials
+  through the environment rather than the command line, so there is no string
+  for a caller to escape out of. The rule is right in general — it exists
+  because an HTTP handler is exactly where untrusted text meets a shell — it
+  simply does not describe this call site. Re-examine this acceptance if that
+  spawn ever gains an argument derived from a request.

--- a/server.js
+++ b/server.js
@@ -3252,9 +3252,17 @@ function digitizingOptions(catalog) {
  * embroidery capacity constraint, no digitizing on DTF.
  */
 const ADDONS = [
-  { code: 'underbase', label: 'Underbase (dark garments)', appliesTo: SCREEN_METHOD_RE,
-    kind: 'once', rate: 25, auto: 'dark',
-    note: 'A 1-colour print on a dark garment needs two screens: the white underbase, then the colour.' },
+  /* Screens. Not optional and not a tick box — every screen-print job burns
+     them, so this is attached by the METHOD, not by someone remembering.
+
+     It replaces an `underbase` add-on that charged a flat $25 once however many
+     colours or locations the job had. Invoice #16899 (62 shirts, white on
+     black, two locations) is four screens: that add-on recovered $25 against
+     $80 of screens actually bought. The count now comes from screenCount() in
+     quotePricingSource(), so the fee and the screens ordered are one number. */
+  { code: 'screens', label: 'Screens', appliesTo: SCREEN_METHOD_RE,
+    kind: 'per_screen', rate: 35, auto: 'method',
+    note: 'A screen is burned once and then runs the whole job, so it is billed once — not per shirt. (Colours + 1 on a dark garment) x locations, at $35 each.' },
   { code: 'specialty_ink', label: 'Specialty ink (metallic, glitter, waterbase, discharge)',
     appliesTo: SCREEN_METHOD_RE, kind: 'per_piece', rate: 1.50 },
   { code: 'unbagging', label: 'Unbagging', appliesTo: SCREEN_METHOD_RE,
@@ -3284,6 +3292,15 @@ const RUSH_CAVEAT = 'Rush is subject to availability and is confirmed before you
    March and quoting every job three days slow. */
 const HOLIDAY_MODE = String(process.env.JT_HOLIDAY_MODE || '') === '1';
 const HOLIDAY_EXTRA_DAYS = 3;
+
+/* Screens bill separately ONLY once the per-piece tables have had the amortised
+   screen charge taken out of them — `tools/reprice-anchorfish-2026.js --apply`.
+   Until that has run, the live `printings` tables still carry screens inside the
+   per-piece rate, and charging the fee as well bills every screen twice.
+   The two changes cannot be made atomic: one is a deploy, the other is a write
+   to the Lumise database. So this is the switch that joins them, and it stays
+   off until the tables are repriced. Read once, used by both surfaces. */
+const SCREEN_FEES_LIVE = String(process.env.JT_SCREEN_FEES || '') === '1';
 
 /** The add-ons available for a method, in the order they should be offered. */
 function addonsFor(methodTitle) {
@@ -3405,17 +3422,42 @@ function quotePricingSource() {
         return parseInt((String(method.title || '').match(/(\\d+)\\s*Colou?r/i) || [0, 1])[1], 10) || 1;
       }
 
+      /* How many screens a job actually burns.
+
+         Written once, here, for the same reason colourCount() is: this number
+         is both what the customer is charged for and what the shop orders from
+         Anchorfish. Two copies of it is two chances for the fee on screen to
+         differ from the screens bought.
+
+         A screen is per COLOUR and per LOCATION — invoice #16899 is 4 screens
+         for a 2-colour job across 2 locations. A dark garment adds one more per
+         location for the white underbase; the same invoice's "Ink: Base, White"
+         line is what proves the underbase is its own screen rather than part of
+         the first colour. */
+      function screenCount(colours, locations, dark) {
+        var c = parseInt(colours, 10); if (!(c > 0)) c = 1;
+        var l = parseInt(locations, 10); if (!(l > 0)) l = 1;
+        return (c + (dark ? 1 : 0)) * l;
+      }
+
       /* One add-on's charge. The whole point of the table is that this
          switch exists exactly once. */
-      function addonAmount(a, qty, colours, decorationSubtotal) {
+      function addonAmount(a, qty, colours, decorationSubtotal, screens) {
         var n = parseFloat(a.rate) || 0;
         var q = parseInt(qty, 10) || 0;
         var c = parseInt(colours, 10) || 1;
+        /* Screens fall back to one per colour — one location, light garment —
+           rather than to zero. A caller that forgets to pass the count then
+           under-bills a two-sided dark job, which someone notices; a zero would
+           make the screens free and silently, which is the failure this file
+           keeps having to design against. */
+        var s = parseInt(screens, 10); if (!(s > 0)) s = c;
         switch (a.kind) {
           case 'once':                  return n;
           case 'per_order':             return n;
           case 'per_piece':             return n * q;
           case 'per_piece_per_colour':  return n * q * c;
+          case 'per_screen':            return n * s;
           case 'percent_of_decoration': return (decorationSubtotal || 0) * (n / 100);
           default:                      return 0;
         }
@@ -3513,12 +3555,24 @@ function quotePricingSource() {
         var unit = hasOverride ? parseFloat(o.unitOverride) : listUnit;
 
         var decorationSubtotal = decoration * qty;
+
+        /* Locations comes from the same \`stage\` the decoration was priced off,
+           so the screens billed and the passes charged can never disagree —
+           'both' is two locations by the same definition that doubled the
+           table above. */
+        var locations = (o.stage === 'both') ? 2 : 1;
+        var screens = screenCount(colours, locations, !!o.dark);
+
         var addonLines = [], addonTotal = 0;
         for (var k = 0; k < (o.addons || []).length; k++) {
           var a = o.addons[k];
-          var amt = Math.round(addonAmount(a, qty, colours, decorationSubtotal) * 100) / 100;
+          var amt = Math.round(addonAmount(a, qty, colours, decorationSubtotal, screens) * 100) / 100;
           if (!amt) continue;
-          addonLines.push({ code: a.code, label: a.label, kind: a.kind, rate: a.rate, total: amt });
+          /* \`count\` rides along so a surface can print "4 x $35" without
+             dividing the total back out — a division that would quietly lie the
+             moment a rate changed between quoting and rendering. */
+          addonLines.push({ code: a.code, label: a.label, kind: a.kind, rate: a.rate,
+                            count: (a.kind === 'per_screen' ? screens : null), total: amt });
           addonTotal += amt;
         }
 
@@ -3533,6 +3587,10 @@ function quotePricingSource() {
           blank: blank, decoration: decoration, sizeUpcharge: upcharge,
           addonLines: addonLines, addonTotal: Math.round(addonTotal * 100) / 100,
           unit: unit, listUnit: listUnit, manual: hasOverride,
+          /* Returned so a surface can SHOW the count it is charging for —
+             "4 screens x $35" is checkable by the customer, "$140 setup" is
+             not — without re-deriving it and drifting. */
+          colours: colours, locations: locations, screens: screens,
           lineTotal: lineTotal, listTotal: listTotal
         };
       }
@@ -3541,11 +3599,11 @@ function quotePricingSource() {
 
 /* The same source, executed here, so Node prices a line with the identical
    code the browser runs. */
-const { priceLine, addonAmount, colourCount } = (function () {
+const { priceLine, addonAmount, colourCount, screenCount } = (function () {
   const sandbox = {};
   vm.runInNewContext(quotePricingSource() +
     '\nthis.priceLine = priceLine; this.addonAmount = addonAmount;' +
-    '\nthis.colourCount = colourCount;', sandbox);
+    '\nthis.colourCount = colourCount; this.screenCount = screenCount;', sandbox);
   return sandbox;
 })();
 
@@ -3599,6 +3657,47 @@ function quoteSummary(items) {
   if (!parts.length) return 'your order';
   if (parts.length <= 2) return parts.join(' + ');
   return `${parts[0]} + ${parts.length - 1} more`;
+}
+
+/* The chargeable extras on a line, written so the customer can check them.
+ *
+ * `unit_price` is deliberately the GARMENT-AND-PRINT price with add-ons taken
+ * out (see the save route), so a line carrying any add-on does not foot from
+ * qty x unit alone. Until now only digitizing was ever printed, through its own
+ * `setup_fee` column — so specialty ink, unbagging, puff and the jumbo hoop all
+ * arrived as an unexplained difference between the unit price and the line
+ * total, and screens would have joined them at up to $140 a line.
+ *
+ * A screen fee especially has to show its working: "4 screens x $35" is
+ * something a customer can agree with, "$140 setup" is something they query.
+ */
+function addonNotes(item) {
+  const css = 'class="muted" style="font-size:13px;margin-top:3px"';
+  const rows = (Array.isArray(item.addons) ? item.addons : [])
+    .filter((a) => a && Number(a.total) > 0);
+
+  /* Quotes saved before add-ons were itemised carry digitizing in its own two
+     columns and have no `addons` array to read. */
+  if (!rows.length) {
+    return Number(item.setup_fee) > 0
+      ? `<div ${css}>+ ${escEmail(item.setup_label || 'Digitizing')} — ${money(item.setup_fee)} one time</div>`
+      : '';
+  }
+
+  return rows.map((a) => {
+    const n = Number(a.count) || 0;
+    const detail =
+      a.kind === 'per_screen' && n > 0
+        ? `${n} &times; ${money(a.rate)} = ${money(a.total)}, one time`
+      : a.kind === 'per_piece'
+        ? `${money(a.rate)} each = ${money(a.total)}`
+      : a.kind === 'per_piece_per_colour'
+        ? `${money(a.rate)} per colour each = ${money(a.total)}`
+      : a.kind === 'percent_of_decoration'
+        ? `+${Number(a.rate)}% = ${money(a.total)}`
+      : `${money(a.total)} one time`;
+    return `<div ${css}>+ ${escEmail(a.label)} — ${detail}</div>`;
+  }).join('');
 }
 
 function quoteLink(code) { return `${PUBLIC_BASE_URL}/q/${code}`; }
@@ -4201,6 +4300,7 @@ ${quotePricingSource()}
       })))};
       var RUSH = ${JSON.stringify(RUSH_OPTIONS)};
       var HOLIDAY = ${HOLIDAY_MODE ? 'true' : 'false'};
+      var SCREEN_FEES_LIVE = ${SCREEN_FEES_LIVE ? 'true' : 'false'};
 
       /** Which add-ons apply to a method, mirroring addonsFor() on the server. */
       function addonsForTitle(title){
@@ -4348,9 +4448,9 @@ ${quotePricingSource()}
           if (aoBox && aoBox.dataset.for !== mkey) {
             aoBox.dataset.for = mkey;
             var avail = addonsForTitle(meth && meth.title);
-            /* The underbase is applied by the dark-garment box, so it is never
-               offered as something to tick separately. */
-            avail = avail.filter(function(a){ return a.auto !== 'dark'; });
+            /* Anything the method carries automatically — screens — is never
+               offered as something to tick, because it is not a decision. */
+            avail = avail.filter(function(a){ return !a.auto; });
             aoBox.innerHTML = avail.length
               ? '<div class="muted" style="font-size:11px;text-transform:uppercase;letter-spacing:.05em;margin-bottom:4px">Upgrades</div>' +
                 avail.map(function(a){
@@ -4368,7 +4468,10 @@ ${quotePricingSource()}
           }
 
           /* Collect the add-ons this line has switched on, plus digitizing and
-             the automatic underbase, into one list the engine can price. */
+             anything the method carries automatically, into one list the engine
+             can price. Mirrors the save route — if these two ever disagree the
+             preview and the saved quote disagree, which is the whole reason the
+             pricing rule itself lives in one string. */
           var addons = [];
           if (isEmb && su && su.value) {
             var dm = DIGI.find(function(d){ return String(d.id) === su.value; });
@@ -4381,13 +4484,16 @@ ${quotePricingSource()}
             var a = ADDONS.find(function(x){ return x.code === cb.dataset.code; });
             if (a) addons.push(a);
           });
-          /* The underbase is not optional on a dark garment — a 1-colour print
-             needs the white base under it — so it is added by the colour, not
-             by a tick box someone has to remember. */
-          if (isDark && meth && /screen\\s*print/i.test(meth.title)) {
-            var ub = ADDONS.find(function(x){ return x.code === 'underbase'; });
-            if (ub && !addons.some(function(x){ return x.code === 'underbase'; })) addons.push(ub);
-          }
+          /* Screens are not a choice — a screen-print job burns them whether or
+             not anyone ticked anything, so they come from the method. The dark
+             garment does not add a CHARGE here, it adds a SCREEN: it is passed
+             to priceLine below and screenCount() decides how many. */
+          addonsForTitle(meth && meth.title).forEach(function(a){
+            if (a.auto !== 'method') return;
+            if (a.code === 'screens' && !SCREEN_FEES_LIVE) return;
+            if (addons.some(function(x){ return x.code === a.code; })) return;
+            addons.push(a);
+          });
 
           var stage = L.querySelector('.loc') ? L.querySelector('.loc').value : '';
           var bpEl = L.querySelector('.bp');
@@ -4395,6 +4501,7 @@ ${quotePricingSource()}
             product: prod, method: meth, qty: qty, sizeMix: sizeQty ? mix : null,
             colours: colEl ? colEl.value : '',
             stage: stage, addons: addons, blankTiers: BLANK_TIERS,
+            dark: isDark,
             blankOverride: bpEl ? bpEl.value : '',
             unitOverride: u.value
           });
@@ -4888,16 +4995,18 @@ app.post(['/api/quotes', '/api/quotes/:code'], requireAdmin, async (req, res) =>
         if (d) lineAddons.push({ code: 'digitizing', label: d.title, kind: 'once', rate: d.price });
       }
       for (const a of addonsFor(methodTitle)) {
-        if (a.auto === 'dark') continue;   // applied by the garment colour, below
+        if (a.auto) continue;              // attached by the method itself, below
         if (String(one(b[`addon_${a.code}${i}`]) || '') !== '1') continue;
         lineAddons.push({ code: a.code, label: a.label, kind: a.kind, rate: a.rate });
       }
-      /* A 1-colour print on a dark garment needs two screens — the white
-         underbase, then the colour. Applied by the colour rather than by a tick
-         box, because it is not optional and it is easy to forget. */
-      if (garmentDark && isScreen) {
-        const ub = ADDONS.find((a) => a.code === 'underbase');
-        if (ub) lineAddons.push({ code: ub.code, label: ub.label, kind: ub.kind, rate: ub.rate });
+      /* Screens are not a choice — a screen-print job burns them whether or not
+         anyone ticked a box, and the garment colour decides how many. Note the
+         rate comes from ADDONS here and never from the posted body: the client
+         says only WHICH line and how dark the garment is, never what it costs. */
+      for (const a of addonsFor(methodTitle)) {
+        if (a.auto !== 'method') continue;
+        if (a.code === 'screens' && !SCREEN_FEES_LIVE) continue;
+        lineAddons.push({ code: a.code, label: a.label, kind: a.kind, rate: a.rate });
       }
 
       /* Second print location: the posted stage must be one this method really
@@ -4926,6 +5035,10 @@ app.post(['/api/quotes', '/api/quotes/:code'], requireAdmin, async (req, res) =>
       const priced = priceLine({
         product: prod, method, qty: q, sizeMix: mix, colours,
         stage, addons: lineAddons, blankTiers: BLANK_TIERS,
+        /* The garment colour is a pricing INPUT, not a charge: it decides how
+           many screens screenCount() asks for. Omit it and a dark job silently
+           under-bills by one screen per location. */
+        dark: garmentDark,
         blankOverride, unitOverride: rawUnit,
       });
 
@@ -5180,8 +5293,7 @@ app.get('/q/:code', async (req, res) => {
         <td>
           ${escEmail(i.description)}
           ${i.details ? `<div class="muted" style="font-size:13px;margin-top:3px">${escEmail(i.details)}</div>` : ''}
-          ${Number(i.setup_fee) > 0 ? `<div class="muted" style="font-size:13px;margin-top:3px">
-             + ${escEmail(i.setup_label || 'Digitizing')} — ${money(i.setup_fee)} one time</div>` : ''}
+          ${addonNotes(i)}
           ${gallery}
         </td>
         <td class="num">${i.qty}</td>

--- a/tests/quote-pricing-engine.test.js
+++ b/tests/quote-pricing-engine.test.js
@@ -120,7 +120,7 @@ test('an override suppresses size upcharges but never the add-ons', () => {
      it. An add-on is a separate cost the shop still incurs. */
   const r = priceLine({ product: GILDAN, method: SCREEN1, qty: 50, unitOverride: 12,
     sizeMix: { M: 46, '2XL': 4 }, blankTiers: TIERS,
-    addons: [{ code: 'underbase', label: 'Underbase', kind: 'once', rate: 25 }] });
+    addons: [{ code: 'unbagging', label: 'Unbagging', kind: 'per_piece', rate: 0.50 }] });
   assert.strictEqual(r.sizeUpcharge, 0);
   assert.strictEqual(r.addonTotal, 25);
   assert.strictEqual(r.lineTotal, 625);
@@ -149,13 +149,17 @@ test('a "once" add-on is charged once, whatever the quantity', () => {
 });
 
 test('each add-on kind scales the way it says it does', () => {
-  const at = (kind, rate, qty, colours) =>
-    addonAmount({ kind, rate }, qty, colours, 1000);
+  const at = (kind, rate, qty, colours, screens) =>
+    addonAmount({ kind, rate }, qty, colours, 1000, screens);
   assert.strictEqual(at('once', 25, 50, 1), 25);
   assert.strictEqual(at('per_order', 15, 50, 1), 15);
   assert.strictEqual(at('per_piece', 0.5, 50, 1), 25);
   assert.strictEqual(at('per_piece_per_colour', 0.5, 50, 4), 100);
   assert.strictEqual(at('percent_of_decoration', 50, 50, 1), 500);
+  /* Screens are per screen and per ORDER — six screens is six screens whether
+     the run is 50 shirts or 5,000. See tests/screen-fees.test.js. */
+  assert.strictEqual(at('per_screen', 35, 50, 3, 6), 210);
+  assert.strictEqual(at('per_screen', 35, 5000, 3, 6), 210);
 });
 
 test('an unknown add-on kind charges nothing rather than guessing', () => {

--- a/tests/screen-fees.test.js
+++ b/tests/screen-fees.test.js
@@ -1,0 +1,225 @@
+/* Screens are bought once, so they are billed once.
+ *
+ * WHAT WENT WRONG
+ * ---------------
+ * A screen is burned once and then runs the whole job, but the price tables
+ * amortised it into the per-piece rate: `p[c-1] * mk + (25 * colours) / band`.
+ * Three things follow from that, and all three are wrong.
+ *
+ *   - A 50-piece job paid the whole setup and a 500-piece job paid a tenth of
+ *     it per shirt, so small runs subsidised large ones inside a single rate
+ *     card nobody could see into.
+ *   - The setup cost was invisible to the customer. "$8.45 each" cannot be
+ *     checked; "4 screens x $35" can.
+ *   - The old `underbase` add-on charged a FLAT $25 once, no matter how many
+ *     colours or locations. Invoice #16899 — 62 shirts, white on black, two
+ *     locations — is four screens. At $25 flat the shop recovered $25 against
+ *     four screens it had actually paid $80 for.
+ *
+ * THE RULE
+ * --------
+ * $35 per screen, charged ONCE per order, where
+ *
+ *     screens = (design colours + 1 if the garment is dark) x locations
+ *
+ * The "+1 on darks" is not a surcharge. Invoice #16899 lists "Ink: Base,
+ * White", which is the white underbase getting its own screen — so a 1-colour
+ * design on black is physically a 2-screen job per location.
+ *
+ * WHAT THESE PIN
+ * --------------
+ * 1. screenCount()'s arithmetic, including the junk-input floor.
+ * 2. That `per_screen` bills once and never scales with quantity — the exact
+ *    bug class that made a $30 digitizing fee bill $1,500 on a 50-piece line.
+ * 3. That the per-piece table no longer carries a screen charge, so the two
+ *    halves cannot both bill it.
+ *
+ * Run: node tests/screen-fees.test.js
+ */
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const ROOT = path.join(__dirname, '..');
+const src = fs.readFileSync(path.join(ROOT, 'server.js'), 'utf8');
+
+/** Lift a top-level `function name(...) {...}` out of server.js by brace depth. */
+function lift(name) {
+  const start = src.indexOf(`function ${name}(`);
+  assert.notStrictEqual(start, -1, `function ${name} not found in server.js`);
+  let depth = 0;
+  for (let i = src.indexOf('{', start); i < src.length; i++) {
+    if (src[i] === '{') depth++;
+    else if (src[i] === '}' && --depth === 0) return src.slice(start, i + 1);
+  }
+  throw new Error(`unbalanced braces reading ${name} from server.js`);
+}
+
+/* runInThisContext, not runInNewContext: values built in a fresh realm carry
+   that realm's Array.prototype and deepStrictEqual compares prototypes, which
+   fails on arrays that are character-for-character identical. The engine has no
+   free variables, so there are no globals to fake. */
+const text = vm.runInThisContext(lift('quotePricingSource') + '\nquotePricingSource()');
+const { priceLine, addonAmount, screenCount } =
+  vm.runInThisContext(text + '\n({ priceLine, addonAmount, screenCount })');
+
+const SCREEN_FEE = 35;
+const screensAddon = { code: 'screens', label: 'Screens', kind: 'per_screen', rate: SCREEN_FEE };
+
+/* Method #22 as the catalogue holds it: one `color` table, bands as CEILINGS.
+   Rates are print-only — the agreed table with screens taken out. */
+const SCREEN = {
+  id: 22, title: 'Screen Printing', type: 'color', min_order_qty: 50,
+  positions: { front: [
+    { min_qty:  99, price: 4.25, colors: { '1-color':4.25, '2-color':5.30, '3-color':6.40, '7-color':10.80, 'full-color':10.80 } },
+    { min_qty: 249, price: 3.80, colors: { '1-color':3.80, '2-color':4.75, '3-color':5.85, '7-color':10.15, 'full-color':10.15 } },
+    { min_qty: 499, price: 3.35, colors: { '1-color':3.35, '2-color':4.20, '3-color':5.25, '7-color': 9.50, 'full-color': 9.50 } },
+  ] },
+};
+const BLANK = { id: 12, price: 0, sizes: [{ size: 'M', upcharge: 0 }] };
+
+const line = (over) => priceLine(Object.assign({
+  product: BLANK, method: SCREEN, qty: 100, colours: 1, stage: 'front',
+  addons: [screensAddon], blankTiers: [],
+}, over));
+
+/* ── screenCount ─────────────────────────────────────────────────────────── */
+
+test('screens are per colour and per location', () => {
+  assert.strictEqual(screenCount(1, 1, false), 1);
+  assert.strictEqual(screenCount(3, 1, false), 3);
+  assert.strictEqual(screenCount(3, 2, false), 6, 'a second location is a second set of screens');
+  assert.strictEqual(screenCount(7, 2, false), 14);
+});
+
+test('a dark garment adds one underbase screen PER LOCATION', () => {
+  assert.strictEqual(screenCount(1, 1, true), 2, '1 colour on black is two screens');
+  assert.strictEqual(screenCount(3, 1, true), 4);
+  assert.strictEqual(screenCount(3, 2, true), 8, 'the underbase is burned for each location');
+});
+
+test('invoice #16899: white on black, two locations, is four screens', () => {
+  /* 62 shirts. Anchorfish charged 4 screens at $20 = $80 of cost. The retired
+     flat-$25 underbase add-on recovered $25 of that. */
+  assert.strictEqual(screenCount(1, 2, true), 4);
+  assert.strictEqual(screenCount(1, 2, true) * SCREEN_FEE, 140);
+});
+
+test('junk colour or location counts floor at one, never zero', () => {
+  /* A zero would make the screens free silently, which is the failure mode this
+     codebase keeps having to design against. */
+  for (const bad of [0, -3, null, undefined, '', 'abc', NaN]) {
+    assert.ok(screenCount(bad, 1, false) >= 1, `colours=${String(bad)} must not zero the fee`);
+    assert.ok(screenCount(1, bad, false) >= 1, `locations=${String(bad)} must not zero the fee`);
+  }
+  assert.strictEqual(screenCount(-3, -3, false), 1);
+});
+
+/* ── addonAmount ─────────────────────────────────────────────────────────── */
+
+test('per_screen bills rate x screens, and ignores quantity', () => {
+  assert.strictEqual(addonAmount(screensAddon, 50, 3, 0, 6), 210);
+  assert.strictEqual(addonAmount(screensAddon, 5000, 3, 0, 6), 210, 'quantity must not enter it');
+});
+
+test('a missing screen count falls back to one per colour, not to zero', () => {
+  assert.strictEqual(addonAmount(screensAddon, 100, 4, 0, undefined), 4 * SCREEN_FEE);
+  assert.strictEqual(addonAmount(screensAddon, 100, 4, 0, 0), 4 * SCREEN_FEE);
+});
+
+/* ── through priceLine ───────────────────────────────────────────────────── */
+
+test('the screen fee is charged ONCE, not per piece', () => {
+  /* The digitizing bug in miniature: a one-time fee multiplied by a 50-piece
+     line billed $1,500 instead of $30. */
+  const small = line({ qty: 50, colours: 3 });
+  const big   = line({ qty: 500, colours: 3 });
+  assert.strictEqual(small.addonTotal, 3 * SCREEN_FEE);
+  assert.strictEqual(big.addonTotal, 3 * SCREEN_FEE, 'ten times the shirts, the same screens');
+});
+
+test('priceLine derives locations from the same stage it priced the print off', () => {
+  const one  = line({ colours: 2, stage: 'front' });
+  const both = line({ colours: 2, stage: 'both' });
+  assert.strictEqual(one.locations, 1);
+  assert.strictEqual(both.locations, 2);
+  assert.strictEqual(both.screens, 4);
+  assert.strictEqual(both.addonTotal, 4 * SCREEN_FEE);
+  /* And the print itself doubled, because a second screen-print location is a
+     second pass — confirmed with Anchorfish 2026-08-30, no shared-setup
+     discount on their screen sheet. */
+  assert.strictEqual(both.decoration, one.decoration * 2);
+});
+
+test('a dark two-sided job bills every screen it burns', () => {
+  const r = line({ qty: 62, colours: 1, stage: 'both', dark: true });
+  assert.strictEqual(r.screens, 4);
+  assert.strictEqual(r.addonTotal, 140);
+});
+
+test('the line reports the counts it charged, so a surface can show them', () => {
+  const r = line({ colours: 3, stage: 'both', dark: true });
+  assert.strictEqual(r.colours, 3);
+  assert.strictEqual(r.locations, 2);
+  assert.strictEqual(r.screens, 8);
+  assert.deepStrictEqual(r.addonLines.map((a) => a.code), ['screens']);
+  assert.strictEqual(r.addonLines[0].total, 8 * SCREEN_FEE);
+});
+
+test('screens ride on top of the print, they do not replace it', () => {
+  const r = line({ qty: 100, colours: 3, stage: 'front' });
+  assert.strictEqual(r.decoration, 5.85, 'the 100-249 band, 3 colours, print only');
+  assert.strictEqual(r.lineTotal, 5.85 * 100 + 3 * SCREEN_FEE);
+});
+
+/* ── the deploy/reprice ordering guard ───────────────────────────────────── */
+
+test('the fee is gated until the tables are repriced, on BOTH surfaces', () => {
+  /* The per-piece tables and the fee cannot change atomically — one is a deploy,
+     the other is a write to the Lumise database. Ship the fee while the tables
+     still amortise screens and every screen bills twice. The flag is what joins
+     them, and it has to gate the browser preview and the save route alike or
+     one surface quotes a price the other does not charge. */
+  assert.ok(/const SCREEN_FEES_LIVE = String\(process\.env\.JT_SCREEN_FEES/.test(src),
+    'SCREEN_FEES_LIVE must be read from JT_SCREEN_FEES');
+  const gates = src.split('!SCREEN_FEES_LIVE').length - 1;
+  assert.ok(gates >= 2,
+    `the screens add-on is gated in ${gates} place(s); it must be gated in both ` +
+    'the browser preview and the save route');
+});
+
+/* ── the rate card no longer carries a screen charge ─────────────────────── */
+
+test('the reprice tool prices print only — screens are not folded back in', () => {
+  /* Anchored on the declarations, not on the formula they guard: if someone
+     rewrites the formula this still resolves and the assertion below names the
+     regression, rather than dying with "not found" and reporting a rename. */
+  const tool = fs.readFileSync(path.join(ROOT, 'tools', 'reprice-anchorfish-2026.js'), 'utf8');
+  const grab = (anchor, end) => {
+    const i = tool.indexOf(anchor);
+    assert.notStrictEqual(i, -1, `${anchor} not found in reprice-anchorfish-2026.js`);
+    return tool.slice(i, tool.indexOf(end, i) + end.length);
+  };
+  const sandbox = { up05: (n) => Math.ceil(n * 20 - 1e-9) / 20 };
+  vm.createContext(sandbox);
+  vm.runInContext(grab('const SP = {', '};') + '\n' + grab('const spPrice =', ';') +
+    '\nthis.spPrice = spPrice;', sandbox);
+
+  /* The agreed card, print only, from the plan. If a screen charge creeps back
+     into the base every one of these rises. */
+  const AGREED = {
+    1: [4.25, 3.80, 3.35, 3.00, 2.60, 2.20],
+    3: [6.40, 5.85, 5.25, 4.75, 4.30, 3.80],
+    7: [10.80, 10.15, 9.50, 9.00, 8.50, 8.00],
+  };
+  const FLOORS = [50, 100, 250, 500, 1000, 2500];
+  for (const c of [1, 3, 7]) {
+    FLOORS.forEach((f, i) => {
+      assert.strictEqual(sandbox.spPrice(f, c), AGREED[c][i],
+        `${c} colour at the ${f} band should be print-only $${AGREED[c][i].toFixed(2)}`);
+    });
+  }
+});

--- a/tools/reprice-anchorfish-2026.js
+++ b/tools/reprice-anchorfish-2026.js
@@ -41,15 +41,47 @@ const APPLY = process.argv.includes('--apply');
    The markup falls with quantity because Anchorfish's cost curve is much
    flatter than the old vendor's while market price still drops steeply, so one
    multiple would either starve the small runs or lose the big bids. */
+/* Markups repriced to market 2026-08-30, from a real contract invoice (#16899:
+   62 shirts, 2 colours, 2 locations — $4.50/pc print, 4 screens at $20).
+   At the old 4.40x a two-sided 2-colour job billed $27.44/pc against an $8.61
+   cost: 69% margin, well above the $15-18 that job fetches, and — because the
+   second location doubles a marked-up figure — MORE than the same job in DTF,
+   which inverts the one advantage screen printing has at volume.
+   The cut is deepest at the small end, where 4.40x was the outlier; the large
+   bands were already thin and barely move. Nothing goes below 1.80x. */
+/* Screens are NOT in this table. They are billed once per order as a separate
+   fee (SCREEN_FEE below), because a screen is bought once however many pieces
+   run through it — amortising it into a per-piece rate makes a 50-piece job
+   subsidise a 500-piece one and hides the setup cost from the customer.
+
+   So the markup IS the margin on the print itself: 1 - 1/mk. 2.34 anchors
+   1 colour / 1 location / 50-99 on $4.25 (57.3%), and the curve settles to a
+   flat 55% at volume, where competition is hardest.
+
+   An earlier draft of this file folded (SCREEN_COST * colours) / band_floor
+   into the base before applying the markup. That was written before screens
+   became a separate fee; leaving it in would bill every screen twice. */
 const SP = {
-   50: { ceil:  99, mk: 4.40, p: [1.80, 2.25, 2.72, 3.19, 3.66, 4.13, 4.60] },
-  100: { ceil: 249, mk: 3.65, p: [1.65, 2.06, 2.53, 3.00, 3.47, 3.94, 4.41] },
-  250: { ceil: 499, mk: 2.75, p: [1.47, 1.84, 2.31, 2.78, 3.25, 3.72, 4.19] },
-  500: { ceil: 999, mk: 2.55, p: [1.32, 1.65, 2.12, 2.59, 3.06, 3.53, 4.00] },
- 1000: { ceil:2499, mk: 2.10, p: [1.17, 1.46, 1.93, 2.40, 2.87, 3.34, 3.81] },
- 2500: { ceil:7000, mk: 1.95, p: [0.99, 1.24, 1.71, 2.18, 2.65, 3.12, 3.59] },
+   50: { ceil:  99, mk: 2.34, p: [1.80, 2.25, 2.72, 3.19, 3.66, 4.13, 4.60] },
+  100: { ceil: 249, mk: 2.30, p: [1.65, 2.06, 2.53, 3.00, 3.47, 3.94, 4.41] },
+  250: { ceil: 499, mk: 2.26, p: [1.47, 1.84, 2.31, 2.78, 3.25, 3.72, 4.19] },
+  500: { ceil: 999, mk: 2.24, p: [1.32, 1.65, 2.12, 2.59, 3.06, 3.53, 4.00] },
+ 1000: { ceil:2499, mk: 2.22, p: [1.17, 1.46, 1.93, 2.40, 2.87, 3.34, 3.81] },
+ 2500: { ceil:7000, mk: 2.22, p: [0.99, 1.24, 1.71, 2.18, 2.65, 3.12, 3.59] },
 };
-const SCREEN_CHARGE = 25;   // yours, per colour, amortised at the band floor
+/* Anchorfish's actual per-SCREEN charge, confirmed on invoice #16899: 4 screens
+   at $20 for a 2-colour job across 2 locations. Screens are therefore
+   colours x LOCATIONS, not colours — the old $25/colour figure counted only
+   colours, so every two-sided job under-recovered its setup. The invoice's
+   "Ink: Base, White" line also proves the white underbase is its own screen,
+   so a 1-colour design on a dark garment is a 2-screen job.
+
+   Neither constant enters the per-piece table below. They are here because
+   this tool is where the screen economics are written down, and because the
+   sell price has to be changed in the same breath as the cost that justifies
+   it. The charge itself is applied by the `screens` add-on in server.js. */
+const SCREEN_COST = 20;   // what Anchorfish charges us, per screen
+const SCREEN_FEE  = 35;   // what we bill, per screen, ONCE per order
 
 /* Anchorfish prices 5, 6 and 7 colours separately; the designer had one
    combined "5-6 Colors" method, which had to quote one of them wrong. */
@@ -73,16 +105,24 @@ const SP_INSERTS = [
    Columns used: [0]=16sq [1]=132sq (the standard print) [2]=252sq [3]=addl loc.
    Live bands stopped at 175 pieces, so every larger order was quoting at the
    175 rate; these run to 2,500. */
+/* Markups taper harder above 50 pieces (2026-08-30). At the old 3.6x, DTF at 100
+   pieces cost $11.05 against a 1-colour screen print's $6.30 — so the full-colour
+   convenience option was the DEAR one exactly where volume should make printing
+   cheap, and the product page advertises the DTF ladder by default. Under 50 the
+   markup stays at 4.0: small runs are labour-heavy per piece and screen printing
+   cannot bid for them at all (50-piece minimum), so there is nothing to undercut.
+   Above 50 DTF now lands just above a 2-colour screen job, which is the honest
+   place for it — unlimited colours, no screens, no colour-count ceiling. */
 const DTF = {
-    1: { ceil:  11, mk: 4.0, v: [5.00, 7.03, 9.38, 1.80] },
-   12: { ceil:  24, mk: 4.0, v: [3.23, 5.63, 7.50, 1.80] },
-   25: { ceil:  49, mk: 4.0, v: [2.58, 4.50, 6.00, 1.50] },
-   50: { ceil:  99, mk: 3.6, v: [2.73, 3.60, 4.80, 1.50] },
-  100: { ceil: 249, mk: 3.6, v: [1.65, 3.06, 4.08, 1.35] },
-  250: { ceil: 499, mk: 3.0, v: [1.47, 2.60, 3.47, 1.20] },
-  500: { ceil: 999, mk: 2.8, v: [1.32, 2.21, 2.95, 1.11] },
- 1000: { ceil:2499, mk: 2.4, v: [1.17, 1.88, 2.51, 1.05] },
- 2500: { ceil:7000, mk: 2.2, v: [0.99, 1.60, 2.13, 1.02] },
+    1: { ceil:  11, mk: 3.70, v: [5.00, 7.03, 9.38, 1.80] },
+   12: { ceil:  24, mk: 3.60, v: [3.23, 5.63, 7.50, 1.80] },
+   25: { ceil:  49, mk: 3.50, v: [2.58, 4.50, 6.00, 1.50] },
+   50: { ceil:  99, mk: 3.30, v: [2.73, 3.60, 4.80, 1.50] },
+  100: { ceil: 249, mk: 3.10, v: [1.65, 3.06, 4.08, 1.35] },
+  250: { ceil: 499, mk: 2.90, v: [1.47, 2.60, 3.47, 1.20] },
+  500: { ceil: 999, mk: 2.75, v: [1.32, 2.21, 2.95, 1.11] },
+ 1000: { ceil:2499, mk: 2.60, v: [1.17, 1.88, 2.51, 1.05] },
+ 2500: { ceil:7000, mk: 2.50, v: [0.99, 1.60, 2.13, 1.02] },
 };
 
 /* ── Anchorfish cost sheets ─────────────────────────────────────────────── */
@@ -363,10 +403,12 @@ console.log('\n  Fitted from your two prices: $' + EMB_PRICE.chest.toFixed(2) + 
 /* ── Screen print ───────────────────────────────────────────────────────── */
 
 const SPF = Object.keys(SP).map(Number).sort((a, b) => a - b);
-const spPrice = (f, c) => up05(SP[f].p[c - 1] * SP[f].mk + (SCREEN_CHARGE * c) / f);
+const spPrice = (f, c) => up05(SP[f].p[c - 1] * SP[f].mk);
 const spTiers = (c) => SPF.map((f) => [SP[f].ceil, spPrice(f, c)]);
 
-console.log('\n\nSCREEN PRINT — Anchorfish 2026, $' + SCREEN_CHARGE + '/colour screen charge baked in.');
+console.log('\n\nSCREEN PRINT — Anchorfish 2026, print only. Screens are NOT in these rates:');
+console.log('they bill once per order at $' + SCREEN_FEE + '/screen (cost $' + SCREEN_COST +
+            '), screens = (colours + 1 on darks) x locations.');
 console.log('50-piece minimum: the old bands started at 12, which contradicted it.\n');
 let sh = '  id   colours   ';
 for (const f of SPF) sh += (f + '-' + SP[f].ceil).padStart(11);


### PR DESCRIPTION
## What changed

**Screens become a one-time fee.** $35 per screen, charged once per order, where `screens = (design colours + 1 if the garment is dark) x locations`. A screen is burned once and then runs the whole job, so amortising it into a per-piece rate made small runs subsidise large ones inside a rate card nobody could see into — and hid the setup cost from the customer entirely.

- New `per_screen` add-on kind, and `screenCount(colours, locations, dark)` written once in `quotePricingSource()` so the fee and the screens actually ordered from Anchorfish are the same number.
- `priceLine` derives `locations` from the same `stage` it priced the print off, so the screens billed and the passes charged cannot disagree.
- The `underbase` add-on is retired. It charged a flat $25 regardless of colours or locations; invoice #16899 (62 shirts, white on black, two locations) is four screens — $80 of cost recovered at $25. The dark-garment box is now a pricing **input** that adds a screen per location, not a charge of its own.
- `tools/reprice-anchorfish-2026.js` no longer folds `SCREEN_COST` into the marked-up base. That draft predated the decision to separate the fee; left in, it would bill every screen twice.
- The customer quote now itemises add-ons. `unit_price` deliberately excludes them, so until now specialty ink, unbagging, puff and the jumbo hoop all arrived as an unexplained difference between `qty x unit` and the line total — and screens would have joined them at up to $140 a line. A screen fee especially has to show its working: "4 x $35" is checkable, "$140 setup" gets queried.

## Sequencing — read before merging

**This must not go live until the print tables are repriced.** The tables and the fee cannot change atomically: one is a deploy, the other is a write to the Lumise database. So the fee is gated on `JT_SCREEN_FEES`, **off by default**. Merging and deploying with the flag unset changes nothing.

The order is: merge → deploy → `railway variables --service MySQL --json | node tools/reprice-anchorfish-2026.js --apply` → verify the tables are print-only → set `JT_SCREEN_FEES=1`.

## Why this approach

The add-on table already existed and already states how each charge scales, once, in a `kind` — that abstraction was built after digitizing (a $30 fee billed $1,500 on a 50-piece line) and it is the right home for this. Adding a fifth `kind` reuses the whole assembled/validated/persisted path rather than special-casing screens.

Rates and kinds continue to be looked up server-side from `ADDONS`; the client posts only which line and whether the garment is dark, never what anything costs.

## What I did NOT do

**The designer half is not built** — the designer still neither charges nor knows about screens. It is a bigger job than the plan assumed, and the reason is worth recording:

- `lumise.cart.price.fixed` is **not a hook**. It is a plain numeric field at `app.js:15082` / `cart.php:408`, it is reset and rebuilt on every `calc()` from the per-size quantity attribute, and it already has the qty multiply folded inside it. Nothing can register against it; adding a fee means editing both files directly.
- The real `apply_filters` system exposes two pricing hooks and both fire **before** the qty multiply, so a fee added through them would be multiplied by quantity.
- The designer has no light/dark flag. A `product_color` attribute carries a raw hex reachable in both languages, and JS has a luminance test in `lumise.fn.invert` that could classify it — PHP has nothing equivalent. Neither is guaranteed present: a product using a plain `select` for colour carries a label string, no hex.
- Designer colour count is **per stage**, so "design colours" needs a decision — union across stages, max of any one, or sum.

Until that lands, the designer and the quote form price screen printing differently. That is the reason the flag exists.

## What to check by hand

1. With `JT_SCREEN_FEES` unset, a screen-print quote prices exactly as it does today.
2. With it set: a 100-piece 3-colour front-only job shows `Screens — 3 x $35 = $105, one time`, and the same job at 500 pieces shows the same $105.
3. Two-sided, dark, 1 colour = 4 screens = $140, and the customer quote line foots (`qty x unit + add-ons = line total`).
4. Reopening a saved dark-garment quote keeps the box ticked and re-derives the same fee. Note issue #48: the *optional* add-on boxes do not survive a reopen — pre-existing, not from this change.

23 test files pass, including 13 new ones in `tests/screen-fees.test.js`. Nothing in CI runs them; `for f in tests/*.test.js; do node "$f"; done`.