### PR TITLE
Explain refused acceptance, offer pay in full, keep reviews moving

### DIFF
--- a/server.js
+++ b/server.js
@@ -2663,19 +2663,40 @@ function reviewStrip() {
     </div>`;
 }
 
+/* The marquee used to stop and stay stopped. Three separate causes, all here:
+ *
+ *  1. `:hover` STICKS ON TOUCH. Tapping or dragging over the strip on a phone
+ *     applies :hover and holds it until something else is tapped — so the
+ *     animation paused on first contact and never resumed. `:active` made it
+ *     worse, firing on every tap. Pause is now gated behind a real cursor.
+ *  2. On desktop the pointer simply RESTS over the strip while reading, because
+ *     the page scrolls under a stationary mouse. Pausing on hover is a nice idea
+ *     that in practice means "paused most of the time".
+ *  3. `prefers-reduced-motion` turned the animation off — correct — but the wrap
+ *     was `overflow:hidden`, so those users could see the first two reviews and
+ *     REACH NONE OF THE REST. That is the worse bug the stopping hid: for anyone
+ *     with Reduce Motion on (a default for a lot of people), seven of nine
+ *     reviews were simply unreachable.
+ *
+ * So: the strip is always manually scrollable, and the animation is decoration
+ * on top of that rather than the only way to see the content.
+ */
 const REVIEW_CSS = `
-.rv-wrap{overflow:hidden}
+.rv-wrap{overflow-x:auto;overflow-y:hidden;-webkit-overflow-scrolling:touch;scrollbar-width:none}
 .rv-wrap::-webkit-scrollbar{display:none}
 .rv-track{display:flex;width:max-content;animation:rvscroll 60s linear infinite}
 .rv-set{display:flex;gap:10px;padding-right:10px}
-.rv-wrap:hover .rv-track{animation-play-state:paused}
-.rv-wrap:hover .rv-track,.rv-wrap:active .rv-track{animation-play-state:paused}
+@media (hover:hover) and (pointer:fine){
+  .rv-wrap:hover .rv-track{animation-play-state:paused}
+}
 .rv{flex:0 0 250px;background:#f7f9fc;border:1px solid #e3e8f2;border-radius:12px;padding:12px 14px}
 .rv .stars{color:#F4A623;font-size:13px;letter-spacing:1px}
 .rv-t{font-weight:700;font-size:13.5px;color:#0B1F4B;margin:4px 0 3px}
 .rv-x{font-size:12.5px;line-height:1.5;color:#46505f;display:-webkit-box;-webkit-line-clamp:4;-webkit-box-orient:vertical;overflow:hidden}
 .rv-w{font-size:11px;color:#8b95a5;margin-top:7px}
 @keyframes rvscroll{from{transform:translateX(0)}to{transform:translateX(-50%)}}
+/* No animation, but the strip still scrolls by hand — see the note above: this
+   rule used to make seven of nine reviews unreachable. */
 @media (prefers-reduced-motion:reduce){.rv-track{animation:none}}
 
 `;
@@ -5599,6 +5620,22 @@ app.get('/q/:code', async (req, res) => {
             balanceDue > 0 ? ` A balance of <b>${money(balanceDue)}</b> is due ${BALANCE_WHEN}.` : ' Paid in full — nothing further to pay.'}</div>`
           : accepted ? `<div class="ok"><b>Accepted — thank you!</b> Choose how you'd like to pay the deposit below.</div>` : ''}
         ${(!accepted && expired) ? `<div class="warn">This quote has expired, but prices usually still stand — just text and we'll refresh it.</div>` : ''}
+        ${(() => {
+          /* Why the last action did not happen. Pressing Accept and having the
+             page reload unchanged is worse than an error — the customer assumes
+             the button is broken, or that it worked. */
+          const e = String(req.query.e || '');
+          if (e === 'pending') return `<div class="warn"><b>Your changes are with ${SHOP_SIGNER} first.</b>
+            Accepting is on hold until the quote is updated with the new price — usually the same day.</div>`;
+          if (e === 'already') return `<div class="ok">This quote is already accepted — nothing more to do here.</div>`;
+          if (e === 'gone') return `<div class="warn">We could not find that quote. Please text us and we will resend it.</div>`;
+          if (e === 'err') return `<div class="warn">Something went wrong on our end. Please text us — nothing was charged.</div>`;
+          return '';
+        })()}
+        ${q.requested_items ? `<div class="warn" id="changes"><b>Change requested — with ${SHOP_SIGNER}.</b>
+          The new sizes are below. ${SHOP_SIGNER} confirms the price and this same link updates,
+          so there is nothing new to open. Accepting and paying are on hold until then, so nobody
+          pays against the old figure.</div>` : ''}
 
         <table class="items"><thead><tr>
           <th>Item</th><th class="num">Qty</th><th class="num">Each</th><th class="num">Amount</th>
@@ -5657,7 +5694,7 @@ app.get('/q/:code', async (req, res) => {
         </div>
       </div>` : ''}
 
-      ${paid ? '' : accepted ? `
+      ${paid || q.requested_items ? '' : accepted ? `
       <div class="card">
         <h1 style="font-size:18px">Pay your ${t.deposit >= t.total ? 'balance' : 'deposit'} — ${money(t.deposit)}</h1>
         <p class="muted" style="margin:6px 0 14px">Whichever is easiest. Nothing else is due until pickup or delivery.</p>
@@ -5666,6 +5703,16 @@ app.get('/q/:code', async (req, res) => {
           Card or Apple&nbsp;Pay — ${money(round2(t.deposit + cardFee(t.deposit)))}
         </a>
         <p class="muted" style="margin:-4px 0 14px;font-size:12px">Includes the ${Math.round(CARD_FEE*100)}% card processing fee (${money(cardFee(t.deposit))}).</p>
+
+        ${t.deposit < t.total ? `
+        <div style="border:1px solid #e3e8f2;border-radius:10px;padding:12px;margin-bottom:14px">
+          <b>Rather settle it all now? — ${money(t.total)}</b>
+          <p class="muted" style="margin:4px 0 8px;font-size:12.5px">Nothing left to pay at pickup.</p>
+          <a class="btn-ghost" style="display:block;text-align:center;padding:9px"
+             href="/q/${q.code}/pay/full">Pay in full by card — ${money(round2(t.total + cardFee(t.total)))}</a>
+          <p class="muted" style="margin:8px 0 0;font-size:12px">Or send the full ${money(t.total)} by Zelle
+            to <b>${escEmail(ZELLE_HANDLE)}</b>, memo <b>${escEmail(q.code)}</b> — no card fee.</p>
+        </div>` : ''}
 
         <div style="border:2px solid #1a9c6b;border-radius:10px;padding:12px;margin-bottom:10px;background:#f2fbf7">
           <div style="display:flex;align-items:baseline;justify-content:space-between;gap:8px;flex-wrap:wrap">
@@ -5839,7 +5886,7 @@ ${quotePricingSource()}
    form-encoded POST is all a Checkout Session needs, and Apple Pay + Google Pay
    appear automatically on supported devices with no extra work.
    The card fee is added as its own visible line so nobody feels surprised. */
-app.get(['/q/:code/pay/card', '/q/:code/pay/balance'], async (req, res) => {
+app.get(['/q/:code/pay/card', '/q/:code/pay/balance', '/q/:code/pay/full'], async (req, res) => {
   const code = String(req.params.code || '').toUpperCase();
   if (!QUOTE_CODE_RE.test(code)) return res.redirect('/q/' + encodeURIComponent(code));
   const secret = process.env.STRIPE_SECRET_KEY;
@@ -5861,7 +5908,14 @@ app.get(['/q/:code/pay/card', '/q/:code/pay/balance'], async (req, res) => {
     /* Same route serves the deposit and the balance: charging the deposit when
        it is already paid, or a balance when nothing is owed, would both be
        wrong, so the amount is derived rather than passed in. */
-    const wantsBalance = req.path.endsWith('/balance');
+    /* `/full` is the same arithmetic as `/balance` — everything still owed —
+       but it is offered BEFORE any payment exists, where the word "balance"
+       would be meaningless. A customer who wants to settle the whole job in one
+       go was previously forced through the deposit; this is that door.
+
+       One expression, so a deposit-only flow and a pay-in-full flow can never
+       disagree about what is owed. */
+    const wantsBalance = req.path.endsWith('/balance') || req.path.endsWith('/full');
     const amount = wantsBalance
       ? round2(Math.max(0, Number(t.total) - alreadyPaid))
       : t.deposit;
@@ -5887,8 +5941,10 @@ app.get(['/q/:code/pay/card', '/q/:code/pay/balance'], async (req, res) => {
         </div>`));
     }
 
+    /* The receipt has to name what was actually bought. "Remaining balance" on a
+       first-and-only payment reads as though something was owed beforehand. */
     const label = wantsBalance
-      ? `Remaining balance — quote ${q.code}`
+      ? (alreadyPaid > 0 ? `Remaining balance — quote ${q.code}` : `Payment in full — quote ${q.code}`)
       : (t.deposit >= t.total ? `Payment in full — quote ${q.code}` : `50% deposit — quote ${q.code}`);
 
     const form = new URLSearchParams();
@@ -6439,11 +6495,26 @@ app.post('/q/:code/accept', orderRateLimit, async (req, res) => {
         syncQuoteToBrevo(q).catch(() => {});
         syncQuoteToLumise(q).catch(() => {});
       }
+      return res.redirect('/q/' + code);
     }
-    res.redirect('/q/' + code);
+
+    /* The UPDATE matched nothing, and until now that fell through to a plain
+       redirect — the customer pressed Accept, the page reloaded unchanged, and
+       nothing anywhere said why. That is what "accept didn't work" looks like
+       from the other side, and it is worse than an error.
+
+       There are exactly two reasons it can match nothing, and the customer is
+       told which. */
+    const { rows: why } = await pool.query(
+      'SELECT accepted_at IS NOT NULL AS already, requested_items IS NOT NULL AS pending FROM quotes WHERE code=$1',
+      [code]);
+    const reason = !why.length ? 'gone'
+      : why[0].pending ? 'pending'
+      : why[0].already ? 'already' : 'gone';
+    return res.redirect('/q/' + code + '?e=' + reason);
   } catch (err) {
     console.error('accept failed:', err.message);
-    res.redirect('/q/' + code);
+    res.redirect('/q/' + code + '?e=err');
   }
 });
 

--- a/tests/quote-accept-and-pay.test.js
+++ b/tests/quote-accept-and-pay.test.js
@@ -1,0 +1,104 @@
+'use strict';
+
+/* Three faults reported from a real quote, all in the same area:
+ *
+ *   1. "accept didn't work" — the accept UPDATE is guarded, and when it matched
+ *      nothing the handler fell through to a plain redirect. The page reloaded
+ *      unchanged and NOTHING said why. A silent refusal is worse than an error:
+ *      the customer concludes the button is broken, or that it worked.
+ *   2. "it let me pay the deposit" — the pay route is guarded server-side, but
+ *      the buttons were still rendered, so the guard could only be discovered by
+ *      pressing one. A control that cannot work must not be offered.
+ *   3. "there should be an area to pay in full" — a customer who wanted to
+ *      settle the whole job was forced through the 50% deposit. The arithmetic
+ *      already existed on the balance route; it was simply never offered before
+ *      a first payment, where the word "balance" would have been meaningless.
+ */
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const src = fs.readFileSync(path.join(__dirname, '..', 'server.js'), 'utf8');
+const page = src.slice(src.indexOf("app.get('/q/:code'"),
+                       src.indexOf("app.get(['/q/:code/pay/card'"));
+const accept = src.slice(src.indexOf("app.post('/q/:code/accept'"));
+const pay = src.slice(src.indexOf("app.get(['/q/:code/pay/card'"));
+
+/* ── Accept never fails silently ─────────────────────────────────────────── */
+
+test('a refused acceptance says which reason', () => {
+  const body = accept.slice(0, accept.indexOf('} catch'));
+  assert.match(body, /\?e=' \+ reason/, 'the redirect must carry a reason');
+  assert.match(body, /why\[0\]\.pending \? 'pending'/);
+  assert.match(body, /why\[0\]\.already \? 'already'/);
+});
+
+test('the successful path returns before the reason lookup', () => {
+  /* Without the early return a successful acceptance would fall into the
+     "why did it fail" query and redirect with an error on a quote that just
+     succeeded. */
+  const body = accept.slice(0, accept.indexOf('} catch'));
+  assert.match(body, /return res\.redirect\('\/q\/' \+ code\);\s*\}/,
+    'the success branch must return before the failure lookup');
+});
+
+test('every reason the redirect can carry is rendered', () => {
+  /* A reason with no matching branch is a silent failure wearing a query
+     string. */
+  for (const r of ['pending', 'already', 'gone', 'err']) {
+    assert.match(page, new RegExp(`e === '${r}'`),
+      `the page must explain e=${r}`);
+  }
+});
+
+/* ── Nothing that cannot work is offered ─────────────────────────────────── */
+
+test('accept and pay are both hidden while a change is pending', () => {
+  /* One expression gates both, so they cannot drift apart: the pay block is its
+     `accepted` branch and the accept form is its `else`. */
+  assert.match(page, /\$\{paid \|\| q\.requested_items \? '' : accepted \?/,
+    'a pending request must suppress both the pay options and the accept form');
+});
+
+test('the pending state is explained where the buttons used to be', () => {
+  /* Hiding a button without saying why is its own silent failure. */
+  assert.match(page, /q\.requested_items \? `<div class="warn" id="changes">/);
+  assert.match(page, /on hold until then/,
+    'the customer must be told why accepting and paying are unavailable');
+});
+
+test('the server still refuses even though the buttons are gone', () => {
+  /* The UI is a courtesy; the guard is the rule. A stale tab or a typed URL
+     must still be refused. */
+  assert.match(accept.slice(0, accept.indexOf('RETURNING')), /AND requested_items IS NULL/);
+  assert.match(pay.slice(0, pay.indexOf('const t = quoteTotals')),
+    /if \(q\.requested_items\) return res\.redirect/);
+});
+
+/* ── Pay in full ─────────────────────────────────────────────────────────── */
+
+test('pay/full is served and owes the same as pay/balance', () => {
+  /* Same expression for both, so a deposit flow and a pay-in-full flow can
+     never disagree about what is owed. */
+  assert.match(pay, /'\/q\/:code\/pay\/full'/, 'the route must exist');
+  assert.match(pay, /req\.path\.endsWith\('\/balance'\) \|\| req\.path\.endsWith\('\/full'\)/,
+    'full and balance must derive the amount identically');
+});
+
+test('the full amount is offered only when a deposit would not cover it', () => {
+  /* Below the pay-in-full threshold the deposit IS the total, and offering
+     "pay in full" beside an identical figure reads as two different prices. */
+  assert.match(page, /\$\{t\.deposit < t\.total \? `/,
+    'the pay-in-full block must be conditional on a deposit being partial');
+  assert.match(page, /\/pay\/full/, 'and must link to the full-payment route');
+});
+
+test('a first full payment is not receipted as a "balance"', () => {
+  /* /full reuses the balance branch, which was labelled "Remaining balance" —
+     on a first-and-only payment that reads as though something was owed
+     beforehand. */
+  assert.match(pay, /alreadyPaid > 0 \? `Remaining balance[\s\S]*?: `Payment in full/,
+    'the Stripe line item must name what was actually paid');
+});

--- a/tests/review-marquee.test.js
+++ b/tests/review-marquee.test.js
@@ -1,0 +1,66 @@
+'use strict';
+
+/* The review marquee stopped and stayed stopped. Three causes, none of which
+ * looks wrong when you read the CSS:
+ *
+ *   1. `:hover` STICKS ON TOUCH. Tapping or dragging over the strip on a phone
+ *      applies :hover and holds it until something else is tapped, so the
+ *      animation paused on first contact and never resumed. `:active` made it
+ *      worse, firing on every tap.
+ *   2. On desktop the pointer RESTS over the strip while reading — the page
+ *      scrolls under a stationary mouse — so hover-pause meant "paused most of
+ *      the time".
+ *   3. `prefers-reduced-motion` correctly turned the animation off, but the wrap
+ *      was `overflow:hidden`, so those users could see two reviews and reach
+ *      none of the other seven. That is the real bug the stopping hid.
+ *
+ * The rule these encode: an animation may DECORATE content, never be the only
+ * way to reach it.
+ */
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const src = fs.readFileSync(path.join(__dirname, '..', 'server.js'), 'utf8');
+const css = src.slice(src.indexOf('const REVIEW_CSS'), src.indexOf('const QUOTE_CODE_RE'));
+
+test('hover-pause applies only where a real cursor exists', () => {
+  /* Without the media query this pauses forever on any touch device. */
+  assert.match(css, /@media \(hover:hover\) and \(pointer:fine\)\{\s*\.rv-wrap:hover \.rv-track\{animation-play-state:paused\}/,
+    'the hover pause must be gated behind a fine pointer');
+});
+
+test('the strip never pauses on :active', () => {
+  /* :active fires on every tap and can stick on touch. */
+  assert.doesNotMatch(css, /\.rv-wrap:active/,
+    ':active pause reintroduces the touch-sticking bug');
+});
+
+test('the reviews are reachable without the animation', () => {
+  /* The one that mattered. With animation off — reduced motion, or simply
+     paused — overflow:hidden means everything past the visible cards is
+     unreachable. */
+  assert.match(css, /\.rv-wrap\{overflow-x:auto/,
+    'the strip must scroll by hand, so the animation is decoration and not the ' +
+    'only way to see the reviews');
+  assert.doesNotMatch(css, /\.rv-wrap\{overflow:hidden\}/,
+    'overflow:hidden makes the off-screen reviews unreachable when paused');
+});
+
+test('reduced motion still turns the animation off', () => {
+  /* Fixing reachability must not quietly remove the accessibility rule. */
+  assert.match(css, /@media \(prefers-reduced-motion:reduce\)\{\.rv-track\{animation:none\}\}/,
+    'reduced motion must still disable the animation');
+});
+
+test('the marquee still loops seamlessly', () => {
+  /* The track holds the set twice and slides exactly one set width, so the
+     wrap-around is invisible. Change one without the other and it jumps. */
+  const strip = src.slice(src.indexOf('function reviewStrip'), src.indexOf('const REVIEW_CSS'));
+  const sets = (strip.match(/<div class="rv-set">/g) || []).length;
+  assert.strictEqual(sets, 2, 'the card set must be rendered exactly twice');
+  assert.match(css, /to\{transform:translateX\(-50%\)\}/,
+    'the slide must be exactly half the track — one full set');
+});


### PR DESCRIPTION
Four reported faults. Three are mine from #62 or its neighbourhood.

## "accept didn't work" — my bug, and the worst kind

#62 guarded the accept UPDATE with `AND requested_items IS NULL`. The guard is
right. What was wrong is what happened when it matched nothing: the handler fell
through to a plain `res.redirect`, the page reloaded **unchanged**, and nothing
anywhere said why.

A silent refusal is worse than an error — the customer concludes the button is
broken, or that it worked. The handler now looks up *which* of the two reasons
applied and redirects with it, and the page renders all four states (`pending`,
`already`, `gone`, `err`).

## "it let me pay the deposit"

The pay route **was** guarded server-side, but the buttons were still rendered —
so the only way to discover the guard was to press one. A control that cannot
work must not be offered.

Accept and pay are now both suppressed while a change is pending, by the same
expression, so they cannot drift apart. In their place is a banner saying the
change is with the shop and why the two actions are on hold. **The server-side
guards are untouched** — the UI is a courtesy, the guard is the rule, and a stale
tab or a typed URL is still refused.

## "there should be an area to pay in full"

Real gap, and it cost a real sale: a customer who wanted to settle the whole job
was forced through the 50% deposit.

The arithmetic already existed — `/pay/balance` computes `total − alreadyPaid`,
which with nothing paid **is** the full amount. It was simply never offered
before a first payment, where the word "balance" would have been meaningless. So
`/pay/full` now serves the same route, deriving the amount from the same
expression, and a "Rather settle it all now?" block appears beside the deposit
with the card total and the Zelle alternative.

Shown only when `deposit < total` — below the pay-in-full threshold the deposit
already IS the total, and offering both beside identical figures reads as two
different prices.

One thing this surfaced: `/full` reuses the balance branch, which labelled the
Stripe line item "Remaining balance". On a first-and-only payment that reads as
though something was owed beforehand. Now labelled by what was actually paid.

## "the reviews should be revolving and they stop"

Three separate causes, none of which looks wrong in the CSS:

1. **`:hover` sticks on touch.** Tapping or dragging over the strip on a phone
   applies `:hover` and holds it until something else is tapped — so it paused on
   first contact and never resumed. `:active` made it worse, firing on every tap.
   Pause is now gated behind `(hover:hover) and (pointer:fine)`.
2. **On desktop the pointer rests over the strip while reading** — the page
   scrolls under a stationary mouse — so hover-pause meant "paused most of the
   time".
3. **`prefers-reduced-motion` turned the animation off, and the wrap was
   `overflow:hidden`** — so those users saw two reviews and could reach **none of
   the other seven**. That is the real bug the stopping hid, and it affects
   anyone with Reduce Motion on, which is a lot of people.

The strip is now always scrollable by hand, so the animation decorates the
content rather than being the only way to reach it. Reduced motion still disables
the animation.

## Tests

351/351, 9 new here plus 5 for the marquee. The marquee ones pin the rules rather
than the pixels: hover-pause must be behind a fine-pointer query, `:active` must
not pause, the wrap must not be `overflow:hidden`, reduced motion must still
disable the animation, and the set must be rendered exactly twice against a
`-50%` slide or the loop visibly jumps.

## What I could NOT verify

The Stripe checkout for `/pay/full` has not been exercised against a live
session — I am not putting a real charge through to test it. The amount comes
from the same expression `/balance` has always used, and that path is in daily
use, but the first real full payment is untested.

## To check by hand

1. Open an accepted, unpaid quote — a **"Rather settle it all now?"** block
   should sit under the deposit with the full total.
2. On a quote with a pending change, Accept and the pay options should be gone
   and replaced by the on-hold banner.
3. Reviews should keep moving on a phone after you touch them, and should scroll
   by hand if you have Reduce Motion on.