### PR TITLE
Show every size, in order, on the customer quote

### DIFF
--- a/server.js
+++ b/server.js
@@ -4453,10 +4453,12 @@ ${quotePricingSource()}
         document.querySelectorAll('.line').forEach(function(L, ix){
           var r = REQUESTED[ix];
           if (!r) return;
-          if (r.size_mix) {
+          if (Array.isArray(r.sizes)) {
+            var want = {};
+            r.sizes.forEach(function(e){ if (e && e.size) want[e.size] = e.n || 0; });
             L.querySelectorAll('.sz').forEach(function(el){
-              if (Object.prototype.hasOwnProperty.call(r.size_mix, el.dataset.size)) {
-                el.value = r.size_mix[el.dataset.size] || 0;
+              if (Object.prototype.hasOwnProperty.call(want, el.dataset.size)) {
+                el.value = want[el.dataset.size];
               }
             });
           } else {
@@ -5394,6 +5396,42 @@ app.post(['/api/quotes', '/api/quotes/:code'], requireAdmin, async (req, res) =>
 });
 
 /* What the customer opens. Public, no login. Reads like an invoice. */
+/* Sizes a line can be edited across, in the order a person expects to read them.
+ *
+ * TWO reasons this cannot come from `size_mix`:
+ *
+ *   1. **Postgres JSONB does not preserve key order.** It normalises objects by
+ *      key length then bytewise, so a mix saved as {S,M,L,XL} is read back as
+ *      {L,M,S,XL}. The customer page showed sizes shuffled for exactly this
+ *      reason. Anything that must stay ordered through JSONB has to be an ARRAY.
+ *   2. `size_mix` only ever held sizes with a count above zero, so a customer
+ *      could not add a size the original order did not have — no way to ask for
+ *      two 2XLs when the quote was all mediums.
+ *
+ * So the list comes from the catalogue product, which carries every size it is
+ * sold in, in catalogue order. The fallback matters: the catalogue is fetched
+ * over the network and can be empty, and a product can be retired out from under
+ * an old quote. Then we show what the line itself carries, sorted into a sane
+ * order rather than JSONB's.
+ */
+const SIZE_ORDER = ['XS', 'S', 'M', 'L', 'XL', '2XL', '3XL', '4XL', '5XL', '6XL'];
+
+function orderedSizeKeys(item, catalog) {
+  const prods = (catalog && catalog.products) || [];
+  const prod = prods.find((p) => String(p.id) === String(item && item.product_id));
+  if (prod && Array.isArray(prod.sizes) && prod.sizes.length) {
+    return prod.sizes.map((s) => s.size);
+  }
+  const own = Object.keys((item && item.size_mix) || {});
+  return own.slice().sort((a, b) => {
+    const ia = SIZE_ORDER.indexOf(a), ib = SIZE_ORDER.indexOf(b);
+    if (ia === -1 && ib === -1) return own.indexOf(a) - own.indexOf(b);
+    if (ia === -1) return 1;
+    if (ib === -1) return -1;
+    return ia - ib;
+  });
+}
+
 app.get('/q/:code', async (req, res) => {
   const code = String(req.params.code || '').toUpperCase();
   const friendly = (msg) => res.status(404).send(quotePage('Quote not found', `
@@ -5413,6 +5451,11 @@ app.get('/q/:code', async (req, res) => {
     }
 
     const t = quoteTotals(q);
+    /* Only for the size list. It is cached and it can come back empty, so every
+       use of it falls back to what the line already carries — a public page must
+       not depend on a network fetch to render. */
+    let catalog = { products: [], methods: [] };
+    try { catalog = await getCatalog(); } catch { /* fall back to the line */ }
     const expired = q.valid_until && new Date(q.valid_until) < new Date(new Date().toDateString());
     const accepted = !!q.accepted_at;
     const paid = Number(q.paid_amount || 0) > 0;
@@ -5442,13 +5485,18 @@ app.get('/q/:code', async (req, res) => {
        as if it had. */
     const canEditQty = !accepted && !paid;
 
-    const sizeInputs = (i, ix) => Object.entries(i.size_mix)
-      .map(([sz, n]) => `<label style="display:inline-flex;flex-direction:column;align-items:center;gap:2px;font-size:11px;color:#6b7280">
+    /* Every size the garment comes in, in catalogue order — not just the ones
+       already ordered. A customer whose quote is all mediums has to be able to
+       ask for two 2XLs, and a size they did not order starts at 0. */
+    const sizeInputs = (i, ix) => orderedSizeKeys(i, catalog)
+      .map((sz) => {
+        const n = parseInt((i.size_mix || {})[sz], 10) || 0;
+        return `<label style="display:inline-flex;flex-direction:column;align-items:center;gap:2px;font-size:11px;color:${n ? '#6b7280' : '#9aa3b2'}">
           ${escEmail(sz)}
           <input form="changeform" type="number" min="0" max="10000" step="1"
-                 name="sz_${ix}_${escEmail(sz)}" value="${parseInt(n, 10) || 0}"
-                 style="width:52px;padding:4px;font-size:13px;text-align:center"></label>`)
-      .join(' ');
+                 name="sz_${ix}_${escEmail(sz)}" value="${n}"
+                 style="width:52px;padding:4px;font-size:13px;text-align:center"></label>`;
+      }).join(' ');
 
     const lines = (q.items || []).map((i, ix) => {
       const imgs = (i.images || []).filter(u => /^https:\/\//.test(u));
@@ -5467,7 +5515,7 @@ app.get('/q/:code', async (req, res) => {
           ${gallery}
         </td>
         <td class="num">${!canEditQty ? i.qty
-          : i.size_mix && Object.keys(i.size_mix).length
+          : orderedSizeKeys(i, catalog).length
             ? `<div style="display:flex;gap:5px;flex-wrap:wrap;justify-content:flex-end">${sizeInputs(i, ix)}</div>
                <div class="muted" style="font-size:11px;margin-top:4px">now ${i.qty}</div>`
             : `<input form="changeform" type="number" min="0" max="10000" step="1"
@@ -6258,13 +6306,17 @@ function describeRequestedEdits(items, requested) {
   (requested || []).forEach((r, ix) => {
     const it = (items || [])[ix];
     if (!it || !r) return;
+    /* The requested sizes are an ordered array; the quote's own mix is an object
+       whose key order JSONB has already scrambled. So the ARRAY drives both the
+       comparison and the order it is reported in, and a size the original order
+       did not contain reads as 0 -> n rather than being skipped. */
     const sizes = [];
-    if (r.size_mix && it.size_mix) {
-      for (const sz of Object.keys(it.size_mix)) {
-        const was = parseInt(it.size_mix[sz], 10) || 0;
-        const now = parseInt(r.size_mix[sz], 10) || 0;
-        if (was !== now) sizes.push({ size: sz, was, now });
-      }
+    for (const entry of (Array.isArray(r.sizes) ? r.sizes : [])) {
+      const sz = entry && entry.size;
+      if (!sz) continue;
+      const was = parseInt((it.size_mix || {})[sz], 10) || 0;
+      const now = parseInt(entry.n, 10) || 0;
+      if (was !== now) sizes.push({ size: sz, was, now });
     }
     const wasQty = parseInt(it.qty, 10) || 0;
     const nowQty = parseInt(r.qty, 10) || 0;
@@ -6302,28 +6354,41 @@ app.post('/q/:code/changes', orderRateLimit, async (req, res) => {
     const items = Array.isArray(q.items) ? q.items : [];
     const editable = !q.accepted_at;
     let requested = null;
+    /* The same list the customer's page rendered from, derived the same way, so
+       the names posted and the names read are the same set by construction. */
+    let catalog = { products: [], methods: [] };
+    try { catalog = await getCatalog(); } catch { /* fall back to the line */ }
 
     if (editable) {
       const draft = items.map((it, ix) => {
-        /* Sizes are read from the LINE, never from what was posted, so a
-           fabricated size key cannot enter the quote — the form is public and
-           the only thing standing in front of it is a six-character code. */
-        if (it.size_mix && Object.keys(it.size_mix).length) {
-          const mix = {}; let total = 0;
-          for (const sz of Object.keys(it.size_mix)) {
+        /* Size keys are derived SERVER-side — from the catalogue product, or
+           failing that from the line — and each one is then looked up in the
+           body by name. The body is never enumerated: this endpoint is public
+           and the only thing in front of it is a six-character code, so a
+           request naming sz_0_FREE must not be able to invent a size on a
+           priced quote.
+
+           Stored as an ARRAY, not an object. Postgres JSONB normalises object
+           key order, so a mix saved {S,M,L,XL} reads back {L,M,S,XL} — which is
+           what shuffled the sizes on the customer's page. An array keeps the
+           order it was written in. */
+        const keys = orderedSizeKeys(it, catalog);
+        if (keys.length) {
+          const sizes = []; let total = 0;
+          for (const sz of keys) {
             const raw = one(b['sz_' + ix + '_' + sz]);
             const n = raw === undefined || String(raw).trim() === ''
-              ? (parseInt(it.size_mix[sz], 10) || 0)
+              ? (parseInt((it.size_mix || {})[sz], 10) || 0)
               : Math.max(0, Math.min(10000, parseInt(raw, 10) || 0));
-            mix[sz] = n; total += n;
+            sizes.push({ size: sz, n }); total += n;
           }
-          return { qty: total, size_mix: mix };
+          return { qty: total, sizes };
         }
         const raw = one(b['qty' + '_' + ix]);
         const n = raw === undefined || String(raw).trim() === ''
           ? (parseInt(it.qty, 10) || 0)
           : Math.max(0, Math.min(10000, parseInt(raw, 10) || 0));
-        return { qty: n, size_mix: null };
+        return { qty: n, sizes: null };
       });
 
       /* Store only if something moved. An untouched form posts every current

--- a/tests/quote-customer-edits.test.js
+++ b/tests/quote-customer-edits.test.js
@@ -46,6 +46,13 @@ function lift(name) {
 const describeRequestedEdits = vm.runInThisContext(
   lift('describeRequestedEdits') + '\ndescribeRequestedEdits');
 
+/* SIZE_ORDER is a const the function closes over, so it has to be evaluated in
+   the same snippet rather than lifted separately. */
+const SIZE_ORDER_SRC = src.match(/^const SIZE_ORDER = \[[^\]]*\];$/m);
+assert.ok(SIZE_ORDER_SRC, 'SIZE_ORDER not found at module level in server.js');
+const orderedSizeKeys = vm.runInThisContext(
+  SIZE_ORDER_SRC[0] + '\n' + lift('orderedSizeKeys') + '\norderedSizeKeys');
+
 const line = (over) => Object.assign(
   { description: 'Gildan 5000', qty: 100, size_mix: { S: 10, M: 30, L: 40, XL: 20 } }, over);
 
@@ -57,13 +64,15 @@ test('an untouched request is not a change', () => {
      board would light up with requests that ask for nothing, and the alert would
      stop being read. */
   const items = [line()];
-  const same = [{ qty: 100, size_mix: { S: 10, M: 30, L: 40, XL: 20 } }];
+  const same = [{ qty: 100, sizes: [
+    { size: 'S', n: 10 }, { size: 'M', n: 30 }, { size: 'L', n: 40 }, { size: 'XL', n: 20 }] }];
   assert.deepStrictEqual(describeRequestedEdits(items, same), []);
 });
 
 test('a changed size is reported with both numbers', () => {
   const items = [line()];
-  const asked = [{ qty: 106, size_mix: { S: 10, M: 36, L: 40, XL: 20 } }];
+  const asked = [{ qty: 106, sizes: [
+    { size: 'S', n: 10 }, { size: 'M', n: 36 }, { size: 'L', n: 40 }, { size: 'XL', n: 20 }] }];
   const out = describeRequestedEdits(items, asked);
   assert.strictEqual(out.length, 1);
   assert.deepStrictEqual(out[0].sizes, [{ size: 'M', was: 30, now: 36 }]);
@@ -75,14 +84,15 @@ test('a size dropped to zero is a change, not an absence', () => {
   /* Removing a size is the commonest real edit — "no smalls after all" — and
      0 is falsy, so it is exactly the value a lazy check loses. */
   const items = [line()];
-  const asked = [{ qty: 90, size_mix: { S: 0, M: 30, L: 40, XL: 20 } }];
+  const asked = [{ qty: 90, sizes: [
+    { size: 'S', n: 0 }, { size: 'M', n: 30 }, { size: 'L', n: 40 }, { size: 'XL', n: 20 }] }];
   const out = describeRequestedEdits(items, asked);
   assert.deepStrictEqual(out[0].sizes, [{ size: 'S', was: 10, now: 0 }]);
 });
 
 test('a line with no sizes reports its quantity alone', () => {
   const items = [line({ size_mix: null, qty: 12 })];
-  const out = describeRequestedEdits(items, [{ qty: 24, size_mix: null }]);
+  const out = describeRequestedEdits(items, [{ qty: 24, sizes: null }]);
   assert.strictEqual(out.length, 1);
   assert.deepStrictEqual(out[0].sizes, []);
   assert.strictEqual(out[0].wasQty, 12);
@@ -92,8 +102,9 @@ test('a line with no sizes reports its quantity alone', () => {
 test('only the lines that moved are reported', () => {
   const items = [line(), line({ description: 'Tote', size_mix: null, qty: 50 })];
   const asked = [
-    { qty: 100, size_mix: { S: 10, M: 30, L: 40, XL: 20 } },   // untouched
-    { qty: 75, size_mix: null },                                // moved
+    { qty: 100, sizes: [{ size: 'S', n: 10 }, { size: 'M', n: 30 },
+                        { size: 'L', n: 40 }, { size: 'XL', n: 20 }] },  // untouched
+    { qty: 75, sizes: null },                                            // moved
   ];
   const out = describeRequestedEdits(items, asked);
   assert.strictEqual(out.length, 1);
@@ -105,7 +116,7 @@ test('a request for a line that no longer exists is ignored', () => {
   /* The shop can delete a line between the customer loading the page and
      submitting it. Reading items[ix] blindly would throw inside the alert path
      and lose the whole request. */
-  assert.deepStrictEqual(describeRequestedEdits([], [{ qty: 5, size_mix: null }]), []);
+  assert.deepStrictEqual(describeRequestedEdits([], [{ qty: 5, sizes: null }]), []);
   assert.deepStrictEqual(describeRequestedEdits([line()], [null, null]), []);
 });
 
@@ -114,7 +125,8 @@ test('a stale request reads as no change once the shop has applied it', () => {
      and saving makes the request describe nothing — which is what stops an
      already-handled request from being shown a second time. */
   const applied = [line({ qty: 106, size_mix: { S: 10, M: 36, L: 40, XL: 20 } })];
-  const asked = [{ qty: 106, size_mix: { S: 10, M: 36, L: 40, XL: 20 } }];
+  const asked = [{ qty: 106, sizes: [
+    { size: 'S', n: 10 }, { size: 'M', n: 36 }, { size: 'L', n: 40 }, { size: 'XL', n: 20 }] }];
   assert.deepStrictEqual(describeRequestedEdits(applied, asked), []);
 });
 
@@ -125,8 +137,10 @@ const handler = src.slice(src.indexOf("app.post('/q/:code/changes'"));
 test('size keys come from the line, never from what was posted', () => {
   /* The endpoint is public. Iterating the posted body instead would let a
      request name any key it liked and write it onto a priced quote. */
-  assert.match(handler, /for \(const sz of Object\.keys\(it\.size_mix\)\)/,
-    'the loop must iterate the LINE\'s sizes and look each one up in the body');
+  assert.match(handler, /const keys = orderedSizeKeys\(it, catalog\)/,
+    'the size list must be derived server-side, not read out of the body');
+  assert.match(handler, /for \(const sz of keys\)/,
+    'the loop must iterate that derived list and look each name up in the body');
   assert.match(handler, /one\(b\['sz_' \+ ix \+ '_' \+ sz\]\)/,
     'each size is fetched by name from the body, not enumerated out of it');
 });
@@ -237,4 +251,65 @@ test('one() is a module-level helper, reachable from every handler that reads a 
     'one() must be declared at module level');
   assert.doesNotMatch(src, /^\s+const one = \(v\) =>/m,
     'a local re-declaration shadows the shared helper and invites the same bug back');
+});
+
+/* ── The two bugs the first version shipped ──────────────────────────────── */
+
+test('every size the garment is sold in is offered, not just the ones ordered', () => {
+  /* First version rendered from size_mix, which only ever held sizes with a
+     count above zero. A quote of 100 mediums offered exactly one box, so there
+     was no way to ask for two 2XLs. */
+  const catalog = { products: [{ id: 12, sizes:
+    [{ size: 'S' }, { size: 'M' }, { size: 'L' }, { size: 'XL' }, { size: '2XL' }] }] };
+  const item = { product_id: 12, size_mix: { M: 100 } };
+  assert.deepStrictEqual(orderedSizeKeys(item, catalog), ['S', 'M', 'L', 'XL', '2XL']);
+});
+
+test('sizes come back in catalogue order, not in JSONB order', () => {
+  /* THE bug. Postgres JSONB normalises object keys by length then bytewise, so
+     a mix written {S,M,L,XL} is read back {L,M,S,XL} — which is what the
+     customer saw. The catalogue list is an array and keeps its order. */
+  const catalog = { products: [{ id: 12, sizes:
+    [{ size: 'S' }, { size: 'M' }, { size: 'L' }, { size: 'XL' }] }] };
+  const jsonbScrambled = { product_id: 12, size_mix: { L: 40, M: 30, S: 10, XL: 20 } };
+  assert.deepStrictEqual(orderedSizeKeys(jsonbScrambled, catalog), ['S', 'M', 'L', 'XL']);
+});
+
+test('with no catalogue the line is still sorted into a sane order', () => {
+  /* The catalogue is fetched over the network and can come back empty, and a
+     product can be retired out from under an old quote. Falling back to raw
+     JSONB order would reproduce the bug exactly where it is hardest to notice. */
+  const orphan = { product_id: 999, size_mix: { L: 40, M: 30, S: 10, XL: 20, '2XL': 4 } };
+  assert.deepStrictEqual(orderedSizeKeys(orphan, { products: [] }),
+    ['S', 'M', 'L', 'XL', '2XL']);
+});
+
+test('an unknown size sorts last rather than being dropped', () => {
+  const odd = { product_id: 999, size_mix: { M: 2, Tall: 1, S: 3 } };
+  assert.deepStrictEqual(orderedSizeKeys(odd, { products: [] }), ['S', 'M', 'Tall']);
+});
+
+test('adding a size the order never had reads as 0 to n', () => {
+  /* The point of showing every size. The quote had no 2XL, so the diff has to
+     report it against zero rather than skip it for being absent from the mix. */
+  const items = [{ description: 'Gildan 5000', qty: 100, size_mix: { M: 100 } }];
+  const asked = [{ qty: 102, sizes: [{ size: 'M', n: 100 }, { size: '2XL', n: 2 }] }];
+  const out = describeRequestedEdits(items, asked);
+  assert.deepStrictEqual(out[0].sizes, [{ size: '2XL', was: 0, now: 2 }]);
+  assert.strictEqual(out[0].nowQty, 102);
+});
+
+test('the requested sizes are stored as an array, never as an object', () => {
+  /* An object here would be re-ordered by JSONB on the way to disk and the
+     shop would read the diff in a shuffled order. */
+  assert.match(handler, /sizes\.push\(\{ size: sz, n \}\)/,
+    'the request must be built as an ordered array');
+  assert.doesNotMatch(handler, /return \{ qty: total, size_mix:/,
+    'storing a size object reintroduces the JSONB ordering bug');
+});
+
+test('the diff is driven by the requested array, not by the stored object', () => {
+  const fn = String(describeRequestedEdits);
+  assert.match(fn, /Array\.isArray\(r\.sizes\)/,
+    'order comes from the array; the quote mix is only looked up in');
 });


### PR DESCRIPTION
Both reported faults, one root cause each, found on the first live walkthrough of #60.

## "they aren't in order"

**Postgres JSONB does not preserve object key order.** It normalises keys by
length, then bytewise — so a mix written `{S, M, L, XL}` is read back
`{L, M, S, XL}`. The page was rendering `Object.entries(size_mix)`, so the
customer saw the sizes shuffled, and it would have looked correct in any test
that never round-tripped through the database.

Two changes:

- the size list is now taken from the **catalogue product**, whose `sizes` is an
  array and keeps its order
- what the customer asks for is stored as an **ordered array**
  (`[{size, n}, …]`), not an object, so it survives the trip to disk

## "only shows the sizes I selected"

`size_mix` only ever held sizes with a count above zero. A quote of 100 mediums
rendered exactly one box, so there was no way to ask for two 2XLs. Now every size
the garment is sold in is offered, in catalogue order, with the unordered ones
starting at 0 and greyed until used. A size the original order did not contain
reports as `0 → 2` rather than being skipped.

## The fallback, which is where this would bite again

`getCatalog()` is a cached network fetch and can return empty, and a product can
be retired out from under an old quote. Falling back to raw `size_mix` order
would reproduce the ordering bug exactly where it is hardest to notice, so the
fallback sorts by a canonical `SIZE_ORDER` (XS…6XL, unknown names last, stable).
The customer page never depends on the fetch succeeding.

## Trust boundary unchanged

Size keys are still derived **server-side** — now from the catalogue, previously
from the line — and each is looked up in the body by name. The body is never
enumerated, so a request naming `sz_0_FREE` still cannot invent a size on a
priced quote. Quantities still clamped 0–10000.

## Migration

None needed: `SELECT count(requested_items) FROM quotes` is **0**, so no request
exists in the old object shape. Confirmed against production before changing the
shape.

## Tests

330/330, 7 new — including the JSONB-scrambled input producing catalogue order,
the empty-catalogue fallback sorting correctly, an unknown size sorting last, and
an added size reporting as `0 → n`. Also pinned: the request must be built as an
array, because an object here silently reintroduces the ordering bug.

## To check by hand

Reload the same quote. The boxes should read S, M, L, XL, 2XL… in that order,
with every size present and the ones you did not order showing 0. Add two 2XLs,
submit, and the email should say `2XL 0 → 2 (total 100 → 102)`.