### PR TITLE
Re-price the customer's edits live, and gate accept and pay

### DIFF
--- a/server.js
+++ b/server.js
@@ -5432,6 +5432,51 @@ function orderedSizeKeys(item, catalog) {
   });
 }
 
+/* What the customer's browser needs to re-price their own lines, and NOTHING
+ * else. This is a public page: the catalogue the admin form receives carries a
+ * `cost` field on every product — the shop's supplier cost — and shipping that
+ * to a customer would hand them the margin on their own job.
+ *
+ * So each line is rebuilt from scratch with only the fields priceLine() reads:
+ * the garment's SELL price, its size upcharges, and the decoration's own tier
+ * table. Nothing is copied wholesale, so a field added to the catalogue later
+ * cannot leak by default — it has to be added here deliberately.
+ *
+ * The tier tables are the "buy more, save more" ladder the storefront already
+ * advertises, so they are not a disclosure; the cost basis behind them is, and
+ * it is not here.
+ */
+function customerLinePricing(items, catalog) {
+  const prods = (catalog && catalog.products) || [];
+  const meths = (catalog && catalog.methods) || [];
+  return (items || []).map((it) => {
+    const p = prods.find((x) => String(x.id) === String(it.product_id));
+    const m = meths.find((x) => String(x.id) === String(it.method_id));
+    return {
+      /* Sell price and upcharges only — never `cost`. */
+      product: p ? {
+        price: Number(p.price) || 0,
+        sizes: (p.sizes || []).map((z) => ({ size: z.size, upcharge: Number(z.upcharge) || 0 })),
+      } : null,
+      method: m ? {
+        id: m.id, title: m.title, type: m.type, multi: m.multi,
+        positions: m.positions, colour_options: m.colour_options || null,
+        min_order_qty: m.min_order_qty || 0,
+      } : null,
+      /* The line as it was priced, so an untouched line re-prices to exactly
+         what is already on screen rather than drifting by a rounding step. */
+      stage: it.stage || null,
+      dark: !!it.garment_dark,
+      colours: it.colours || null,
+      addons: (it.addons || []).map((a) => ({
+        code: a.code, label: a.label, kind: a.kind, rate: Number(a.rate) || 0,
+      })),
+      blankOverride: it.blank_price === undefined ? null : it.blank_price,
+      unitOverride: it.manual ? it.unit_price : null,
+    };
+  });
+}
+
 app.get('/q/:code', async (req, res) => {
   const code = String(req.params.code || '').toUpperCase();
   const friendly = (msg) => res.status(404).send(quotePage('Quote not found', `
@@ -5488,14 +5533,27 @@ app.get('/q/:code', async (req, res) => {
     /* Every size the garment comes in, in catalogue order — not just the ones
        already ordered. A customer whose quote is all mediums has to be able to
        ask for two 2XLs, and a size they did not order starts at 0. */
+    const upchargeFor = (i, sz) => {
+      const p = (catalog.products || []).find((x) => String(x.id) === String(i.product_id));
+      const row = p && (p.sizes || []).find((z) => z.size === sz);
+      return row ? Number(row.upcharge) || 0 : 0;
+    };
+
     const sizeInputs = (i, ix) => orderedSizeKeys(i, catalog)
       .map((sz) => {
         const n = parseInt((i.size_mix || {})[sz], 10) || 0;
-        return `<label style="display:inline-flex;flex-direction:column;align-items:center;gap:2px;font-size:11px;color:${n ? '#6b7280' : '#9aa3b2'}">
-          ${escEmail(sz)}
+        const up = upchargeFor(i, sz);
+        /* The extended-size surcharge is shown ON the box the customer types
+           into. Printed once at the bottom of the quote it reads as a mystery
+           difference; printed here it is the answer to "why did adding a 2XL
+           cost more than a medium". */
+        return `<label style="display:inline-flex;flex-direction:column;align-items:center;gap:1px;font-size:11px;color:${n ? '#6b7280' : '#9aa3b2'}">
+          <span>${escEmail(sz)}</span>
+          <span style="font-size:10px;color:${up > 0 ? '#b45309' : 'transparent'}">${up > 0 ? '+' + money(up) : '&nbsp;'}</span>
           <input form="changeform" type="number" min="0" max="10000" step="1"
+                 class="cq" data-line="${ix}"
                  name="sz_${ix}_${escEmail(sz)}" value="${n}"
-                 style="width:52px;padding:4px;font-size:13px;text-align:center"></label>`;
+                 style="width:56px;padding:4px;font-size:13px;text-align:center"></label>`;
       }).join(' ');
 
     const lines = (q.items || []).map((i, ix) => {
@@ -5519,12 +5577,13 @@ app.get('/q/:code', async (req, res) => {
             ? `<div style="display:flex;gap:5px;flex-wrap:wrap;justify-content:flex-end">${sizeInputs(i, ix)}</div>
                <div class="muted" style="font-size:11px;margin-top:4px">now ${i.qty}</div>`
             : `<input form="changeform" type="number" min="0" max="10000" step="1"
+                      class="cq" data-line="${ix}"
                       name="qty_${ix}" value="${parseInt(i.qty, 10) || 0}"
                       style="width:64px;padding:5px;font-size:14px;text-align:right">`}</td>
-        <td class="num">${Number(i.list_total) > Number(i.line_total)
+        <td class="num" data-each="${ix}">${Number(i.list_total) > Number(i.line_total)
           ? `<span style="color:#9aa3b2;text-decoration:line-through">${money(Number(i.list_total) / i.qty)}</span><br>${money(i.unit_price)}`
           : money(i.unit_price)}</td>
-        <td class="num">${Number(i.list_total) > Number(i.line_total)
+        <td class="num" data-amount="${ix}">${Number(i.list_total) > Number(i.line_total)
           ? `<span style="color:#9aa3b2;text-decoration:line-through">${money(i.list_total)}</span><br>
              <b style="color:#166534">${money(i.line_total)}</b>`
           : money(i.line_total)}</td>
@@ -5552,7 +5611,10 @@ app.get('/q/:code', async (req, res) => {
                 q.discount_kind === 'pct' ? ` (${Number(q.discount_value)}% off)` : ''}</td>
               <td class="num" style="color:#166534">&minus;${money(t.discount)}</td></tr>` : ''}
           ${t.tax > 0 ? `<tr><td colspan="3" class="num muted">Sales tax</td><td class="num">${money(t.tax)}</td></tr>` : ''}
-          <tr><td colspan="3" class="num tot">Total</td><td class="num tot">${money(t.total)}</td></tr>
+          <tr><td colspan="3" class="num tot">Total</td><td class="num tot" id="qtotal">${money(t.total)}</td></tr>
+          <tr id="estrow" style="display:none"><td colspan="3" class="num" style="color:#b45309;font-weight:700;padding-top:10px">
+              With your changes <span style="font-weight:400;font-size:12px">(estimate)</span></td>
+              <td class="num" style="color:#b45309;font-weight:700;padding-top:10px" id="esttotal">&mdash;</td></tr>
           ${!paid ? `<tr><td colspan="3" class="num" style="color:#1848B8;font-weight:700">
               ${t.deposit >= t.total ? 'Due now (paid in full)' : 'Deposit to start (50%)'}</td>
               <td class="num" style="color:#1848B8;font-weight:700">${money(t.deposit)}</td></tr>` : `
@@ -5685,6 +5747,86 @@ app.get('/q/:code', async (req, res) => {
       <div class="card" style="text-align:center">
         <p class="muted">Questions? <a href="tel:+17738491854">${SHOP_PHONE}</a> &middot; ${SHOP_SIGNER}</p>
       </div>
+
+      ${canEditQty ? `<script>
+      /* Re-price the customer's own edits, live, using the SAME engine the
+         server runs. Reimplementing the rule here would be the classic pricing
+         bug: two ladders that agree until the day one is changed.
+
+         It is an ESTIMATE and it is labelled as one. The quoted total stays on
+         screen untouched, because that is the figure the shop stands behind;
+         the new number appears beside it in amber. The shop still approves, and
+         Accept and Pay are refused server-side while a request is pending — so
+         a customer cannot bind the shop to a figure nobody at the shop priced. */
+${quotePricingSource()}
+
+      var LINES = ${JSON.stringify(customerLinePricing(q.items || [], catalog))};
+      var QITEMS = ${JSON.stringify((q.items || []).map((i) => ({
+        qty: Number(i.qty) || 0, line_total: Number(i.line_total) || 0,
+        unit_price: Number(i.unit_price) || 0,
+      })))};
+      var BLANK_TIERS = ${JSON.stringify(BLANK_TIERS)};
+      var TAX = ${TAX_RATE}, TAXABLE = ${Number(q.tax) > 0 ? 'true' : 'false'};
+      var DISC_KIND = ${JSON.stringify(q.discount_kind || 'amt')};
+      var DISC_VAL = ${Number(q.discount_value) || 0};
+      function m2(v){ return '$' + (Math.round(v*100)/100).toFixed(2); }
+
+      function estimate(){
+        var moved = false, sub = 0;
+        LINES.forEach(function(L, ix){
+          var boxes = document.querySelectorAll('.cq[data-line="' + ix + '"]');
+          var mix = null, qty = 0;
+          boxes.forEach(function(el){
+            var v = Math.max(0, parseInt(el.value, 10) || 0);
+            if (el.name.indexOf('sz_') === 0) {
+              /* The size is in the field name, which the server built from the
+                 catalogue — not from anything typed here. */
+              var sz = el.name.slice(('sz_' + ix + '_').length);
+              mix = mix || {};
+              if (v > 0) mix[sz] = v;
+              qty += v;
+            } else { qty = v; }
+          });
+          if (qty !== (QITEMS[ix] ? QITEMS[ix].qty : 0)) moved = true;
+
+          var r = priceLine({
+            qty: qty, product: L.product, method: L.method, stage: L.stage,
+            dark: L.dark, colours: L.colours, addons: L.addons,
+            sizeMix: mix, blankTiers: BLANK_TIERS,
+            blankOverride: L.blankOverride, unitOverride: L.unitOverride,
+          });
+          sub += r.lineTotal;
+
+          var each = document.querySelector('[data-each="' + ix + '"]');
+          var amt  = document.querySelector('[data-amount="' + ix + '"]');
+          var same = qty === (QITEMS[ix] ? QITEMS[ix].qty : 0);
+          if (each) each.innerHTML = same ? each.dataset.orig
+            : '<span style="color:#9aa3b2;text-decoration:line-through">' +
+              m2(QITEMS[ix].unit_price) + '</span><br><b style="color:#b45309">' +
+              m2(qty > 0 ? (r.lineTotal - r.addonTotal) / qty : 0) + '</b>';
+          if (amt) amt.innerHTML = same ? amt.dataset.orig
+            : '<span style="color:#9aa3b2;text-decoration:line-through">' +
+              m2(QITEMS[ix].line_total) + '</span><br><b style="color:#b45309">' +
+              m2(r.lineTotal) + '</b>';
+        });
+
+        var row = document.getElementById('estrow');
+        if (!moved) { row.style.display = 'none'; return; }
+        var disc = DISC_VAL <= 0 ? 0
+          : Math.min(DISC_KIND === 'pct' ? sub * DISC_VAL / 100 : DISC_VAL, sub);
+        var net = sub - disc;
+        var total = net + (TAXABLE ? net * TAX : 0);
+        document.getElementById('esttotal').textContent = m2(total);
+        row.style.display = '';
+      }
+
+      document.querySelectorAll('[data-each],[data-amount]').forEach(function(el){
+        el.dataset.orig = el.innerHTML;
+      });
+      document.querySelectorAll('.cq').forEach(function(el){
+        el.addEventListener('input', estimate);
+      });
+      </script>` : ''}
     `));
   } catch (err) {
     console.error('view quote failed:', err.message);
@@ -5706,6 +5848,14 @@ app.get(['/q/:code/pay/card', '/q/:code/pay/balance'], async (req, res) => {
     const { rows } = await pool.query('SELECT * FROM quotes WHERE code=$1', [code]);
     if (!rows.length) return res.redirect('/q/' + code);
     const q = rows[0];
+
+    /* No payment while a change is pending. The customer's page re-prices as
+       they edit, so the number in front of them may not be the number stored —
+       and this route charges from the STORED total. Taking money for a quote
+       the shop has not re-priced is the one failure here that costs a refund
+       and an apology, so the door is shut until the request is cleared. */
+    if (q.requested_items) return res.redirect('/q/' + code + '#changes');
+
     const t = quoteTotals(q);
     const alreadyPaid = Number(q.paid_amount || 0);
     /* Same route serves the deposit and the balance: charging the deposit when
@@ -6213,12 +6363,17 @@ app.post('/q/:code/accept', orderRateLimit, async (req, res) => {
     const cphone = String(rb.phone || '').trim().slice(0, 40) || null;
 
     const { rows } = await pool.query(
+      /* requested_items IS NULL is the money guard. The customer's page
+         re-prices live as they edit, so without this they could change the
+         quantities, watch the total move, and accept — binding the shop to a
+         figure nobody at the shop had seen. Accepting is only ever possible
+         against a quote the shop has actually priced. */
       `UPDATE quotes SET accepted_at=NOW(), status='accepted',
               needed_by = COALESCE($2::date, needed_by),
               name  = COALESCE(NULLIF(name,''),  $3),
               email = COALESCE(NULLIF(email,''), $4),
               phone = COALESCE(NULLIF(phone,''), $5)
-        WHERE code=$1 AND accepted_at IS NULL RETURNING *`,
+        WHERE code=$1 AND accepted_at IS NULL AND requested_items IS NULL RETURNING *`,
       [code, nb, cname, cemail, cphone]);
 
     if (rows.length) {                       // first acceptance only

--- a/tests/quote-customer-edits.test.js
+++ b/tests/quote-customer-edits.test.js
@@ -313,3 +313,103 @@ test('the diff is driven by the requested array, not by the stored object', () =
   assert.match(fn, /Array\.isArray\(r\.sizes\)/,
     'order comes from the array; the quote mix is only looked up in');
 });
+
+/* ── Live estimate, and the guards that make it safe ─────────────────────── */
+
+const custPage = src.slice(src.indexOf("app.get('/q/:code'"),
+                           src.indexOf("app.get(['/q/:code/pay/card'"));
+
+test('the customer payload carries no supplier cost', () => {
+  /* THE disclosure risk. jt-catalog.php returns a `cost` field on every
+     product — the shop's supplier cost — and the admin form receives the
+     catalogue wholesale. This page is public: a customer who opened dev tools
+     would read the margin on their own job.
+
+     customerLinePricing rebuilds each line field by field rather than copying,
+     so a field added to the catalogue later cannot leak by default. */
+  const fn = src.slice(src.indexOf('function customerLinePricing'));
+  /* Comments stripped first: this file's own prose explains WHY cost is
+     excluded, and matching that would make the check pass by accident on a
+     version that leaked it. The assertion is about the code. */
+  const body = fn.slice(0, fn.indexOf('\n}\n'))
+    .replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '');
+  assert.doesNotMatch(body, /\bcost\b/,
+    'customerLinePricing must never read a cost field');
+  assert.doesNotMatch(body, /\.\.\.p\b|Object\.assign\(\{\}, p\)|JSON\.parse\(JSON\.stringify\(p\)\)/,
+    'the product must be rebuilt field by field, never spread — a spread ships ' +
+    'whatever the catalogue adds next');
+  assert.match(body, /price: Number\(p\.price\)/, 'only the SELL price is sent');
+});
+
+test('the whole catalogue is never serialised into the customer page', () => {
+  /* The admin form does `var CAT = ${JSON.stringify(catalog)}`. Doing that here
+     would ship cost, every other product, and the methods table to a public
+     page. */
+  assert.doesNotMatch(custPage, /JSON\.stringify\(catalog\)/,
+    'the customer page must serialise only its own scrubbed line payload');
+});
+
+test('accepting is refused while a change is pending', () => {
+  /* Without this the customer could edit, watch the total move, and accept —
+     binding the shop to a figure nobody at the shop had priced. */
+  const accept = src.slice(src.indexOf("app.post('/q/:code/accept'"));
+  assert.match(accept.slice(0, accept.indexOf('RETURNING')),
+    /AND requested_items IS NULL/,
+    'the accept UPDATE must require that no request is outstanding');
+});
+
+test('paying is refused while a change is pending', () => {
+  /* This route charges from the STORED total, which is not what the customer is
+     looking at once they have edited. Taking that money is the one failure here
+     that costs a refund and an apology. */
+  const pay = src.slice(src.indexOf("app.get(['/q/:code/pay/card'"));
+  assert.match(pay.slice(0, pay.indexOf('const t = quoteTotals')),
+    /if \(q\.requested_items\) return res\.redirect/,
+    'the payment route must refuse a quote with an outstanding request');
+});
+
+test('the estimate runs the shared engine, not a second copy of the rule', () => {
+  /* Two ladders agree until the day one of them is changed. */
+  assert.match(custPage, /\$\{quotePricingSource\(\)\}/,
+    'the customer page must emit the shared pricing source');
+  assert.match(custPage, /priceLine\(\{/, 'and call priceLine, not its own maths');
+});
+
+test('the quoted total stays on screen beside the estimate', () => {
+  /* The stored figure is what the shop stands behind. Overwriting it would
+     leave no record on the page of what was actually quoted. */
+  assert.match(custPage, /id="qtotal"/);
+  assert.match(custPage, /id="estrow"/);
+  assert.match(custPage, /With your changes/,
+    'the recalculated figure must be labelled as an estimate');
+});
+
+test('the estimate script the browser receives actually parses', () => {
+  /* Same trap as the admin form: this script lives inside a template literal,
+     so a broken line is just a string to Node and ships silently — the page
+     then loads with no recalculation and no error. */
+  const open = custPage.indexOf('${canEditQty ? `<script>');
+  assert.notStrictEqual(open, -1, 'the estimate script block was not found');
+  let js = custPage.slice(custPage.indexOf('<script>', open) + 8,
+                          custPage.indexOf('</script>', open));
+  /* Server-side interpolations are values at render time; substitute a literal
+     so the surrounding control flow can be parsed. Brace MATCHING, not a regex:
+     `${JSON.stringify(x.map(i => ({...})))}` contains nested braces, and a
+     [^}]* stops at the first one and leaves stray parens behind — which reads
+     as a syntax error in code that is perfectly fine. */
+  js = js.replace(/\$\{quotePricingSource\(\)\}/,
+    'function priceLine(){return {lineTotal:0,addonTotal:0};}');
+  let out = '', i = 0;
+  while (i < js.length) {
+    const k = js.indexOf('${', i);
+    if (k === -1) { out += js.slice(i); break; }
+    out += js.slice(i, k);
+    let depth = 0, j = k + 1;
+    for (; j < js.length; j++) {
+      if (js[j] === '{') depth++;
+      else if (js[j] === '}' && --depth === 0) break;
+    }
+    out += '0'; i = j + 1;
+  }
+  assert.doesNotThrow(() => new Function(out));
+});


### PR DESCRIPTION
Reverses the "no recalculation" call from #60, and makes it safe by gating the
money instead of hiding the number.

## Live estimate

Editing a size or quantity now re-prices the line as you type — struck-through
old figure, new one in amber — and an **"With your changes (estimate)"** row
appears under the total. The quoted total stays on screen untouched, because that
is the figure the shop stands behind.

It runs `quotePricingSource()` — **the same engine the server prices with**.
Reimplementing the ladder in the page would be the classic pricing bug: two
copies that agree right up until one of them is changed.

## The money guard, which is what makes the above safe

Live numbers without this would be worse than no numbers: the customer edits,
watches the total move, and accepts — binding the shop to a figure nobody at the
shop had priced.

- **`/accept`** now requires `requested_items IS NULL` in the UPDATE itself, so
  the guard is in the same statement as the write.
- **`/q/:code/pay/card`** and **`/pay/balance`** refuse outright while a request
  is pending. That route charges from the **stored** total, which is not what the
  customer is looking at once they have edited — taking that money is the one
  failure here that costs a refund and an apology.

Approval is unchanged: you apply their numbers, check the total, save. That
clears the request and re-opens both doors.

## Size surcharges

They already existed and were already charged — the gap was that the customer
could not see them. The upcharge now prints on the box you type into (`2XL
+$3.68`), which is the answer to "why did adding a 2XL cost more than a medium".

Catalogue audit, since the ask was to add them: **every product that stocks 2XL+
already carries one** — 34 of 44 sized products, and zero products with an
extended size have a $0 upcharge. Median $3.26 at 2XL rising to $12.36 at 6XL.
The 10 without simply do not stock above XL. So nothing needed adding to the
data; if any specific garment is wrong, that is a catalogue edit, not code.

## The disclosure this could have been

`jt-catalog.php` returns a **`cost`** field on every product — the shop's
supplier cost — and the admin form receives the catalogue wholesale with
`JSON.stringify(catalog)`. Doing the same here would have handed every customer
the margin on their own job, in a page they can read with dev tools.

`customerLinePricing()` therefore rebuilds each line **field by field** rather
than copying: sell price, size upcharges, the decoration's tier table. No spread,
no wholesale copy — so a field added to the catalogue later cannot leak by
default, it has to be added here deliberately. Three tests enforce it, including
one that fails if `customerLinePricing` so much as mentions `cost` (with comments
stripped first, so the prose explaining the rule cannot satisfy it).

Verified by adding `cost: Number(p.cost)` to the payload: the test fails, and
passes again on revert.

## Tests

337/337, 7 new. Including the emitted script parsing — extracted with **brace
matching**, not a regex, because `${JSON.stringify(x.map(i => ({…})))}` contains
nested braces and a `[^}]*` stops at the first one and reports a syntax error in
code that is fine. My first attempt did exactly that.

## What I could NOT verify

Still no live run. The estimate arithmetic is the shared engine and is covered,
but I have not watched a real browser recalculate a real quote.

## To check by hand

1. Open an unaccepted quote. Sizes should show `+$3.68` style surcharges.
2. Change a quantity — the line and an estimate row should update as you type,
   with the quoted total still visible above it.
3. Submit, then try to Accept or Pay: **both should refuse** until you apply the
   change and save.
4. Apply, save, reload — the estimate row should be gone and both doors open.