### PR TITLE
Split the board: deposit paid moves a quote into Orders

### DIFF
--- a/server.js
+++ b/server.js
@@ -7876,7 +7876,7 @@ async function renderBoard(VIEW, req, res) {
       sent: '#eef1f8|#33415c', viewed: '#fff4e0|#8a5a00', changes: '#fdecea|#b45309',
       accepted: '#e7f6ec|#166534', paid: '#1848B8|#ffffff', expired: '#f3f4f6|#6b7280',
     };
-    const body = rows.map(q => {
+    const quoteCard = (q) => {
       const expired = q.status !== 'accepted' && q.valid_until && new Date(q.valid_until) < new Date(new Date().toDateString());
       /* "accepted" and "paid" looked identical, so there was no way to see at a
          glance who had actually handed over money. Paid wins over every other
@@ -8165,12 +8165,44 @@ async function renderBoard(VIEW, req, res) {
         ${q.phone ? ` &middot; <a class="muted" href="tel:${escEmail(q.phone)}">${escEmail(q.phone)}</a>` : ''}
         ${q.email ? ` &middot; <a class="muted" href="#" onclick="if(confirm('Email a receipt to ${escEmail(q.email)}?')){var f=document.createElement('form');f.method='POST';f.action='/quote/${q.code}/receipt';document.body.appendChild(f);f.submit();}return false;">email receipt</a>` : ''}</div>
       </div>`;
-    }).join('');
+    };
+
+    /* Once money has arrived the job stops being a quote and becomes work in
+       hand. They were rendered in one flat list, so a paid job sat among the
+       quotes still waiting for an answer and the open-quote list was never
+       actually a list of open quotes.
+
+       Grouped rather than moved to /orders: that route is the DESIGNER's online
+       store orders from design.jtees.net, a different thing entirely, and
+       merging the two would put shop quotes and storefront orders in one list
+       that means nothing.
+
+       The existing sort — behind schedule, then soonest deadline — is preserved
+       inside each group, because urgency still matters within the work in hand. */
+    const isDelivered = (q) => !!q.delivered_at;
+    const isPaid = (q) => Number(q.paid_amount || 0) > 0;
+
+    const gOrders = rows.filter((q) => isPaid(q) && !isDelivered(q));
+    const gQuotes = rows.filter((q) => !isPaid(q) && !isDelivered(q));
+    const gDone   = rows.filter(isDelivered);
+
+    const group = (title, note, list) => !list.length ? '' : `
+      <div style="display:flex;align-items:baseline;gap:10px;margin:22px 0 10px">
+        <h2 style="font-size:16px;margin:0;color:#0B1F4B">${title}</h2>
+        <span class="muted" style="font-size:12.5px">${list.length}${note ? ' &middot; ' + note : ''}</span>
+      </div>${list.map(quoteCard).join('')}`;
+
+    const body =
+      group('Orders', 'deposit in — work in hand', gOrders) +
+      group('Open quotes', 'sent, nothing paid yet', gQuotes) +
+      group('Delivered', 'done', gDone);
+
     const needCount = (body.match(/Needs a text/g) || []).length;
     const changeCount = (body.match(/Change requested/g) || []).length;
     res.send(adminPage(VIEW === 'work' ? 'Production' : 'Quotes',
       `<h1>${VIEW === 'work' ? 'Production' : 'Quotes'}</h1>
-      <div class="sub">${rows.length} total${
+      <div class="sub">${gQuotes.length} open quote${gQuotes.length === 1 ? '' : 's'} &middot; ${
+        gOrders.length} order${gOrders.length === 1 ? '' : 's'} in hand${
         atRiskCount ? ` &middot; <b style="color:#b91c1c">${atRiskCount} behind schedule</b>` : ''}${
         changeCount ? ` &middot; <b style="color:#1848B8">${changeCount} awaiting your edit</b>` : ''}${
         needCount ? ` &middot; <b style="color:#8a5a00">${needCount} need a text</b>` : ''}

--- a/tests/board-grouping.test.js
+++ b/tests/board-grouping.test.js
@@ -1,0 +1,99 @@
+'use strict';
+
+/* The Jobs board rendered every quote in one flat list, so a job with the
+ * deposit already in sat among the quotes still waiting for an answer. The
+ * "open quotes" list was therefore never a list of open quotes, and the only
+ * way to find what still needed chasing was to read every card.
+ *
+ * Money is the line: once a deposit has arrived the job is work in hand, not an
+ * offer. So the board groups on `paid_amount > 0`, with delivered work dropping
+ * out of both.
+ *
+ * NOT moved to /orders — that route is the DESIGNER's online store orders from
+ * design.jtees.net, which are a different thing with a different source. Merging
+ * them would produce one list that means nothing.
+ */
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const src = fs.readFileSync(path.join(__dirname, '..', 'server.js'), 'utf8');
+const board = src.slice(src.indexOf('async function renderBoard'));
+
+test('the board groups on money arriving, not on status text', () => {
+  /* `status` is a string that several paths write; paid_amount is the ledger
+     figure. Grouping on the string would put a quote marked "accepted" in with
+     the paid work while no money had moved. */
+  assert.match(board, /const isPaid = \(q\) => Number\(q\.paid_amount \|\| 0\) > 0/,
+    'the split must be on the amount actually paid');
+  assert.match(board, /const gOrders = rows\.filter\(\(q\) => isPaid\(q\) && !isDelivered\(q\)\)/);
+  assert.match(board, /const gQuotes = rows\.filter\(\(q\) => !isPaid\(q\) && !isDelivered\(q\)\)/);
+});
+
+test('every job lands in exactly one group', () => {
+  /* A job appearing twice would double the board; one appearing nowhere would
+     be invisible, which is worse. */
+  const rows = [
+    { code: 'A', paid_amount: 0,   delivered_at: null },        // open quote
+    { code: 'B', paid_amount: 500, delivered_at: null },        // order
+    { code: 'C', paid_amount: 500, delivered_at: '2026-08-01' },// delivered
+    { code: 'D', paid_amount: 0,   delivered_at: '2026-08-01' },// delivered unpaid
+    { code: 'E', paid_amount: null, delivered_at: null },       // never touched
+  ];
+  const isDelivered = (q) => !!q.delivered_at;
+  const isPaid = (q) => Number(q.paid_amount || 0) > 0;
+  const groups = {
+    orders: rows.filter((q) => isPaid(q) && !isDelivered(q)),
+    quotes: rows.filter((q) => !isPaid(q) && !isDelivered(q)),
+    done:   rows.filter(isDelivered),
+  };
+  const seen = [].concat(groups.orders, groups.quotes, groups.done).map((q) => q.code).sort();
+  assert.deepStrictEqual(seen, ['A', 'B', 'C', 'D', 'E'],
+    'every row must appear exactly once across the three groups');
+  assert.deepStrictEqual(groups.quotes.map((q) => q.code), ['A', 'E'],
+    'a null paid_amount is unpaid, not paid');
+  assert.deepStrictEqual(groups.orders.map((q) => q.code), ['B']);
+});
+
+test('an empty group renders nothing at all', () => {
+  /* A heading with no cards under it reads as a broken page. */
+  assert.match(board, /const group = \(title, note, list\) => !list\.length \? '' :/,
+    'an empty group must render as an empty string');
+});
+
+test('the three groups are rendered in working order', () => {
+  /* Work in hand first — it has deadlines and money attached. Quotes second,
+     because they need chasing. Delivered last, because it is history. */
+  const i = board.indexOf("group('Orders'");
+  const j = board.indexOf("group('Open quotes'");
+  const k = board.indexOf("group('Delivered'");
+  assert.ok(i > -1 && j > -1 && k > -1, 'all three groups must be rendered');
+  assert.ok(i < j && j < k, 'order must be Orders, then Open quotes, then Delivered');
+});
+
+test('the sort inside each group is preserved', () => {
+  /* The groups filter the already-sorted `rows`, so behind-schedule and
+     soonest-deadline still float within the work in hand. Building them from
+     the raw query would silently drop that. */
+  assert.match(board, /rows\.filter\(\(q\) => isPaid/,
+    'groups must filter the sorted rows, not re-query');
+});
+
+test('the header counts the two live groups separately', () => {
+  /* "10 total" told June nothing about how many quotes were actually
+     outstanding — which is the number the board exists to answer. */
+  assert.match(board, /\$\{gQuotes\.length\} open quote/);
+  assert.match(board, /gOrders\.length\} order/);
+});
+
+test('the studio orders route is left alone', () => {
+  /* /orders is the designer storefront's own orders. If this ever starts
+     rendering quotes, the two sources have been conflated. */
+  const orders = src.slice(src.indexOf("app.get('/orders'"));
+  assert.match(orders.slice(0, 400), /fetchStudioOrders\(\)/,
+    '/orders must still serve the designer store orders');
+  assert.doesNotMatch(orders.slice(0, 400), /gOrders|quoteCard/,
+    'quotes must not be merged into the studio orders page');
+});


### PR DESCRIPTION
## What changed

The Jobs board rendered all 200 quotes in **one flat list**, so a job with the
deposit already in sat among the quotes still waiting for an answer. The open-quote
list was never actually a list of open quotes.

Three groups now, on the same board:

- **Orders** — deposit in, work in hand
- **Open quotes** — sent, nothing paid yet
- **Delivered** — done

The header counts the two live groups separately (`1 open quote · 2 orders in
hand`) instead of "10 total", which was the number that told you nothing.

On the real data that is **1 open quote, 2 orders, 7 delivered** — the open list
is now one card.

## Why not /orders

`/orders` is the **designer storefront's** own orders, fetched from
design.jtees.net via `fetchStudioOrders()`. Different source, different meaning.
Merging shop quotes into it would produce one list that means nothing, so it is
left alone and a test pins that.

## Why the split is on money, not status

`status` is a string several code paths write. `paid_amount` is the ledger
figure. Grouping on the string would file a quote marked "accepted" with the paid
work while no money had moved — which is exactly the case sitting on the board
right now.

Delivered work drops out of both, so finished jobs stop competing for attention
with live ones.

## Preserved

The existing sort — behind schedule, then soonest deadline — still applies
**inside** each group, because urgency matters within work in hand. The groups
filter the already-sorted rows rather than re-querying.

## Tests

358/358, 7 new. The one worth having is the partition test: every row must land
in exactly **one** group. A job in two groups doubles the board; a job in none is
invisible, which is worse. It also pins that a `null` paid_amount counts as
unpaid rather than paid.