### PR TITLE
Start the garment volume break at 35 pieces

### DIFF
--- a/docs/pricing-2026.md
+++ b/docs/pricing-2026.md
@@ -208,7 +208,7 @@ Volume breaks come off that list price, in `BLANK_TIERS` in `server.js`:
 
 | from | off |
 | --- | --- |
-| 100 | 2% |
+| 35 | 2% |
 | 500 | 3% |
 | 1,000 | 5% |
 | 3,000 | 8% |
@@ -217,12 +217,17 @@ Volume breaks come off that list price, in `BLANK_TIERS` in `server.js`:
 tables above, whose keys are band CEILINGS. Read one as the other and every band
 lands one step out.
 
-**The first floor moved 125 → 100 on 2026-08-30.** 100 is the commonest order
-size in the shop and it sat one step under the old floor, so the most-quoted job
-in the building got no break at all — and the way round it was to type a garment
-price over the catalogue by hand on every quote. An override works once; it is
-not a price list, it never reaches a margin report, and the next person quoting
-the same job invents a different number.
+**The first floor moved 125 → 100 → 35 on 2026-08-30.** 100 is the commonest
+order size in the shop and it sat one step under the old floor, so the
+most-quoted job in the building got no break at all — and the way round it was to
+type a garment price over the catalogue by hand on every quote. An override works
+once; it is not a price list, it never reaches a margin report, and the next
+person quoting the same job invents a different number.
+
+It then went to **35** so the break reaches the small runs. Screen print is not
+sold below 50, so 35–49 is DTF, embroidery and HTV — the jobs where the
+decoration is dearest per piece and the quote is most likely to be up against a
+shop that does not mind a thin garment margin.
 
 Worth being honest about what this is: **there is no supplier break behind any of
 it.** The garment costs the same at 50 as at 5,000. Every point here is margin

--- a/server.js
+++ b/server.js
@@ -3178,7 +3178,7 @@ const BLANK_TIERS = [
   { min: 3000, pct: 8 },
   { min: 1000, pct: 5 },
   { min:  500, pct: 3 },
-  { min:  100, pct: 2 },
+  { min:   35, pct: 2 },
 ];
 
 /* Below this the garment is flat cost x2 with no volume break at all — honest
@@ -3186,12 +3186,16 @@ const BLANK_TIERS = [
    break is margin given away rather than a saving passed on. It buys
    competitiveness on the bids where the garment is most of the price.
 
-   Lowered from 125 to 100 on 2026-08-30. 100 is one of the commonest order
-   sizes there is, and it sat just under the old floor — so the most-quoted job
-   in the shop got no break at all, and the way round it was to type a garment
-   price over the catalogue by hand on each quote. An override works once; it is
-   not a price list, it never reaches a margin report, and the next person
-   quoting the same job invents a different number.
+   Lowered 125 -> 100 -> 35 on 2026-08-30. 100 sat just under the old floor, so
+   the commonest order size in the shop got no break at all, and the way round it
+   was to type a garment price over the catalogue by hand on each quote. An
+   override works once; it is not a price list, it never reaches a margin report,
+   and the next person quoting the same job invents a different number.
+
+   35 rather than 100 so the break reaches the small runs too. Screen print is
+   not sold below 50, so 35-49 is DTF, embroidery and HTV — the jobs where the
+   decoration is dearest per piece and the quote is most likely to be compared
+   against a shop that does not mind a thin garment margin.
 
    DERIVED from the table, never written twice. This was a hand-kept 125 while
    the table said 125 in its own row — two copies of one threshold, and nothing

--- a/tests/quote-blank-pricing.test.js
+++ b/tests/quote-blank-pricing.test.js
@@ -83,11 +83,13 @@ test('the agreed curve is the one in the code', () => {
      this — the garment costs the same at 50 as at 5,000 — so every point given
      away here is margin, not a saving passed on. The shallow curve keeps a real
      gesture on the bids where the garment is most of the price, and nothing
-     below 100 pieces, where the shop's flat cost x2 rule stands unmodified.
-     The first floor moved 125 -> 100 on 2026-08-30: 100 is the commonest order
-     size in the shop and it sat just under the old floor, so the most-quoted
-     job got no break and was being hand-overridden on each quote instead. */
-  for (const [qty, pct] of [[100, 2], [500, 3], [1000, 5], [3000, 8]]) {
+     below 35 pieces, where the shop's flat cost x2 rule stands unmodified.
+     The first floor moved 125 -> 100 -> 35 on 2026-08-30: 100 is the commonest
+     order size and sat just under the old floor, so the most-quoted job got no
+     break and was being hand-overridden on each quote instead; 35 then extends
+     it to the small runs, which are DTF/embroidery/HTV since screen print is
+     not sold below 50. */
+  for (const [qty, pct] of [[35, 2], [100, 2], [500, 3], [1000, 5], [3000, 8]]) {
     assert.strictEqual(blankDiscountPct(qty), pct, `${qty} pieces should be ${pct}% off`);
   }
 });
@@ -95,14 +97,14 @@ test('the agreed curve is the one in the code', () => {
 /* ── Floors, not ceilings ───────────────────────────────────────────────── */
 
 test('a floor applies AT its quantity, not one piece later', () => {
-  assert.strictEqual(blankDiscountPct(100), 2);
-  assert.strictEqual(blankDiscountPct(99), 0);
+  assert.strictEqual(blankDiscountPct(35), 2);
+  assert.strictEqual(blankDiscountPct(34), 0);
 });
 
 test('below the minimum the garment is flat cost x2, with no break at all', () => {
   /* The shop's stated rule. A break here would be pure give-away on the
      smallest orders, which are also the ones that carry the most setup. */
-  for (const q of [1, 12, 50, 99]) {
+  for (const q of [1, 12, 24, 34]) {
     assert.strictEqual(blankDiscountPct(q), 0, `${q} pieces must not be discounted`);
   }
 });
@@ -122,7 +124,7 @@ test('the largest applicable discount wins, not the smallest', () => {
 });
 
 test('below the first floor there is no discount at all', () => {
-  for (const q of [1, 12, 50, 72, 99]) {
+  for (const q of [1, 6, 12, 24, 34]) {
     assert.strictEqual(blankDiscountPct(q), 0, `${q} pieces must not be discounted`);
   }
 });
@@ -136,9 +138,9 @@ test('a nonsense quantity is not a discount', () => {
 /* ── The money ─────────────────────────────────────────────────────────── */
 
 test('the garment price drops by exactly the tier', () => {
-  assert.strictEqual(blankPriceFor(5.64, 50), 5.64);    // Gildan 5000, no break
-  assert.strictEqual(blankPriceFor(5.64, 99), 5.64);    // still none, one under the floor
-  assert.strictEqual(blankPriceFor(5.64, 100), 5.53);   // 2%
+  assert.strictEqual(blankPriceFor(5.64, 12), 5.64);    // Gildan 5000, no break
+  assert.strictEqual(blankPriceFor(5.64, 34), 5.64);    // still none, one under the floor
+  assert.strictEqual(blankPriceFor(5.64, 35), 5.53);    // 2%, at the floor
   assert.strictEqual(blankPriceFor(5.64, 1000), 5.36);  // 5%
   assert.strictEqual(blankPriceFor(5.64, 3000), 5.19);  // 8%
 });
@@ -148,7 +150,7 @@ test('the garment never sells below cost x1.8 on this curve', () => {
      the multiple down with nothing recovering it; 8% at the top keeps the
      garment at 1.84x rather than the 1.60x the previous curve reached. */
   const cost = 2.82, retail = 5.64;   // Gildan 5000, the shop's volume seller
-  for (const q of [1, 100, 500, 1000, 3000, 99999]) {
+  for (const q of [1, 35, 500, 1000, 3000, 99999]) {
     assert.ok(blankPriceFor(retail, q) / cost >= 1.8,
       `${q} pieces sells the garment at ${(blankPriceFor(retail, q) / cost).toFixed(2)}x`);
   }


### PR DESCRIPTION
## What changed

`BLANK_TIERS` first floor: **100 → 35**, still 2% off. The other tiers (500/3%,
1,000/5%, 3,000/8%) are unchanged.

`BLANK_DISCOUNT_MIN_QTY` follows automatically — it is derived from the table
with `Math.min` as of the previous PR, so there is no second copy to forget.

## Why

The break now reaches the small runs. Screen print is not sold below 50, so
35–49 pieces is DTF, embroidery and HTV — the jobs where the decoration is
dearest per piece and the quote is most likely to be up against a shop that does
not mind a thin garment margin.

Being honest about what this is: **there is no supplier break behind it.** A
Gildan 5000 costs $2.82 at 35 and at 5,000. Every point here is margin given away
to win the bid, not a saving passed on. At 2% on a $5.64 blank that is 11¢ a
piece — about $5.50 on a 50-piece job. It is a gesture, and it is priced as one.

## Tests

297/297. `quote-blank-pricing.test.js` updated — the floor assertions moved to
35/34, and the "no break" cases to 34 and below.

## What I did NOT do

Left the 2% rate alone and did not touch the upper tiers. If the intent is to be
meaningfully cheaper rather than symbolically cheaper, the rate is the lever, not
the floor — but that is a bigger margin decision than moving where the curve
starts, so it is not folded in here.