### PR TITLE
Deepen the garment volume curve and add the 100 and 250 steps

### DIFF
--- a/docs/pricing-2026.md
+++ b/docs/pricing-2026.md
@@ -206,12 +206,31 @@ Blanks sell at **cost × 2**, applied to the cheapest core size (S/M/L/XL) by
 
 Volume breaks come off that list price, in `BLANK_TIERS` in `server.js`:
 
-| from | off |
-| --- | --- |
-| 35 | 2% |
-| 500 | 3% |
-| 1,000 | 5% |
-| 3,000 | 8% |
+| from | off | garment multiple |
+| --- | --- | --- |
+| 35 | 3% | 1.94× |
+| 100 | 5% | 1.90× |
+| 250 | 7% | 1.86× |
+| 500 | 8% | 1.84× |
+| 1,000 | 9% | 1.82× |
+| 3,000 | 10% | 1.80× |
+
+**Deepened 2026-08-30, and the 100 and 250 steps added.** The curve previously ran
+35 → 2% and then nothing until 500, so a 100-piece and a 250-piece order — the two
+commonest sizes in the shop — were discounted the same as a 35-piece one. A flat
+stretch across the busiest part of the range is a worse fault than a shallow rate:
+it is the orders you quote most often that it fails to move on.
+
+10% at the top is a ceiling, not a round number. It puts the garment at **1.80×
+cost**, which is the floor enforced by `quote-blank-pricing.test.js`. The curve
+and the guard are now the same number by design, so going deeper means moving
+both, on purpose. That floor was tightened to 1.8× on 2026-08-29, away from the
+1.60× an earlier curve reached.
+
+**Keep the size of this lever in view.** The garment is about 40% of a decorated
+job, so the whole move from 2% to 10% is worth about **17¢ a piece at 100** —
+$13.83 → $13.66. If a quote needs to look visibly cheaper, the print table and the
+$35 screen fee are where that lives, not here.
 
 **These are FLOORS** (`qty >= min`), the opposite convention to the decoration
 tables above, whose keys are band CEILINGS. Read one as the other and every band

--- a/server.js
+++ b/server.js
@@ -3175,10 +3175,12 @@ function deliveryEstimate(from = new Date()) {
  * the reason this comment exists.
  */
 const BLANK_TIERS = [
-  { min: 3000, pct: 8 },
-  { min: 1000, pct: 5 },
-  { min:  500, pct: 3 },
-  { min:   35, pct: 2 },
+  { min: 3000, pct: 10 },
+  { min: 1000, pct:  9 },
+  { min:  500, pct:  8 },
+  { min:  250, pct:  7 },
+  { min:  100, pct:  5 },
+  { min:   35, pct:  3 },
 ];
 
 /* Below this the garment is flat cost x2 with no volume break at all — honest
@@ -3196,6 +3198,22 @@ const BLANK_TIERS = [
    not sold below 50, so 35-49 is DTF, embroidery and HTV — the jobs where the
    decoration is dearest per piece and the quote is most likely to be compared
    against a shop that does not mind a thin garment margin.
+
+   Deepened 2026-08-30 to 3/5/7/8/9/10, and the 100 and 250 steps ADDED. The
+   curve previously ran 35 -> 2% and then nothing until 500, so a 100-piece and a
+   250-piece order — the two commonest sizes in the shop — were discounted the
+   same as a 35-piece one. A flat stretch across the busiest part of the range is
+   a worse fault than a shallow rate, because it is the orders you quote most
+   often that it fails to move on.
+
+   10% at the top is the ceiling, not a round number: it puts the garment at
+   1.80x cost, which is the floor the guard in quote-blank-pricing.test.js
+   enforces. Going deeper means lowering that floor deliberately, and it was
+   tightened to 1.8x on 2026-08-29 away from the 1.60x an earlier curve reached.
+   Do not walk it back as a side effect of "be more competitive" — the garment is
+   about 40% of a decorated job, so the whole 2%-to-10% move is worth about 17
+   cents a piece at 100. The print table and the screen fee are where a visible
+   price change actually lives.
 
    DERIVED from the table, never written twice. This was a hand-kept 125 while
    the table said 125 in its own row — two copies of one threshold, and nothing

--- a/tests/quote-blank-pricing.test.js
+++ b/tests/quote-blank-pricing.test.js
@@ -89,7 +89,7 @@ test('the agreed curve is the one in the code', () => {
      break and was being hand-overridden on each quote instead; 35 then extends
      it to the small runs, which are DTF/embroidery/HTV since screen print is
      not sold below 50. */
-  for (const [qty, pct] of [[35, 2], [100, 2], [500, 3], [1000, 5], [3000, 8]]) {
+  for (const [qty, pct] of [[35, 3], [100, 5], [250, 7], [500, 8], [1000, 9], [3000, 10]]) {
     assert.strictEqual(blankDiscountPct(qty), pct, `${qty} pieces should be ${pct}% off`);
   }
 });
@@ -97,8 +97,12 @@ test('the agreed curve is the one in the code', () => {
 /* ── Floors, not ceilings ───────────────────────────────────────────────── */
 
 test('a floor applies AT its quantity, not one piece later', () => {
-  assert.strictEqual(blankDiscountPct(35), 2);
+  assert.strictEqual(blankDiscountPct(35), 3);
   assert.strictEqual(blankDiscountPct(34), 0);
+  assert.strictEqual(blankDiscountPct(100), 5);
+  assert.strictEqual(blankDiscountPct(99), 3);
+  assert.strictEqual(blankDiscountPct(250), 7);
+  assert.strictEqual(blankDiscountPct(249), 5);
 });
 
 test('below the minimum the garment is flat cost x2, with no break at all', () => {
@@ -110,17 +114,17 @@ test('below the minimum the garment is flat cost x2, with no break at all', () =
 });
 
 test('the band holds until the next floor', () => {
-  assert.strictEqual(blankDiscountPct(499), 2);
-  assert.strictEqual(blankDiscountPct(500), 3);
-  assert.strictEqual(blankDiscountPct(999), 3);
-  assert.strictEqual(blankDiscountPct(1000), 5);
+  assert.strictEqual(blankDiscountPct(499), 7);
+  assert.strictEqual(blankDiscountPct(500), 8);
+  assert.strictEqual(blankDiscountPct(999), 8);
+  assert.strictEqual(blankDiscountPct(1000), 9);
 });
 
 test('the largest applicable discount wins, not the smallest', () => {
   /* 5000 clears every floor in the table. Returning 3% here is the missing
      -break bug, and it is invisible in the output. */
-  assert.strictEqual(blankDiscountPct(5000), 8);
-  assert.strictEqual(blankDiscountPct(1000), 5);
+  assert.strictEqual(blankDiscountPct(5000), 10);
+  assert.strictEqual(blankDiscountPct(1000), 9);
 });
 
 test('below the first floor there is no discount at all', () => {
@@ -140,15 +144,21 @@ test('a nonsense quantity is not a discount', () => {
 test('the garment price drops by exactly the tier', () => {
   assert.strictEqual(blankPriceFor(5.64, 12), 5.64);    // Gildan 5000, no break
   assert.strictEqual(blankPriceFor(5.64, 34), 5.64);    // still none, one under the floor
-  assert.strictEqual(blankPriceFor(5.64, 35), 5.53);    // 2%, at the floor
-  assert.strictEqual(blankPriceFor(5.64, 1000), 5.36);  // 5%
-  assert.strictEqual(blankPriceFor(5.64, 3000), 5.19);  // 8%
+  assert.strictEqual(blankPriceFor(5.64, 35), 5.47);    // 3%, at the floor
+  assert.strictEqual(blankPriceFor(5.64, 100), 5.36);   // 5%
+  assert.strictEqual(blankPriceFor(5.64, 250), 5.25);   // 7%
+  assert.strictEqual(blankPriceFor(5.64, 1000), 5.13);  // 9%
+  assert.strictEqual(blankPriceFor(5.64, 3000), 5.08);  // 10%, the 1.80x floor
 });
 
 test('the garment never sells below cost x1.8 on this curve', () => {
   /* The guard the curve exists inside. Cost is flat, so a deep discount walks
-     the multiple down with nothing recovering it; 8% at the top keeps the
-     garment at 1.84x rather than the 1.60x the previous curve reached. */
+     the multiple down with nothing recovering it.
+     The curve now sits exactly ON this floor: 10% at the top puts the garment at
+     1.80x, so the deepest tier and the guard are the same number by design and
+     the next deepening has to move BOTH, deliberately. It was tightened to 1.8x
+     on 2026-08-29 away from the 1.60x an earlier curve reached — do not walk
+     that back as a side effect of making a quote look cheaper. */
   const cost = 2.82, retail = 5.64;   // Gildan 5000, the shop's volume seller
   for (const q of [1, 35, 500, 1000, 3000, 99999]) {
     assert.ok(blankPriceFor(retail, q) / cost >= 1.8,


### PR DESCRIPTION
## What changed

`BLANK_TIERS` — two new steps, and every rate deepened:

| from | was | now | garment multiple |
| --- | --- | --- | --- |
| 35 | 2% | **3%** | 1.94× |
| **100** | — | **5%** | 1.90× |
| **250** | — | **7%** | 1.86× |
| 500 | 3% | **8%** | 1.84× |
| 1,000 | 5% | **9%** | 1.82× |
| 3,000 | 8% | **10%** | 1.80× |

## Why the missing steps mattered more than the rate

The curve ran `35 → 2%` and then **nothing until 500**. A 100-piece and a
250-piece order — the two commonest sizes in the shop — were discounted exactly
like a 35-piece one. A flat stretch across the busiest part of the range is a
worse fault than a shallow rate, because it is the orders you quote most often
that it fails to move on. That gap is why the last quote got a hand-typed
garment override instead of a discount.

## Effect, 1 colour front + back on a dark Gildan 5000

| qty | was | now | margin |
| --- | --- | --- | --- |
| 50 | $16.03 | $15.97 | 49.8% |
| 100 | $13.83 | **$13.66** | 49.3% |
| 250 | $12.19 | **$11.91** | 49.0% |
| 500 | $11.15 | **$10.87** | 48.3% |
| 1,000 | $10.30 | **$10.07** | 48.0% |

Costs $17 of profit on a 100-piece job, $140 on 500. Margin stays above 48%
everywhere.

## The ceiling, and why it is where it is

10% is not a round number — it puts the garment at **1.80× cost**, which is
exactly the floor `quote-blank-pricing.test.js` enforces. The curve and the guard
are now the same number *by design*, so the next deepening has to move both, on
purpose. That floor was tightened to 1.8× on **2026-08-29**, away from the 1.60×
an earlier curve reached; this PR deliberately does not walk that back.

A 1.60× curve (4/8/12/15/18/20%) was modelled and rejected here: it buys $0.74/pc
at 1,000 pieces and costs **$740** of profit on that one job. Worth doing as an
explicit decision, not as a side effect of "be more competitive."

## Keep the size of this lever in view

The garment is about **40% of a decorated job**. The entire move from 2% to 10%
is worth **17¢ a piece at 100 pieces**. If a quote needs to look visibly cheaper,
the print table and the $35 screen fee are where that lives — this curve cannot
get there on its own, and it is worth saying so before the next round of
discounting aims at the wrong number.

## Tests

300/300. Tier assertions updated throughout, plus new boundary cases at the two
added steps (99/100 and 249/250). The 1.8× guard now passes *on* the boundary
rather than comfortably inside it — which is the intent, and its comment says so.