### PR TITLE
Cancel an order, and be able to undo it

### DIFF
--- a/server.js
+++ b/server.js
@@ -127,6 +127,13 @@ async function initDB() {
 
        The amount is STORED rather than derived, so editing the quote afterwards
        cannot silently change a figure that has already been written off. */
+    /* Cancelled, not deleted. A quote is a record of what was agreed and — once
+       money has moved — what it was agreed against, so destroying the row
+       destroys the customer's history and orphans any payment that references
+       it. Cancelling takes it off the board and stops every chase, while the
+       record survives; it is also reversible, which deleting is not. */
+    'cancelled_at TIMESTAMPTZ',
+    'cancel_reason TEXT',
     'written_off NUMERIC(10,2) NOT NULL DEFAULT 0',
     'settled_at TIMESTAMPTZ',
     'settled_note TEXT',
@@ -5657,10 +5664,16 @@ app.get('/q/:code', async (req, res) => {
           if (e === 'pending') return `<div class="warn"><b>Your changes are with ${SHOP_SIGNER} first.</b>
             Accepting is on hold until the quote is updated with the new price — usually the same day.</div>`;
           if (e === 'already') return `<div class="ok">This quote is already accepted — nothing more to do here.</div>`;
+          if (e === 'cancelled') return `<div class="warn">This order has been cancelled, so it cannot be accepted.
+            If that is not right, please text ${SHOP_PHONE}.</div>`;
           if (e === 'gone') return `<div class="warn">We could not find that quote. Please text us and we will resend it.</div>`;
           if (e === 'err') return `<div class="warn">Something went wrong on our end. Please text us — nothing was charged.</div>`;
           return '';
         })()}
+        ${q.cancelled_at ? `<div class="warn"><b>This order has been cancelled.</b>
+          ${Number(q.paid_amount || 0) > 0
+            ? `Any payment already made is being refunded — ${SHOP_SIGNER} will be in touch.`
+            : `Nothing is owed.`} If that is not right, please text ${SHOP_PHONE}.</div>` : ''}
         ${q.requested_items ? `<div class="warn" id="changes"><b>Change requested — with ${SHOP_SIGNER}.</b>
           The new sizes are below. ${SHOP_SIGNER} confirms the price and this same link updates,
           so there is nothing new to open. Accepting and paying are on hold until then, so nobody
@@ -5723,7 +5736,7 @@ app.get('/q/:code', async (req, res) => {
         </div>
       </div>` : ''}
 
-      ${paid || q.requested_items ? '' : accepted ? `
+      ${paid || q.requested_items || q.cancelled_at ? '' : accepted ? `
       <div class="card">
         <h1 style="font-size:18px">Pay your ${t.deposit >= t.total ? 'balance' : 'deposit'} — ${money(t.deposit)}</h1>
         <p class="muted" style="margin:6px 0 14px">Whichever is easiest. Nothing else is due until pickup or delivery.</p>
@@ -5931,6 +5944,9 @@ app.get(['/q/:code/pay/card', '/q/:code/pay/balance', '/q/:code/pay/full'], asyn
        the shop has not re-priced is the one failure here that costs a refund
        and an apology, so the door is shut until the request is cleared. */
     if (q.requested_items) return res.redirect('/q/' + code + '#changes');
+    /* A cancelled order must not take money, whatever page the customer still
+       has open. The buttons are gone; this is what actually enforces it. */
+    if (q.cancelled_at) return res.redirect('/q/' + code);
 
     const t = quoteTotals(q);
     const alreadyPaid = Number(q.paid_amount || 0);
@@ -6458,7 +6474,7 @@ app.post('/q/:code/accept', orderRateLimit, async (req, res) => {
               name  = COALESCE(NULLIF(name,''),  $3),
               email = COALESCE(NULLIF(email,''), $4),
               phone = COALESCE(NULLIF(phone,''), $5)
-        WHERE code=$1 AND accepted_at IS NULL AND requested_items IS NULL RETURNING *`,
+        WHERE code=$1 AND accepted_at IS NULL AND requested_items IS NULL AND cancelled_at IS NULL RETURNING *`,
       [code, nb, cname, cemail, cphone]);
 
     if (rows.length) {                       // first acceptance only
@@ -6535,9 +6551,11 @@ app.post('/q/:code/accept', orderRateLimit, async (req, res) => {
        There are exactly two reasons it can match nothing, and the customer is
        told which. */
     const { rows: why } = await pool.query(
-      'SELECT accepted_at IS NOT NULL AS already, requested_items IS NOT NULL AS pending FROM quotes WHERE code=$1',
+      `SELECT accepted_at IS NOT NULL AS already, requested_items IS NOT NULL AS pending,
+              cancelled_at IS NOT NULL AS cancelled FROM quotes WHERE code=$1`,
       [code]);
     const reason = !why.length ? 'gone'
+      : why[0].cancelled ? 'cancelled'
       : why[0].pending ? 'pending'
       : why[0].already ? 'already' : 'gone';
     return res.redirect('/q/' + code + '?e=' + reason);
@@ -7402,6 +7420,53 @@ async function sendReceipt(code, to = null) {
  *   - the reason is recorded, because "why is this $372.50 short" is a question
  *     somebody will ask months later
  */
+/* Cancel a quote, and put it back.
+ *
+ * CANCEL, not delete. A quote records what was agreed, and once money has moved
+ * it is what the payment rows point at — deleting the row destroys the
+ * customer's history and orphans the ledger. It is also unrecoverable, and the
+ * last gap like this was papered over by marking jobs delivered, which is
+ * exactly what happens when the only available action is too final to trust.
+ *
+ * So: it leaves the board, every chase stops, the record survives, and it can be
+ * put back.
+ */
+app.post('/quote/:code/cancel', requireAdmin, async (req, res) => {
+  const code = String(req.params.code || '').toUpperCase();
+  if (!QUOTE_CODE_RE.test(code)) return res.redirect('/quotes');
+  const reason = String((req.body && req.body.reason) || '').trim().slice(0, 200);
+  try {
+    /* delivered_at is cleared: a cancelled job did not ship, and leaving the
+       stamp on would keep it counted as delivered work in the schedule. It is
+       also how these were being hidden before cancelling existed. */
+    await pool.query(
+      `UPDATE quotes SET cancelled_at = NOW(), cancel_reason = $2,
+              status = 'cancelled', delivered_at = NULL
+        WHERE code = $1 AND cancelled_at IS NULL`,
+      [code, reason || null]);
+  } catch (err) {
+    console.error('cancel failed:', err.message);
+  }
+  res.redirect('/quotes');
+});
+
+app.post('/quote/:code/uncancel', requireAdmin, async (req, res) => {
+  const code = String(req.params.code || '').toUpperCase();
+  if (!QUOTE_CODE_RE.test(code)) return res.redirect('/quotes');
+  try {
+    /* Back to accepted or sent depending on whether they had accepted — not to
+       whatever the status was before, which is not recorded and would be a guess
+       dressed up as a fact. */
+    await pool.query(
+      `UPDATE quotes SET cancelled_at = NULL, cancel_reason = NULL,
+              status = CASE WHEN accepted_at IS NOT NULL THEN 'accepted' ELSE 'sent' END
+        WHERE code = $1`, [code]);
+  } catch (err) {
+    console.error('uncancel failed:', err.message);
+  }
+  res.redirect('/quotes');
+});
+
 app.post('/quote/:code/settle', requireAdmin, async (req, res) => {
   const code = String(req.params.code || '').toUpperCase();
   if (!QUOTE_CODE_RE.test(code)) return res.redirect('/quotes');
@@ -7989,7 +8054,11 @@ async function renderBoard(VIEW, req, res) {
             <span class="chip" style="background:${bg};color:${fg}">${paid ? 'paid ' + money(q.paid_amount) : st}</span>
           </div>
         </div>
-        ${balanceOf(q) > 0
+        ${q.cancelled_at
+          ? `<div class="muted" style="margin-top:6px;color:#b91c1c">cancelled${
+              q.cancel_reason ? ' — ' + escEmail(q.cancel_reason) : ''}${
+              Number(q.paid_amount || 0) > 0 ? ` &middot; <b>${money(q.paid_amount)} paid — refund owed</b>` : ''}</div>`
+          : balanceOf(q) > 0
           ? `<div class="muted" style="margin-top:6px;color:#b45309">balance due ${money(balanceOf(q))}</div>`
           : Number(q.written_off || 0) > 0
           ? `<div class="muted" style="margin-top:6px">settled &middot; ${money(q.written_off)} written off${
@@ -8020,7 +8089,26 @@ async function renderBoard(VIEW, req, res) {
              onclick="document.getElementById('mp-${q.code}').style.display='block';this.style.display='none'">Record a payment</button>` : ''}
           ${outstanding > 0 ? `<button type="button" class="btn btn-ghost" style="padding:8px 16px;font-size:13px"
              onclick="document.getElementById('st-${q.code}').style.display='block';this.style.display='none'">Settle &mdash; no more owed</button>` : ''}
+          ${q.cancelled_at ? `
+          <form method="POST" action="/quote/${q.code}/uncancel" style="display:inline"
+                onsubmit="return confirm('Put ${q.code} back on the board?')">
+            <button type="submit" class="btn btn-ghost" style="padding:8px 16px;font-size:13px">Restore</button>
+          </form>` : `
+          <button type="button" class="btn btn-ghost" style="padding:8px 16px;font-size:13px;color:#b91c1c"
+             onclick="document.getElementById('cx-${q.code}').style.display='block';this.style.display='none'">Cancel order</button>`}
         </div>
+        ${q.cancelled_at ? '' : `
+        <form id="cx-${q.code}" method="POST" action="/quote/${q.code}/cancel"
+              style="display:none;margin-top:10px;background:#fef4f4;border:1px solid #f3c8c8;border-radius:10px;padding:12px"
+              onsubmit="return confirm('Cancel ${q.code}? It leaves the board and all reminders stop. You can restore it later.')">
+          <div style="font-weight:700;color:#b91c1c;margin-bottom:4px">Cancel this order</div>
+          <p class="muted" style="margin:0 0 8px;font-size:12.5px">It comes off the board and every reminder stops.
+            Nothing is deleted &mdash; the record and any payments stay, and you can restore it.${
+            Number(q.paid_amount || 0) > 0 ? ` <b style="color:#b45309">${money(q.paid_amount)} has been paid on this job — refund it separately.</b>` : ''}</p>
+          <input name="reason" maxlength="200" placeholder="Why — e.g. customer cancelled"
+                 style="width:100%;padding:7px;font-size:13px;margin-bottom:8px">
+          <button type="submit" class="btn" style="padding:7px 16px;font-size:13px;background:#b91c1c">Cancel the order</button>
+        </form>`}
         ${outstanding > 0 ? `
         <form id="st-${q.code}" method="POST" action="/quote/${q.code}/settle"
               style="display:none;margin-top:10px;background:#fffbf2;border:1px solid #f0d9a8;border-radius:10px;padding:12px"
@@ -8269,12 +8357,19 @@ async function renderBoard(VIEW, req, res) {
 
        The existing sort — behind schedule, then soonest deadline — is preserved
        inside each group, because urgency still matters within the work in hand. */
-    const isDelivered = (q) => !!q.delivered_at;
+    const isCancelled = (q) => !!q.cancelled_at;
+    const isDelivered = (q) => !!q.delivered_at && !isCancelled(q);
     const isPaid = (q) => Number(q.paid_amount || 0) > 0;
 
-    const gOrders = rows.filter((q) => isPaid(q) && !isDelivered(q));
-    const gQuotes = rows.filter((q) => !isPaid(q) && !isDelivered(q));
+    /* Cancelled work is not work. It leaves the three live groups completely
+       rather than sitting greyed out among them, because the board's job is to
+       show what still needs doing. It keeps a group of its own so a cancellation
+       can be found and undone — the previous fix failed precisely because the
+       only available action could not be reversed. */
+    const gOrders = rows.filter((q) => !isCancelled(q) && isPaid(q) && !isDelivered(q));
+    const gQuotes = rows.filter((q) => !isCancelled(q) && !isPaid(q) && !isDelivered(q));
     const gDone   = rows.filter(isDelivered);
+    const gCancelled = rows.filter(isCancelled);
 
     const group = (title, note, list) => !list.length ? '' : `
       <div class="quote-grid-head">
@@ -8285,7 +8380,8 @@ async function renderBoard(VIEW, req, res) {
     const body =
       group('Orders', 'deposit in — work in hand', gOrders) +
       group('Open quotes', 'sent, nothing paid yet', gQuotes) +
-      group('Delivered', 'done', gDone);
+      group('Delivered', 'done', gDone) +
+      group('Cancelled', 'not going ahead', gCancelled);
 
     const needCount = (body.match(/Needs a text/g) || []).length;
     const changeCount = (body.match(/Change requested/g) || []).length;
@@ -9632,6 +9728,7 @@ async function sendDepositReminders() {
         WHERE accepted_at IS NOT NULL
           AND COALESCE(paid_amount,0) = 0
           AND deposit_nudged_at IS NULL
+          AND cancelled_at IS NULL
           AND accepted_at <= NOW() - ($1 || ' days')::interval
           AND email <> ''
         LIMIT 20`, [String(days)]);
@@ -9678,6 +9775,7 @@ async function sendBalanceReminders() {
         WHERE COALESCE(paid_amount,0) > 0
           AND COALESCE(paid_amount,0) + COALESCE(written_off,0) < total
           AND balance_nudged_at IS NULL
+          AND cancelled_at IS NULL
           AND paid_at <= NOW() - ($1 || ' days')::interval
           AND status <> 'expired'
           AND email <> ''
@@ -9729,6 +9827,7 @@ async function sendReorderNudges() {
         WHERE COALESCE(q.paid_amount,0) >= q.total
           AND q.total > 0
           AND q.reorder_nudged_at IS NULL
+          AND q.cancelled_at IS NULL
           AND q.paid_at <= NOW() - ($1 || ' days')::interval
           AND q.email <> ''
           /* Nothing newer from this customer — a live job means they do not

--- a/tests/board-grouping.test.js
+++ b/tests/board-grouping.test.js
@@ -28,30 +28,40 @@ test('the board groups on money arriving, not on status text', () => {
      the paid work while no money had moved. */
   assert.match(board, /const isPaid = \(q\) => Number\(q\.paid_amount \|\| 0\) > 0/,
     'the split must be on the amount actually paid');
-  assert.match(board, /const gOrders = rows\.filter\(\(q\) => isPaid\(q\) && !isDelivered\(q\)\)/);
-  assert.match(board, /const gQuotes = rows\.filter\(\(q\) => !isPaid\(q\) && !isDelivered\(q\)\)/);
+  assert.match(board, /const gOrders = rows\.filter\(\(q\) => !isCancelled\(q\) && isPaid\(q\) && !isDelivered\(q\)\)/);
+  assert.match(board, /const gQuotes = rows\.filter\(\(q\) => !isCancelled\(q\) && !isPaid\(q\) && !isDelivered\(q\)\)/);
 });
 
 test('every job lands in exactly one group', () => {
   /* A job appearing twice would double the board; one appearing nowhere would
      be invisible, which is worse. */
   const rows = [
-    { code: 'A', paid_amount: 0,   delivered_at: null },        // open quote
-    { code: 'B', paid_amount: 500, delivered_at: null },        // order
-    { code: 'C', paid_amount: 500, delivered_at: '2026-08-01' },// delivered
-    { code: 'D', paid_amount: 0,   delivered_at: '2026-08-01' },// delivered unpaid
-    { code: 'E', paid_amount: null, delivered_at: null },       // never touched
+    { code: 'A', paid_amount: 0,   delivered_at: null, cancelled_at: null },        // open quote
+    { code: 'B', paid_amount: 500, delivered_at: null, cancelled_at: null },        // order
+    { code: 'C', paid_amount: 500, delivered_at: '2026-08-01', cancelled_at: null },// delivered
+    { code: 'D', paid_amount: 0,   delivered_at: '2026-08-01', cancelled_at: null },// delivered unpaid
+    { code: 'E', paid_amount: null, delivered_at: null, cancelled_at: null },       // never touched
+    { code: 'F', paid_amount: 0,   delivered_at: null, cancelled_at: '2026-08-30' },// cancelled
+    /* Cancelled AFTER being hidden as delivered — the exact state the old
+       workaround left behind. It must read as cancelled, not as delivered. */
+    { code: 'G', paid_amount: 0,   delivered_at: '2026-08-01', cancelled_at: '2026-08-30' },
   ];
-  const isDelivered = (q) => !!q.delivered_at;
+  const isCancelled = (q) => !!q.cancelled_at;
+  const isDelivered = (q) => !!q.delivered_at && !isCancelled(q);
   const isPaid = (q) => Number(q.paid_amount || 0) > 0;
   const groups = {
-    orders: rows.filter((q) => isPaid(q) && !isDelivered(q)),
-    quotes: rows.filter((q) => !isPaid(q) && !isDelivered(q)),
+    orders: rows.filter((q) => !isCancelled(q) && isPaid(q) && !isDelivered(q)),
+    quotes: rows.filter((q) => !isCancelled(q) && !isPaid(q) && !isDelivered(q)),
     done:   rows.filter(isDelivered),
+    cancelled: rows.filter(isCancelled),
   };
-  const seen = [].concat(groups.orders, groups.quotes, groups.done).map((q) => q.code).sort();
-  assert.deepStrictEqual(seen, ['A', 'B', 'C', 'D', 'E'],
-    'every row must appear exactly once across the three groups');
+  const seen = [].concat(groups.orders, groups.quotes, groups.done, groups.cancelled)
+    .map((q) => q.code).sort();
+  assert.deepStrictEqual(seen, ['A', 'B', 'C', 'D', 'E', 'F', 'G'],
+    'every row must appear exactly once across the four groups');
+  assert.deepStrictEqual(groups.cancelled.map((q) => q.code), ['F', 'G']);
+  assert.deepStrictEqual(groups.done.map((q) => q.code), ['C', 'D'],
+    'a cancelled job is not delivered work, even if it carries a delivered stamp');
   assert.deepStrictEqual(groups.quotes.map((q) => q.code), ['A', 'E'],
     'a null paid_amount is unpaid, not paid');
   assert.deepStrictEqual(groups.orders.map((q) => q.code), ['B']);
@@ -69,15 +79,17 @@ test('the three groups are rendered in working order', () => {
   const i = board.indexOf("group('Orders'");
   const j = board.indexOf("group('Open quotes'");
   const k = board.indexOf("group('Delivered'");
-  assert.ok(i > -1 && j > -1 && k > -1, 'all three groups must be rendered');
-  assert.ok(i < j && j < k, 'order must be Orders, then Open quotes, then Delivered');
+  const l = board.indexOf("group('Cancelled'");
+  assert.ok(i > -1 && j > -1 && k > -1 && l > -1, 'all four groups must be rendered');
+  assert.ok(i < j && j < k && k < l,
+    'order must be Orders, Open quotes, Delivered, then Cancelled last');
 });
 
 test('the sort inside each group is preserved', () => {
   /* The groups filter the already-sorted `rows`, so behind-schedule and
      soonest-deadline still float within the work in hand. Building them from
      the raw query would silently drop that. */
-  assert.match(board, /rows\.filter\(\(q\) => isPaid/,
+  assert.match(board, /rows\.filter\(\(q\) => !isCancelled\(q\) && isPaid/,
     'groups must filter the sorted rows, not re-query');
 });
 

--- a/tests/quote-accept-and-pay.test.js
+++ b/tests/quote-accept-and-pay.test.js
@@ -58,8 +58,9 @@ test('every reason the redirect can carry is rendered', () => {
 test('accept and pay are both hidden while a change is pending', () => {
   /* One expression gates both, so they cannot drift apart: the pay block is its
      `accepted` branch and the accept form is its `else`. */
-  assert.match(page, /\$\{paid \|\| q\.requested_items \? '' : accepted \?/,
-    'a pending request must suppress both the pay options and the accept form');
+  assert.match(page, /\$\{paid \|\| q\.requested_items \|\| q\.cancelled_at \? '' : accepted \?/,
+    'a pending request — or a cancellation — must suppress both the pay options ' +
+    'and the accept form, through the one expression that gates them together');
 });
 
 test('the pending state is explained where the buttons used to be', () => {

--- a/tests/quote-settle.test.js
+++ b/tests/quote-settle.test.js
@@ -117,3 +117,69 @@ test('revenue is not touched by a write-off', () => {
   assert.doesNotMatch(route, /INSERT INTO quote_payments/,
     'a write-off is not a payment and must not enter the ledger');
 });
+
+/* ── Cancellation ────────────────────────────────────────────────────────── */
+
+test('cancelling never deletes the row', () => {
+  /* A quote records what was agreed, and once money has moved it is what the
+     payment rows point at. Deleting it destroys the customer's history and
+     orphans the ledger — and it cannot be undone, which is how the last gap got
+     papered over with a fake "delivered". */
+  const route = src.slice(src.indexOf("app.post('/quote/:code/cancel'"),
+                          src.indexOf("app.post('/quote/:code/uncancel'"));
+  assert.doesNotMatch(route, /DELETE FROM/, 'cancelling must not delete anything');
+  assert.match(route, /SET cancelled_at = NOW\(\), cancel_reason = \$2/);
+});
+
+test('cancelling clears the delivered stamp', () => {
+  /* A cancelled job did not ship. Leaving the stamp on keeps it counted as
+     delivered work — and marking things delivered is exactly the workaround
+     this replaces, so those rows carry a stamp that is not true. */
+  const route = src.slice(src.indexOf("app.post('/quote/:code/cancel'"),
+                          src.indexOf("app.post('/quote/:code/uncancel'"));
+  assert.match(route, /delivered_at = NULL/);
+});
+
+test('a cancellation can be undone', () => {
+  /* An action too final to trust is an action people work around. */
+  assert.match(src, /app\.post\('\/quote\/:code\/uncancel', requireAdmin/);
+  const route = src.slice(src.indexOf("app.post('/quote/:code/uncancel'"));
+  assert.match(route, /cancelled_at = NULL, cancel_reason = NULL/);
+  assert.match(route, /CASE WHEN accepted_at IS NOT NULL THEN 'accepted' ELSE 'sent' END/,
+    'restoring must not invent a status that was never recorded');
+});
+
+test('cancelling is admin-only, both ways', () => {
+  assert.match(src, /app\.post\('\/quote\/:code\/cancel', requireAdmin/);
+  assert.match(src, /app\.post\('\/quote\/:code\/uncancel', requireAdmin/);
+});
+
+test('a cancelled quote cannot be accepted or paid', () => {
+  /* The buttons are hidden, but a stale tab or a typed URL must still be
+     refused — the guard is the rule, the UI is a courtesy. */
+  const accept = src.slice(src.indexOf("app.post('/q/:code/accept'"));
+  assert.match(accept.slice(0, accept.indexOf('RETURNING')), /AND cancelled_at IS NULL/);
+  const pay = src.slice(src.indexOf("app.get(['/q/:code/pay/card'"));
+  assert.match(pay.slice(0, pay.indexOf('const t = quoteTotals')),
+    /if \(q\.cancelled_at\) return res\.redirect/);
+});
+
+test('every automated chase skips a cancelled quote', () => {
+  /* Three crons email the customer. A cancelled order that still sends "your
+     deposit is due" is the shop asking for money on a job it has called off. */
+  for (const col of ['deposit_nudged_at', 'balance_nudged_at']) {
+    const i = src.indexOf(`AND ${col} IS NULL`);
+    assert.notStrictEqual(i, -1, `${col} chase not found`);
+    assert.match(src.slice(i, i + 120), /AND cancelled_at IS NULL/,
+      `the ${col} chase must skip cancelled quotes`);
+  }
+  const r = src.indexOf('AND q.reorder_nudged_at IS NULL');
+  assert.match(src.slice(r, r + 120), /AND q\.cancelled_at IS NULL/);
+});
+
+test('a cancelled quote with money on it flags the refund', () => {
+  /* Cancelling does not move money. If a deposit was taken, somebody has to
+     send it back, and the board is where that is noticed. */
+  assert.match(src, /refund owed/,
+    'the card must say a refund is owed when a cancelled job carries a payment');
+});


### PR DESCRIPTION
Tesha cancelled; there was no way to record that, so the job was marked
**delivered** to get it off the board. That is the second time a missing action
has been papered over with a wrong one.

## Cancel, not delete

You asked to delete them. This cancels instead, and I want to be straight about
why rather than quietly substituting:

- A quote records what was agreed, and once money has moved it is **what the
  payment rows point at**. Deleting the row destroys the customer's history and
  orphans the ledger.
- Deleting cannot be undone. The last gap got worked around precisely *because*
  the only available action was too final to trust — a cancel that can be
  restored does not create that pressure.

The practical result is the same: it leaves the board, every reminder stops, and
it is out of your way. If you genuinely want rows destroyed, say so and I will
add a hard delete — but I would keep it to quotes with no payments.

## What it does

- **Cancel order** on every card, with a reason. **Restore** on cancelled ones.
- **Clears `delivered_at`.** A cancelled job did not ship, and leaving that stamp
  keeps it counted as delivered work — which is exactly the false state the old
  workaround created.
- Its own **Cancelled** group at the bottom of the board, out of Orders, Open
  quotes and Delivered.
- **All three nudge crons skip it.** A cancelled order that still emails "your
  deposit is due" is the shop chasing money on a job it called off.
- **Accept and pay are refused server-side**, not just hidden — a stale tab or a
  typed URL still fails. The customer's page says it was cancelled.
- If a cancelled job carries a payment, the card says **"refund owed"**.
  Cancelling deliberately does not move money; sending it back is a separate,
  deliberate act.

## On Tesha specifically

She is currently `delivered_at` set, $151.04 total, nothing paid. Cancelling her
clears that false delivered stamp — she will move from Delivered to Cancelled,
which is what actually happened.

**I have not cancelled her.** That is your record of your business to change.

## Tests

378/378, 7 new plus updates. The partition test now includes the exact state the
old workaround left behind — cancelled *and* carrying a delivered stamp — and
asserts it reads as cancelled, not as delivered work.