### PR TITLE
Screen fee $35 to $25, and pin it to the tests

### DIFF
--- a/docs/pricing-2026.md
+++ b/docs/pricing-2026.md
@@ -139,10 +139,17 @@ Print line, per piece, 1 colour:
 | 1000–2499 | $1.17 | $2.40 | $1.23 | 51.2% |
 | 2500–7000 | $0.99 | $2.00 | $1.01 | 50.5% |
 
-The screen add-on is the **thinnest margin in the system**: bill $35, cost $20,
-so $15 a screen at 42.9%. It therefore dilutes a job rather than carrying it —
-but it never drags one below break-even, and the fixed cost now lands on the
-order that caused it instead of on every piece.
+The screen add-on is the **thinnest margin in the system by a distance**: bill
+$25, cost $20, so $5 a screen at **20%**. It is close enough to cost to be near
+pass-through, and that is deliberate — the setup charge is the line a customer
+compares first, and it is what makes a small run look expensive.
+
+**Cut from $35 to $25 on 2026-08-30.** Where it costs is many-colour work, because
+the screen count scales with colours *and* locations: a 7-colour two-location dark
+job burns 16 screens, so the cut is **$160 on that one job** and takes it to 39%
+margin — the lowest any job shape reaches. On the shop's ordinary work it is $20
+to $60 a job. If screen-heavy orders become common, **raise this before touching
+the print table**: 16 screens move a total far faster than a per-piece rate does.
 
 Whole job, decoration only — the blank is a separate line with its own markup:
 
@@ -160,9 +167,11 @@ invoice and nothing else. Still to come out of it: the blank, art and setup
 labour, inbound freight, and card fees (~2.9% + $0.30). Treat 49–52% as the
 ceiling, not the take.
 
-**Worth revisiting:** $35 a screen is the weakest line here. $40 would put it at
-50% and bring it in line with everything else. That is a pricing decision, not a
-bug, so it has not been changed.
+**Where the fee could go.** $25 → 20%, $28 → 28.6%, $30 → 33.3%, $35 → 42.9%.
+The rate lives in `ADDONS` in `server.js`, is mirrored in
+`tools/reprice-anchorfish-2026.js` for the record, and both are pinned by
+`tests/screen-fees.test.js` — including the customer-facing note text, so a stale
+price cannot be left sitting next to a live one.
 
 ## Why the old table was wrong
 

--- a/server.js
+++ b/server.js
@@ -3293,9 +3293,18 @@ const ADDONS = [
      black, two locations) is four screens: that add-on recovered $25 against
      $80 of screens actually bought. The count now comes from screenCount() in
      quotePricingSource(), so the fee and the screens ordered are one number. */
+  /* $25 from 2026-08-30, down from $35. Anchorfish charges $20, so this is a
+     20% margin — by a distance the thinnest line in the system, and close
+     enough to cost that it is now near pass-through. That is the intent: the
+     setup charge is what a customer compares first and it is what makes a
+     small run look expensive. It costs most on many-colour work, where the
+     screen count is high: a 7-colour two-location dark job burns 16 screens,
+     so the cut is $160 on that one job and takes it to 39% margin, the lowest
+     any shape reaches. If screen-heavy work becomes common, raise this before
+     touching the print table. */
   { code: 'screens', label: 'Screens', appliesTo: SCREEN_METHOD_RE,
-    kind: 'per_screen', rate: 35, auto: 'method',
-    note: 'A screen is burned once and then runs the whole job, so it is billed once — not per shirt. (Colours + 1 on a dark garment) x locations, at $35 each.' },
+    kind: 'per_screen', rate: 25, auto: 'method',
+    note: 'A screen is burned once and then runs the whole job, so it is billed once — not per shirt. (Colours + 1 on a dark garment) x locations, at $25 each.' },
   { code: 'specialty_ink', label: 'Specialty ink (metallic, glitter, waterbase, discharge)',
     appliesTo: SCREEN_METHOD_RE, kind: 'per_piece', rate: 1.50 },
   { code: 'unbagging', label: 'Unbagging', appliesTo: SCREEN_METHOD_RE,

--- a/tests/screen-fees.test.js
+++ b/tests/screen-fees.test.js
@@ -66,7 +66,7 @@ const text = vm.runInThisContext(lift('quotePricingSource') + '\nquotePricingSou
 const { priceLine, addonAmount, screenCount } =
   vm.runInThisContext(text + '\n({ priceLine, addonAmount, screenCount })');
 
-const SCREEN_FEE = 35;
+const SCREEN_FEE = 25;
 const screensAddon = { code: 'screens', label: 'Screens', kind: 'per_screen', rate: SCREEN_FEE };
 
 /* Method #22 as the catalogue holds it: one `color` table, bands as CEILINGS.
@@ -105,7 +105,7 @@ test('invoice #16899: white on black, two locations, is four screens', () => {
   /* 62 shirts. Anchorfish charged 4 screens at $20 = $80 of cost. The retired
      flat-$25 underbase add-on recovered $25 of that. */
   assert.strictEqual(screenCount(1, 2, true), 4);
-  assert.strictEqual(screenCount(1, 2, true) * SCREEN_FEE, 140);
+  assert.strictEqual(screenCount(1, 2, true) * SCREEN_FEE, 100);
 });
 
 test('junk colour or location counts floor at one, never zero', () => {
@@ -121,8 +121,9 @@ test('junk colour or location counts floor at one, never zero', () => {
 /* ── addonAmount ─────────────────────────────────────────────────────────── */
 
 test('per_screen bills rate x screens, and ignores quantity', () => {
-  assert.strictEqual(addonAmount(screensAddon, 50, 3, 0, 6), 210);
-  assert.strictEqual(addonAmount(screensAddon, 5000, 3, 0, 6), 210, 'quantity must not enter it');
+  assert.strictEqual(addonAmount(screensAddon, 50, 3, 0, 6), 6 * SCREEN_FEE);
+  assert.strictEqual(addonAmount(screensAddon, 5000, 3, 0, 6), 6 * SCREEN_FEE,
+    'quantity must not enter it');
 });
 
 test('a missing screen count falls back to one per colour, not to zero', () => {
@@ -157,7 +158,7 @@ test('priceLine derives locations from the same stage it priced the print off', 
 test('a dark two-sided job bills every screen it burns', () => {
   const r = line({ qty: 62, colours: 1, stage: 'both', dark: true });
   assert.strictEqual(r.screens, 4);
-  assert.strictEqual(r.addonTotal, 140);
+  assert.strictEqual(r.addonTotal, 4 * SCREEN_FEE);
 });
 
 test('the line reports the counts it charged, so a surface can show them', () => {
@@ -227,4 +228,23 @@ test('the reprice tool prices print only — screens are not folded back in', ()
         `${c} colour at the ${f} band should be print-only $${AGREED[c][i].toFixed(2)}`);
     });
   }
+});
+
+/* This file has always defined its own SCREEN_FEE and priced against that, so
+ * every assertion above would still pass if server.js quietly billed a different
+ * number. The fee is the most-compared line on a quote and the thinnest margin
+ * in the system; it should not be possible to move it without a test saying so.
+ */
+test('the fee this file tests is the fee server.js actually charges', () => {
+  const m = src.match(/code: 'screens'[\s\S]{0,200}?rate: (\d+(?:\.\d+)?)/);
+  assert.ok(m, "could not find the screens add-on's rate in server.js");
+  assert.strictEqual(Number(m[1]), SCREEN_FEE,
+    `server.js bills $${m[1]} a screen but this file tests $${SCREEN_FEE}. ` +
+    'Change both, and docs/pricing-2026.md with them.');
+});
+
+test('the customer-facing note quotes the same fee', () => {
+  assert.ok(src.includes('at $' + SCREEN_FEE + ' each.'),
+    `the screens note must say "at $${SCREEN_FEE} each" — a note that quotes a ` +
+    'stale price is read by the customer and contradicts the number beside it');
 });

--- a/tools/reprice-anchorfish-2026.js
+++ b/tools/reprice-anchorfish-2026.js
@@ -116,7 +116,7 @@ const SP = {
    sell price has to be changed in the same breath as the cost that justifies
    it. The charge itself is applied by the `screens` add-on in server.js. */
 const SCREEN_COST = 20;   // what Anchorfish charges us, per screen
-const SCREEN_FEE  = 35;   // what we bill, per screen, ONCE per order
+const SCREEN_FEE  = 25;   // what we bill, per screen, ONCE per order (was 35 to 2026-08-30)
 
 /* Anchorfish prices 5, 6 and 7 colours separately; the designer had one
    combined "5-6 Colors" method, which had to quote one of them wrong. */


### PR DESCRIPTION
## What changed

Screen fee **$35 → $25**, in all three places it is written: the live `ADDONS`
rate in `server.js`, the customer-facing note beside it, and the record in
`tools/reprice-anchorfish-2026.js`.

## What it costs

Anchorfish charges $20, so this is **$5 a screen — a 20% margin**, by a distance
the thinnest line in the system and close enough to cost to be near pass-through.
That is the point: the setup charge is the line a customer compares first, and it
is what makes a small run look expensive.

| job | screens | at $35 | at $25 | you give up | margin |
| --- | --- | --- | --- | --- | --- |
| 50pc, 1 col, 1 loc, dark | 2 | $536 | $516 | $20 | 47.5% |
| 100pc, 1 col, 2 loc, dark | 4 | $1,366 | $1,326 | $40 | 47.8% |
| 250pc, 2 col, 2 loc, dark | 6 | $3,048 | $2,988 | $60 | 47.8% |
| 500pc, 1 col, 2 loc, dark | 4 | $5,435 | $5,395 | $40 | 47.9% |
| **50pc, 7 col, 2 loc, dark** | **16** | $1,219 | $1,059 | **$160** | **39.4%** |

On ordinary work it is $20–$60 a job. **Where it bites is many-colour work**,
because the screen count scales with colours *and* locations — 16 screens on a
7-colour two-location dark job, which lands at 39% margin, the lowest any shape
reaches. Flagging rather than blocking: if screen-heavy orders become common,
raise this before touching the print table, because 16 screens move a total far
faster than a per-piece rate does. Noted in the code and the doc.

## The gap this closed

`tests/screen-fees.test.js` defined **its own** `SCREEN_FEE = 35` and priced every
assertion against that constant — it never read the rate out of `server.js`. The
live charge could have been changed to anything with the whole suite still green.

Two new tests:

- the rate in `server.js`'s `screens` add-on equals the fee the tests price
  against
- the customer-facing note quotes the same number, so a stale price cannot sit
  next to a live one on the quote a customer reads

Verified by setting the live rate to $30 with the tests still at $25: the pin
fails, and passes again on revert.

## Tests

302/302.