### PR TITLE
Show screens as their own line on the quote totals

### DIFF
--- a/server.js
+++ b/server.js
@@ -4257,6 +4257,14 @@ app.get(['/quote/new', '/quote/:code/edit'], requireAdmin, async (req, res) => {
         <div id="lines">${eItems.map((it, ix) => lineHtml(ix, it)).join('')}</div>
         <button type="button" class="btn btn-ghost" style="padding:9px 18px;font-size:14px" onclick="addLine()">+ Add another item</button>
         <table style="width:100%;margin-top:14px;border-top:1px solid #e3e8f2;padding-top:10px">
+          <!-- Screens are a one-time setup cost, not part of the per-piece
+               price, and a customer who cannot see them reads the whole job as
+               dearer per shirt than it is. They are already inside the subtotal,
+               so these two rows SPLIT it rather than adding to it — a screens
+               row that also added would overstate the job by its own value.
+               Hidden entirely when a job burns none. -->
+          <tr class="scrsplit" style="display:none"><td class="muted">Garments &amp; printing</td><td class="num" id="goods">$0.00</td></tr>
+          <tr class="scrsplit" style="display:none"><td class="muted">Screens <span id="scrdetail" style="font-size:12px;color:#6b7280"></span></td><td class="num" id="scr">$0.00</td></tr>
           <tr><td class="muted">Subtotal</td><td class="num" id="sub">$0.00</td></tr>
           <tr><td class="muted">
             <div style="display:flex;align-items:center;gap:6px;flex-wrap:wrap">
@@ -4399,6 +4407,13 @@ ${quotePricingSource()}
 
       function calc(){
         var sub = 0;
+        /* Screens across every line, so the totals can show them on their own
+           row. Counted from the addon line's own count field rather than
+           dividing the total by a rate — the division would lie the moment the
+           rate changed between quoting and rendering.
+           No backticks in here: this comment is inside a server-side template
+           literal, and one would end it. */
+        var scrTotal = 0, scrCount = 0;
         document.querySelectorAll('.line').forEach(function(L){
           var prod = CAT.products.find(function(x){return String(x.id)===L.querySelector('.p').value;});
           var meth = CAT.methods.find(function(x){return String(x.id)===L.querySelector('.m').value;});
@@ -4583,6 +4598,12 @@ ${quotePricingSource()}
 
           sub += lt;
 
+          if (r.addonLines) r.addonLines.forEach(function(a){
+            if (a.code !== 'screens') return;
+            scrTotal += a.total;
+            scrCount += (a.count || 0);
+          });
+
           /* Screen printing has a floor. The tier keys are band ceilings, so a
              20-piece screen job would otherwise quote at the 50-71 rate and look
              perfectly normal — say so instead, and point at what does run. */
@@ -4620,6 +4641,22 @@ ${quotePricingSource()}
         var tot = net + tax;
         var dep = tot <= 0 ? 0 : (tot < FULL_UNDER ? tot : tot*DEP);
         document.getElementById('sub').textContent = m2(sub);
+
+        /* Split the subtotal only when there is something to split. On a job
+           with no screens these rows would restate the subtotal twice under two
+           different names, which reads as an error. */
+        scrTotal = Math.round(scrTotal * 100) / 100;
+        var showScr = scrTotal > 0;
+        document.querySelectorAll('.scrsplit').forEach(function(el){
+          el.style.display = showScr ? '' : 'none';
+        });
+        if (showScr) {
+          document.getElementById('goods').textContent = m2(Math.round((sub - scrTotal) * 100) / 100);
+          document.getElementById('scr').textContent = m2(scrTotal);
+          document.getElementById('scrdetail').textContent = scrCount
+            ? '— ' + scrCount + ' × ' + m2(scrTotal / scrCount) + ', one-time' : '— one-time';
+        }
+
         document.getElementById('disc').textContent = disc > 0
           ? '−' + m2(disc) + (dk === 'pct' ? ' (' + dv + '%)' : '') : '—';
         document.getElementById('tax').textContent = m2(tax);

--- a/tests/template-literal-leak.test.js
+++ b/tests/template-literal-leak.test.js
@@ -81,3 +81,46 @@ test('the line element still carries the index the checkbox reads', () => {
     'it breaks the checkbox name silently: dataset.n becomes undefined and ' +
     'every add-on posts as "addon_codeundefined".\n  ' + l.text);
 });
+
+/* The generic scan this file's header rejects is unnecessary for one whole class
+ * of the same bug: anything that ends the template literal early makes server.js
+ * stop parsing. A stray backtick in a comment inside the quote-page template did
+ * exactly that while this feature was being written — the file failed to parse
+ * at a line 900 further down, which reads as an unrelated error.
+ *
+ * `node --check` is the tokenizer the header says would be needed. Running it
+ * here means a broken template literal fails the suite rather than the deploy.
+ */
+test('server.js parses', () => {
+  const { spawnSync } = require('node:child_process');
+  const r = spawnSync(process.execPath, ['--check', SERVER], { encoding: 'utf8' });
+  assert.strictEqual(r.status, 0,
+    'server.js does not parse. A backtick or ${...} inside the client-side ' +
+    'script of a server-side template literal will end it early, and the error ' +
+    'is reported far from the real cause:\n' + (r.stderr || ''));
+});
+
+/* ── The screens row ─────────────────────────────────────────────────────── */
+
+test('the totals SPLIT the subtotal for screens rather than adding to it', () => {
+  const src = fs.readFileSync(SERVER, 'utf8');
+
+  /* Screens are already inside every line total, so the screens row has to come
+     OUT of the subtotal. A row that also added would overstate the job by its
+     own value — $140 on a 4-screen job — and it would be the customer-facing
+     number that was wrong. */
+  assert.match(src, /getElementById\('goods'\)\.textContent = m2\(Math\.round\(\(sub - scrTotal\)/,
+    'the garments-and-printing row must be sub MINUS screens');
+
+  assert.match(src, /id="goods"/, 'the split needs a goods row');
+  assert.match(src, /id="scr"/, 'the split needs a screens row');
+  assert.match(src, /class="scrsplit"/, 'both split rows must be hideable together');
+});
+
+test('the screens count is read, never divided back out', () => {
+  const src = fs.readFileSync(SERVER, 'utf8');
+  assert.match(src, /scrCount \+= \(a\.count \|\| 0\)/,
+    'the count comes from the addon line, which carries it precisely so no ' +
+    'surface has to divide a total by a rate — that division silently lies ' +
+    'the moment the rate changes between quoting and rendering');
+});


### PR DESCRIPTION
## What changed

The quote totals now break the screen charge out:

```
Garments & printing    $1,324.00
Screens — 4 × $35.00     $140.00     one-time
Subtotal               $1,464.00
Discount                       —
Illinois sales tax       $150.06
Total                  $1,614.06
```

Both new rows hide entirely on a job that burns no screens.

## Why this shape

Screens were only visible as small grey text under the line, so the customer read
the whole job as dearer per shirt than it is — a $140 setup spread across 100
pieces looks like $1.40 on every shirt unless you say otherwise. That is the
whole argument for billing screens once instead of amortising them, and the
quote was hiding it.

**The rows SPLIT the subtotal, they do not add to it.** Screens are already
inside every line total, so a screens row that also added would overstate the job
by its own value — $140 here — and it would be the customer-facing number that
was wrong. `goods` is `sub - scrTotal`; the subtotal itself is untouched.

The count comes from the addon line's own `count` field, which exists precisely
so no surface has to divide a total by a rate. That division would silently lie
the moment a rate changed between quoting and rendering.

## Tests

300/300, three new:

- **`server.js parses`** — runs `node --check`. While writing this I put
  backticks around a word in a comment that lives inside the quote-page template
  literal, which **ended the literal** and broke the file; the error surfaced 900
  lines further down at an unrelated statement. This is the tokenizer that
  `template-literal-leak.test.js` says would be needed to catch the class
  generically — for anything that terminates the literal, `--check` is exactly
  it. Verified by reintroducing a stray backtick: the test fails, then passes on
  revert.
- the split subtracts rather than adds
- the screens count is read, not divided back out

## What I did NOT do

- The customer-facing quote view (`/q/:code`) is a separate template and still
  shows screens inside the line. Worth the same treatment; not in this PR.
- Could not exercise `/quote/new` end to end — it needs an admin session. The
  arithmetic and the markup are asserted from source.

## To check by hand

Open a quote with a screen-print line, tick **Dark garment**, pick **Front +
back**, and confirm the totals show `Screens — 4 × $35.00` and that
Garments & printing + Screens equals the Subtotal exactly. Then switch the line
to DTF and confirm both rows disappear.