### PR TITLE
Downloadable monthly records, and stop the board hiding live work

### DIFF
--- a/server.js
+++ b/server.js
@@ -7194,7 +7194,8 @@ app.get('/books', requireAdmin, async (req, res) => {
         </div>
         <div class="muted" style="font-size:11px;margin-top:10px">
           Held right now spans every period, not just ${year} — it is what should be in the bank today.
-          <a href="/tax.csv" style="color:#1848B8">Download the payment-level detail</a>.
+          <a href="/tax.csv" style="color:#1848B8">Download the payment-level detail</a>,
+          or <a href="/exports" style="color:#1848B8">keep a month's records</a>.
         </div>
       </div>`, 'money'));
   } catch (err) {
@@ -7289,6 +7290,184 @@ app.post('/expenses/roll', requireAdmin, async (req, res) => {
 
 /* Sales tax detail as CSV, for the ST-1 filing or the bookkeeper. One row per
    payment, because that is the level a state will ask you to substantiate. */
+/* ── Records you can keep ─────────────────────────────────────────────────
+ *
+ * Everything here lives in one Postgres database on Railway. That is a fine
+ * place to run from and a poor place to KEEP records: it is one account, one
+ * card on file, one accidental delete away from being the only copy. Anything
+ * that matters for tax, for a dispute, or for a customer asking "what did I pay
+ * you in March" needs to exist somewhere the shop controls.
+ *
+ * So: plain CSV, one month at a time, downloadable by hand. No dependency, no
+ * account, no format that needs this app to read it back — a spreadsheet in a
+ * folder outlives whatever happens to the hosting.
+ */
+const csvEsc = (v) => {
+  const t = String(v == null ? '' : v);
+  return /[",\n]/.test(t) ? '"' + t.replace(/"/g, '""') + '"' : t;
+};
+
+/** Send rows as a CSV download. `Cache-Control: no-store` because these carry
+ *  customer names, phone numbers and money. */
+function sendCsv(res, filename, head, rows) {
+  res.set('Content-Type', 'text/csv; charset=utf-8');
+  res.set('Content-Disposition', `attachment; filename="${filename}"`);
+  res.set('Cache-Control', 'no-store');
+  res.send([head.join(','), ...rows.map((r) => r.map(csvEsc).join(','))].join('\n'));
+}
+
+/** A month as [start, end), or the whole of time when none is given. Parsed
+ *  strictly: a bad value returns everything rather than a silently empty file
+ *  that reads as "no business that month". */
+function monthRange(v) {
+  const m = /^(\d{4})-(\d{2})$/.exec(String(v || ''));
+  if (!m) return null;
+  const from = `${m[1]}-${m[2]}-01`;
+  const y = Number(m[1]), mo = Number(m[2]);
+  const nextY = mo === 12 ? y + 1 : y, nextM = mo === 12 ? 1 : mo + 1;
+  return { from, to: `${nextY}-${String(nextM).padStart(2, '0')}-01`, label: `${m[1]}-${m[2]}` };
+}
+
+/* Quotes and orders — one row per job. The line items are flattened into a
+   readable summary rather than raw JSON, because the point is a record a person
+   can open, not a backup this app could restore. */
+/* One page listing what can be kept, month by month. The months are DERIVED
+   from the data rather than a date picker: a picker invites a month with nothing
+   in it, and an empty CSV reads as "no business" rather than "wrong month". */
+app.get('/exports', requireAdmin, async (_req, res) => {
+  try {
+    const { rows: months } = await pool.query(
+      `SELECT to_char(m, 'YYYY-MM') AS ym, to_char(m, 'Mon YYYY') AS label,
+              SUM(quotes) AS quotes, SUM(payments) AS payments, SUM(collected) AS collected
+         FROM (
+           SELECT date_trunc('month', created_at) AS m, count(*) AS quotes,
+                  0 AS payments, 0::numeric AS collected FROM quotes GROUP BY 1
+           UNION ALL
+           SELECT date_trunc('month', created_at), 0, count(*), SUM(amount)
+             FROM quote_payments GROUP BY 1
+         ) x GROUP BY m ORDER BY m DESC`);
+
+    const rows = months.map((m) => `
+      <tr>
+        <td style="padding:8px 4px"><b>${escEmail(m.label)}</b></td>
+        <td class="num" style="padding:8px 4px">${m.quotes}</td>
+        <td class="num" style="padding:8px 4px">${m.payments}</td>
+        <td class="num" style="padding:8px 4px">${money(m.collected)}</td>
+        <td style="padding:8px 4px;text-align:right;white-space:nowrap">
+          <a href="/exports/quotes.csv?month=${m.ym}">quotes</a> &middot;
+          <a href="/exports/payments.csv?month=${m.ym}">payments</a> &middot;
+          <a href="/exports/expenses.csv?month=${m.ym}">expenses</a></td>
+      </tr>`).join('');
+
+    res.send(adminPage('Records', `<h1>Records</h1>
+      <div class="sub">Download a month, keep it somewhere that is not this app</div>
+
+      <div class="card" style="margin-bottom:14px">
+        <b style="color:#0B1F4B">Why bother downloading</b>
+        <p class="muted" style="margin:6px 0 0">Everything here lives in one database on Railway.
+          That is fine to run from and poor to keep records in — one account, one card on file, one
+          bad afternoon away from being the only copy. These are plain CSV: they open in Excel,
+          Numbers or Sheets, they import into accounting software, and they do not need this app
+          to be readable in five years.</p>
+        <p class="muted" style="margin:8px 0 0"><b>A habit worth having:</b> on the first of the month,
+          download the previous month's three files into a dated folder. Two minutes, and it is the
+          difference between an inconvenience and a catastrophe.</p>
+      </div>
+
+      <div class="card">
+        <table style="width:100%;border-collapse:collapse">
+          <thead><tr style="text-align:left;border-bottom:1px solid #e3e8f2">
+            <th style="padding:6px 4px">Month</th>
+            <th class="num" style="padding:6px 4px">Quotes</th>
+            <th class="num" style="padding:6px 4px">Payments</th>
+            <th class="num" style="padding:6px 4px">Collected</th>
+            <th style="padding:6px 4px;text-align:right">Download</th>
+          </tr></thead>
+          <tbody>${rows || '<tr><td colspan="5" class="muted" style="padding:10px 4px">Nothing recorded yet.</td></tr>'}</tbody>
+        </table>
+        <p class="muted" style="margin-top:12px;font-size:13px">Everything, all months:
+          <a href="/exports/quotes.csv">quotes</a> &middot;
+          <a href="/exports/payments.csv">payments</a> &middot;
+          <a href="/exports/expenses.csv">expenses</a> &middot;
+          <a href="/tax.csv">sales tax detail</a></p>
+      </div>`, 'money'));
+  } catch (err) {
+    console.error('exports page failed:', err.message);
+    res.status(500).send('Could not load records.');
+  }
+});
+
+app.get('/exports/quotes.csv', requireAdmin, async (req, res) => {
+  const r = monthRange(req.query.month);
+  try {
+    const { rows } = await pool.query(
+      r ? `SELECT * FROM quotes WHERE created_at >= $1 AND created_at < $2 ORDER BY created_at`
+        : `SELECT * FROM quotes ORDER BY created_at`,
+      r ? [r.from, r.to] : []);
+    const head = ['code','created','customer','email','phone','status','items',
+                  'subtotal','discount','tax','total','paid','written_off','balance',
+                  'accepted_at','paid_at','delivered_at','cancelled_at','cancel_reason','needed_by'];
+    const body = rows.map((q) => {
+      const t = quoteTotals(q);
+      const items = (q.items || [])
+        .map((i) => `${i.qty} x ${i.description} @ ${money(i.unit_price)}`).join(' | ');
+      const d = (v) => (v ? new Date(v).toISOString().slice(0, 10) : '');
+      return [q.code, d(q.created_at), q.name, q.email, q.phone, q.status, items,
+              t.subtotal, t.discount, t.tax, t.total,
+              Number(q.paid_amount || 0), Number(q.written_off || 0), balanceOf(q, t.total),
+              d(q.accepted_at), d(q.paid_at), d(q.delivered_at), d(q.cancelled_at),
+              q.cancel_reason || '', d(q.needed_by)];
+    });
+    sendCsv(res, `jtees-quotes-${r ? r.label : 'all'}.csv`, head, body);
+  } catch (err) {
+    console.error('quotes csv failed:', err.message);
+    res.status(500).send('Could not build that export.');
+  }
+});
+
+/* Money actually received, from the ledger — the figure that belongs in a
+   revenue line. A quote total is what was ASKED for. */
+app.get('/exports/payments.csv', requireAdmin, async (req, res) => {
+  const r = monthRange(req.query.month);
+  try {
+    const { rows } = await pool.query(
+      `SELECT p.created_at, p.quote_code, q.name, q.email, p.amount, p.fee, p.method,
+              p.kind, p.source, p.note, q.total AS job_total, q.tax AS job_tax
+         FROM quote_payments p LEFT JOIN quotes q ON q.code = p.quote_code
+        ${r ? 'WHERE p.created_at >= $1 AND p.created_at < $2' : ''}
+        ORDER BY p.created_at`, r ? [r.from, r.to] : []);
+    const head = ['date','quote','customer','email','amount','card_fee','net',
+                  'method','kind','source','note','job_total','job_tax'];
+    const body = rows.map((p) => [
+      new Date(p.created_at).toISOString().slice(0, 10), p.quote_code, p.name, p.email,
+      p.amount, p.fee, round2(Number(p.amount || 0) - Number(p.fee || 0)),
+      p.method, p.kind, p.source, p.note, p.job_total, p.job_tax,
+    ]);
+    sendCsv(res, `jtees-payments-${r ? r.label : 'all'}.csv`, head, body);
+  } catch (err) {
+    console.error('payments csv failed:', err.message);
+    res.status(500).send('Could not build that export.');
+  }
+});
+
+app.get('/exports/expenses.csv', requireAdmin, async (req, res) => {
+  const r = monthRange(req.query.month);
+  try {
+    const { rows } = await pool.query(
+      `SELECT * FROM expenses ${r ? 'WHERE spent_on >= $1 AND spent_on < $2' : ''}
+        ORDER BY spent_on`, r ? [r.from, r.to] : []);
+    const head = ['date','category','vendor','amount','recurring','note'];
+    const body = rows.map((e) => [
+      e.spent_on ? new Date(e.spent_on).toISOString().slice(0, 10) : '',
+      e.category, e.vendor, e.amount, e.recurs ? 'yes' : '', e.note,
+    ]);
+    sendCsv(res, `jtees-expenses-${r ? r.label : 'all'}.csv`, head, body);
+  } catch (err) {
+    console.error('expenses csv failed:', err.message);
+    res.status(500).send('Could not build that export.');
+  }
+});
+
 app.get('/tax.csv', requireAdmin, async (req, res) => {
   try {
     const { rows } = await pool.query(
@@ -7916,7 +8095,28 @@ function studioOrdersSection(feed, { heading = true } = {}) {
 
 async function renderBoard(VIEW, req, res) {
   try {
-    const { rows: allRows } = await pool.query('SELECT * FROM quotes ORDER BY created_at DESC LIMIT 200');
+    /* The board showed the 200 most recent quotes and nothing else, so once the
+       shop passes 200 an older job would drop off it silently — including one
+       still owed money. Invisible is worse than old: nobody chases what they
+       cannot see.
+
+       So the cap applies only to work that is FINISHED. Anything live — money
+       outstanding, not delivered, not cancelled, or a change waiting on a reply
+       — is always loaded, however old it is. The board can grow past 200 rows
+       only by carrying jobs that genuinely still need something. */
+    const { rows: allRows } = await pool.query(
+      `SELECT * FROM quotes
+        WHERE cancelled_at IS NULL AND delivered_at IS NULL
+           OR COALESCE(paid_amount,0) + COALESCE(written_off,0) < total
+           OR requested_items IS NOT NULL
+        UNION
+        SELECT * FROM (
+          SELECT * FROM quotes
+           WHERE (cancelled_at IS NOT NULL OR delivered_at IS NOT NULL)
+             AND COALESCE(paid_amount,0) + COALESCE(written_off,0) >= total
+             AND requested_items IS NULL
+           ORDER BY created_at DESC LIMIT 200) AS finished
+        ORDER BY created_at DESC`);
     /* Fetched alongside the quotes so both halves of the shop appear on one
        page. Never awaited in a way that can fail the board — fetchStudioOrders
        resolves to a stale list plus an error rather than throwing. */

--- a/tests/exports.test.js
+++ b/tests/exports.test.js
@@ -1,0 +1,124 @@
+'use strict';
+
+/* Records the shop can keep.
+ *
+ * Everything lives in one Postgres database on Railway — fine to run from, poor
+ * to KEEP records in: one account, one card on file, one bad afternoon away from
+ * being the only copy. Tax records, disputes and "what did I pay you in March"
+ * all need to survive this app.
+ *
+ * Plain CSV, by month, downloaded by hand. No dependency and no format that
+ * needs this application to read it back.
+ */
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const src = fs.readFileSync(path.join(__dirname, '..', 'server.js'), 'utf8');
+
+function lift(name) {
+  const start = src.indexOf(`function ${name}(`);
+  assert.notStrictEqual(start, -1, `${name} not found`);
+  let depth = 0;
+  for (let i = src.indexOf('{', start); i < src.length; i++) {
+    if (src[i] === '{') depth++;
+    else if (src[i] === '}' && --depth === 0) return src.slice(start, i + 1);
+  }
+  throw new Error('unbalanced braces reading ' + name);
+}
+const monthRange = vm.runInThisContext(lift('monthRange') + '\nmonthRange');
+const csvEsc = vm.runInThisContext(
+  src.match(/^const csvEsc = [\s\S]*?\n\};$/m)[0] + '\ncsvEsc');
+
+/* ── The month window ────────────────────────────────────────────────────── */
+
+test('a month is a half-open range, so nothing is counted twice', () => {
+  /* [from, to) — a payment at 00:00 on the 1st belongs to the new month, not to
+     both. Using BETWEEN with a month end would double-count that row across two
+     exports and the totals would not reconcile. */
+  const r = monthRange('2026-08');
+  assert.strictEqual(r.from, '2026-08-01');
+  assert.strictEqual(r.to, '2026-09-01');
+});
+
+test('December rolls the year, not the month', () => {
+  const r = monthRange('2026-12');
+  assert.strictEqual(r.to, '2027-01-01');
+});
+
+test('a bad month exports everything rather than nothing', () => {
+  /* An empty CSV reads as "no business that month", which is a lie a person
+     could act on. Returning null means the route drops the WHERE and sends the
+     lot — obviously wrong rather than quietly wrong. */
+  for (const bad of ['', 'august', '2026-13-01', '26-08', null, undefined, '2026/08']) {
+    assert.strictEqual(monthRange(bad), null, `${String(bad)} must not parse`);
+  }
+});
+
+/* ── The CSV itself ──────────────────────────────────────────────────────── */
+
+test('a customer name with a comma cannot break the file', () => {
+  /* "Martin, Melissa" unescaped shifts every later column by one, silently, for
+     that row only — the kind of corruption found months later in a spreadsheet
+     nobody reconciled. */
+  assert.strictEqual(csvEsc('Martin, Melissa'), '"Martin, Melissa"');
+  assert.strictEqual(csvEsc('He said "yes"'), '"He said ""yes"""');
+  assert.strictEqual(csvEsc('line one\nline two'), '"line one\nline two"');
+  assert.strictEqual(csvEsc('plain'), 'plain');
+  assert.strictEqual(csvEsc(null), '');
+  assert.strictEqual(csvEsc(0), '0', 'zero is a number, not an empty cell');
+});
+
+test('exports are admin-only and never cached', () => {
+  /* They carry names, emails, phone numbers and money. */
+  for (const r of ['/exports', '/exports/quotes.csv', '/exports/payments.csv', '/exports/expenses.csv']) {
+    assert.match(src, new RegExp(`app\\.get\\('${r.replace(/\//g, '\\/')}', requireAdmin`),
+      `${r} must require admin`);
+  }
+  const send = src.slice(src.indexOf('function sendCsv'));
+  assert.match(send.slice(0, 400), /Cache-Control', 'no-store'/);
+  assert.match(send.slice(0, 400), /Content-Disposition/);
+});
+
+test('the payments export reports net of the card fee', () => {
+  /* Gross minus the processing fee is what actually reached the bank. An export
+     that only shows gross overstates income by the fee on every card payment. */
+  const route = src.slice(src.indexOf("app.get('/exports/payments.csv'"));
+  assert.match(route, /round2\(Number\(p\.amount \|\| 0\) - Number\(p\.fee \|\| 0\)\)/);
+  assert.match(route, /'net'/, 'and the column must be named');
+});
+
+test('the quotes export carries the written-off and balance figures', () => {
+  /* Otherwise a settled job exports as though it were still owed, and the
+     records disagree with the board. */
+  const route = src.slice(src.indexOf("app.get('/exports/quotes.csv'"));
+  assert.match(route, /'written_off','balance'/);
+  assert.match(route, /balanceOf\(q, t\.total\)/, 'through the shared balance rule');
+});
+
+test('the quotes export prices from items, not the stored total', () => {
+  /* quotes.total can lag an edit; quoteTotals is what the customer was shown. */
+  const route = src.slice(src.indexOf("app.get('/exports/quotes.csv'"));
+  assert.match(route, /const t = quoteTotals\(q\)/);
+});
+
+/* ── The board no longer hides live work ─────────────────────────────────── */
+
+test('an old job that still owes money is always loaded', () => {
+  /* The board took the 200 most recent quotes, so past 200 an unpaid job would
+     drop off silently. Nobody chases what they cannot see. The cap now applies
+     only to work that is finished AND settled AND not awaiting a reply. */
+  const board = src.slice(src.indexOf('async function renderBoard'));
+  const q = board.slice(0, board.indexOf('ORDER BY created_at DESC`)') + 40);
+  assert.match(q, /COALESCE\(paid_amount,0\) \+ COALESCE\(written_off,0\) < total/,
+    'anything still owed must bypass the limit');
+  assert.match(q, /requested_items IS NOT NULL/,
+    'a quote awaiting an edit must bypass it too');
+  assert.match(q, /cancelled_at IS NULL AND delivered_at IS NULL/,
+    'live work must bypass it');
+  assert.match(q, /LIMIT 200\) AS finished/,
+    'the cap should apply to finished work only');
+});


### PR DESCRIPTION
## What happens after 200 — it was worse than "it stops showing"

The board loaded `ORDER BY created_at DESC LIMIT 200`. Past 200 quotes, an older
job would **drop off silently — including one still owed money.** Nothing warns
you; it is simply not there. Invisible is worse than old, because nobody chases
what they cannot see.

The cap now applies **only to finished work**. Anything live — money
outstanding, not delivered, not cancelled, or a change waiting on your reply — is
always loaded however old it is. The board can only exceed 200 rows by carrying
jobs that genuinely still need something.

## Records — `/exports`

A page listing every month that has data, with per-month CSVs:

- **quotes** — one row per job: customer, items, subtotal, discount, tax, total,
  paid, written off, balance, and the accepted / paid / delivered / cancelled
  dates
- **payments** — from the ledger, with the card fee and the **net** that actually
  reached the bank
- **expenses** — date, category, vendor, amount

Months are derived from the data, not a date picker: a picker invites you to
choose a month with nothing in it, and an empty CSV reads as "no business that
month" rather than "wrong month".

Plain CSV on purpose — opens in Excel, Numbers or Sheets, imports into accounting
software, and needs nothing from this app to be readable in five years.

## Why this matters more than it looks

Everything lives in one Postgres database on one Railway account. That is fine to
run from and poor to keep records in: one account, one card on file, one bad
afternoon away from being the only copy. Tax records, a chargeback dispute, or a
customer asking what they paid in March all need to survive this application.

The page says so, and suggests the habit: first of the month, download the
previous month into a dated folder.

## Tests

387/387, 9 new. The two worth naming:

- **Half-open month range.** `[from, to)` — a payment at 00:00 on the 1st belongs
  to one month, not both. `BETWEEN` with a month end double-counts that row
  across two exports and the totals stop reconciling.
- **CSV escaping.** "Martin, Melissa" unescaped shifts every later column by one,
  silently, for that row only — the corruption you find months later in a
  spreadsheet nobody reconciled. Quotes, commas, newlines and a literal `0` are
  all pinned.