### PR TITLE
Fix ReferenceError that took down the quote builder

### DIFF
--- a/server.js
+++ b/server.js
@@ -4455,7 +4455,7 @@ ${quotePricingSource()}
               ? '<div class="muted" style="font-size:11px;text-transform:uppercase;letter-spacing:.05em;margin-bottom:4px">Upgrades</div>' +
                 avail.map(function(a){
                   return '<label style="display:flex;align-items:flex-start;gap:6px;margin:0 0 3px;font-size:13px;text-transform:none;letter-spacing:0;font-weight:400">' +
-                    '<input type="checkbox" class="ao" name="addon_' + a.code + '${n}" value="1" data-code="' +
+                    '<input type="checkbox" class="ao" name="addon_' + a.code + L.dataset.n + '" value="1" data-code="' +
                     a.code + '" style="width:auto;margin:3px 0 0"><span>' + a.label +
                     (a.kind === 'per_piece' ? ' <span class="muted">$' + a.rate.toFixed(2) + ' ea</span>'
                      : a.kind === 'percent_of_decoration' ? ' <span class="muted">+' + a.rate + '%</span>'

--- a/tests/template-literal-leak.test.js
+++ b/tests/template-literal-leak.test.js
@@ -1,0 +1,83 @@
+'use strict';
+
+/* THE BUG THIS GUARDS
+ * -------------------
+ * `lineHtml(n, it)` builds one quote line and ends at server.js:4212. The page
+ * template that starts at 4214 is a different template literal and has no `n`.
+ * A checkbox name was written there as
+ *
+ *     '... name="addon_' + a.code + '${n}" value="1" ...'
+ *
+ * which looks like client-side string concatenation but is not: the `${n}` sits
+ * inside a server-side template literal, so the SERVER evaluates it, against a
+ * scope with no `n`. Every render of /quote/new and /quote/:code/edit threw
+ * `ReferenceError: n is not defined` as an unhandled rejection — the admin quote
+ * builder was down for about three hours after #46 before anyone opened it.
+ *
+ * The fix is to concatenate the value at runtime instead of interpolating it at
+ * render time, reading the index off the `.line` element the server already
+ * stamped it onto: `+ L.dataset.n +`.
+ *
+ * WHY THERE IS NO GENERIC SCAN HERE
+ * ---------------------------------
+ * The obvious guard — flag any `${` inside a single-quoted string — cannot be
+ * done with a regex over lines. Most lines of a multi-line template literal
+ * contain no backtick of their own, so `style="color:${x}"` inside one is
+ * indistinguishable from the bug by line-local inspection. A first draft of this
+ * file flagged 44 healthy lines. Catching the class properly needs a tokenizer
+ * that tracks template-literal depth; until someone writes that, this file pins
+ * the one invariant that actually broke.
+ */
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const SERVER = path.join(__dirname, '..', 'server.js');
+const lines = fs.readFileSync(SERVER, 'utf8').split('\n');
+
+/* Assert against the ONE line, never the whole file: assert.match prints the
+   subject on failure, and server.js is half a megabyte. A failure nobody can
+   read is a failure nobody acts on. Anchored on `name="addon_`, which is the
+   shortest text unique to this control and survives the code being rewritten
+   around it. */
+function lineContaining(needle) {
+  const hits = lines
+    .map((text, i) => ({ n: i + 1, text: text.trim() }))
+    .filter((l) => l.text.includes(needle));
+  assert.strictEqual(hits.length, 1,
+    'expected exactly one line containing ' + JSON.stringify(needle) +
+    ', found ' + hits.length + '. Update this test to match the new shape.');
+  return hits[0];
+}
+
+test('the addon checkbox name carries the line index at runtime, not at render time', () => {
+  const l = lineContaining('name="addon_');
+
+  assert.match(l.text, /\+ a\.code \+ L\.dataset\.n \+ '"/,
+    'server.js:' + l.n + ' — the add-on checkbox name must append L.dataset.n ' +
+    'by concatenation. Written as \'${n}\' the server tries to interpolate a ' +
+    'variable that is not in scope in that template, and every quote-builder ' +
+    'render throws ReferenceError.\n  ' + l.text);
+
+  assert.doesNotMatch(l.text, /'\$\{/,
+    'server.js:' + l.n + ' — a ${...} in a single-quoted string here is ' +
+    'evaluated by the server, not the browser.\n  ' + l.text);
+});
+
+test('the posted field name still matches what the browser renders', () => {
+  /* The handler reads addon_<code><index> off the body. If either side is
+     renamed alone, add-ons post against the wrong line and apply silently to
+     the wrong item — a wrong price with no error anywhere. */
+  const l = lineContaining('addon_${a.code}${i}');
+  assert.ok(l.n > 0, 'the POST handler must still read addon_<code><index>');
+});
+
+test('the line element still carries the index the checkbox reads', () => {
+  const l = lineContaining('class="line" data-n=');
+  assert.match(l.text, /data-n="\$\{n\}"/,
+    'server.js:' + l.n + ' — L.dataset.n is read off this attribute. Renaming ' +
+    'it breaks the checkbox name silently: dataset.n becomes undefined and ' +
+    'every add-on posts as "addon_codeundefined".\n  ' + l.text);
+});


### PR DESCRIPTION
## The outage

`/quote/new` and `/quote/:code/edit` have been throwing on **every** render since
#46 deployed at 00:53. Railway logs:

```
UNHANDLED REJECTION: ReferenceError: n is not defined
    at /app/server.js:4458:84
```

## Cause

`lineHtml(n, it)` ends at server.js:4212. The page template that starts at 4214
is a **different** template literal and has no `n` in scope. The add-on checkbox
name was written inside it as:

```js
'... name="addon_' + a.code + '${n}" value="1" ...'
```

That reads like client-side string concatenation, but the `${n}` is inside a
server-side template literal, so **the server** evaluates it — against a scope
with no `n`. It threw while building the page, as an unhandled rejection, so the
page failed outright rather than degrading.

## Fix

Concatenate the value at runtime instead of interpolating it at render time,
reading the index off the `.line` element the server already stamps it onto:

```js
'... name="addon_' + a.code + L.dataset.n + '" value="1" ...'
```

`L` is the `.line` element (server.js:4387) and carries `data-n` from
lineHtml (4132). The POST handler reads `addon_${a.code}${i}`, so the rendered
name has to end in the line index — otherwise every add-on would post against
line 0 and apply silently to the wrong item.

## Tests

`tests/template-literal-leak.test.js`, 3 assertions pinning the invariant from
both ends: the name is built by concatenation, the handler still reads
`addon_<code><index>`, and `.line` still carries `data-n`. **Verified by
reintroducing the bug** — the test fails, then passes again once reverted.

Suite is 297/297.

## What I did NOT do

- **No generic scan for this bug class.** The obvious guard — flag `${` inside a
  single-quoted string — cannot be done line by line: most lines of a multi-line
  template literal have no backtick of their own, so a legitimate
  `style="color:${x}"` is indistinguishable from the bug. My first draft flagged
  44 healthy lines. Catching the class properly needs a tokenizer tracking
  template-literal depth. Reasoning is in the test file's header so the next
  person doesn't repeat the attempt.
- Did not audit the other admin pages for the same shape. Worth doing; this PR
  is scoped to the outage.

## To verify by hand

Open `/quote/new` as admin, add a line, pick a screen-print method, and confirm
the **Upgrades** checkboxes (specialty ink, unbagging) render and survive a save.
That path is what threw, and it is the one thing I could not exercise without an
admin session.