### PR TITLE
Make board section headings span the grid

### DIFF
--- a/server.js
+++ b/server.js
@@ -4059,6 +4059,13 @@ form:has(>.step-row){display:block}
   .wrap{max-width:1840px}
 }
 /* Tables inside a narrower card must scroll rather than force the card wide. */
+/* A section heading inside the grid must span every column. Without this it is
+   just another grid ITEM: it takes one cell, the cards flow around it, and the
+   board renders headings sitting beside cards that belong to a different
+   section — which is worse than no headings at all, because it reads as fact. */
+.quote-grid-head{grid-column:1/-1;display:flex;align-items:baseline;gap:10px;margin:22px 0 -2px}
+.quote-grid-head:first-child{margin-top:0}
+.quote-grid-head h2{font-size:16px;margin:0;color:#0B1F4B}
 .quote-grid .card table{max-width:100%}
 .quote-grid .card details table{display:block;overflow-x:auto}
 `;
@@ -8187,8 +8194,8 @@ async function renderBoard(VIEW, req, res) {
     const gDone   = rows.filter(isDelivered);
 
     const group = (title, note, list) => !list.length ? '' : `
-      <div style="display:flex;align-items:baseline;gap:10px;margin:22px 0 10px">
-        <h2 style="font-size:16px;margin:0;color:#0B1F4B">${title}</h2>
+      <div class="quote-grid-head">
+        <h2>${title}</h2>
         <span class="muted" style="font-size:12.5px">${list.length}${note ? ' &middot; ' + note : ''}</span>
       </div>${list.map(quoteCard).join('')}`;
 

--- a/tests/board-grouping.test.js
+++ b/tests/board-grouping.test.js
@@ -97,3 +97,31 @@ test('the studio orders route is left alone', () => {
   assert.doesNotMatch(orders.slice(0, 400), /gOrders|quoteCard/,
     'quotes must not be merged into the studio orders page');
 });
+
+/* ── The layout, which the grouping tests above did NOT catch ────────────── */
+
+test('a section heading spans every grid column', () => {
+  /* This shipped broken. `.quote-grid` is `display:grid` with 2-3 columns, so a
+     heading placed inside it is just another GRID ITEM: it takes one cell and
+     the cards flow around it. The board rendered "Open quotes" sitting beside a
+     card from a different section — worse than no headings at all, because it
+     reads as fact.
+     Every grouping test above passed the whole time, because they checked which
+     list a job lands in and never that the heading is drawn above that list. */
+  assert.match(src, /\.quote-grid-head\{grid-column:1\/-1/,
+    'the heading must span all columns, or it becomes a card-sized cell');
+  assert.match(board, /<div class="quote-grid-head">/,
+    'the group heading must use that class');
+  assert.doesNotMatch(board, /<div style="display:flex;align-items:baseline;gap:10px;margin:22px 0 10px">/,
+    'an inline-styled heading with no column span reintroduces the bug');
+});
+
+test('the headings live inside the same grid as the cards', () => {
+  /* They have to: a heading in its own container outside the grid would break
+     the masonry flow between sections and leave ragged gaps. Spanning the row
+     is what keeps one grid and still reads as sections. */
+  const render = src.slice(src.indexOf('const body =\n'), src.indexOf('const needCount'));
+  assert.match(render, /group\('Orders'/);
+  assert.match(src, /<div class="quote-grid">\$\{body\}<\/div>/,
+    'body — headings and cards together — is rendered inside one .quote-grid');
+});


### PR DESCRIPTION
Fixes the layout #64 shipped broken.

## What went wrong

`.quote-grid` is `display:grid` with 2–3 columns. I put the section headings
inside it as plain `<div>`s, so each one became **a grid item occupying a single
cell**. The cards then flowed around them, and the board rendered "Open quotes"
sitting beside a card belonging to a different section.

That is worse than having no headings: a heading next to the wrong card still
reads as fact.

## Fix

`.quote-grid-head{grid-column:1/-1}` — the heading spans every column, so the
cards flow beneath it. Still one grid, so the masonry packing between sections is
unchanged.

## Why my tests didn't catch it

All seven grouping tests passed the entire time it was broken. They asserted
*which list a job lands in* — and every one of those answers was correct. Not one
of them asserted that the heading is drawn **above** that list.

The lesson, now pinned: a heading inside a grid is a grid item unless told
otherwise. Two new tests — the span rule must exist, and the old inline-styled
heading must not come back. Verified by removing `grid-column:1/-1`: the test
fails, and passes on revert.

360/360.

## To check

Reload Jobs. Each heading should sit on its own full-width row with its cards
beneath it — Orders (2), Open quotes (1, Melissa), Delivered (7).