### PR TITLE
Two-lane board, and show the designs on unfinished carts

### DIFF
--- a/server.js
+++ b/server.js
@@ -4106,6 +4106,17 @@ form:has(>.step-row){display:block}
 .quote-grid-head{grid-column:1/-1;display:flex;align-items:baseline;gap:10px;margin:22px 0 -2px}
 .quote-grid-head:first-child{margin-top:0}
 .quote-grid-head h2{font-size:16px;margin:0;color:#0B1F4B}
+/* Two lanes: what might become money on the left, what already is on the right.
+   Stacked into one column below 1100px — side-by-side lanes on a phone give two
+   columns of nothing. The lanes are independent, so a long list of enquiries no
+   longer pushes the open quotes off the bottom of the page, which is what the
+   single stacked board did. */
+.board-lanes{display:grid;gap:18px;align-items:start}
+@media (min-width:1100px){ .board-lanes{grid-template-columns:minmax(0,1fr) minmax(0,1fr)} }
+.board-lane{min-width:0}
+.board-lane .quote-grid{display:block}
+.board-lane .quote-grid > .card{margin-bottom:14px}
+.board-lane .quote-grid-head{display:flex}
 .quote-grid .card table{max-width:100%}
 .quote-grid .card details table{display:block;overflow-x:auto}
 `;
@@ -8711,6 +8722,12 @@ async function renderBoard(VIEW, req, res) {
             : `${sent} of 5 recovery emails sent${c.last_sent ? ' — last ' + fmtDate(c.last_sent) : ''}`}
           ${sent >= 5 ? ' &middot; <b style="color:#b45309">sequence finished, no reply</b>' : ''}
         </div>
+        ${Array.isArray(c.previews) && c.previews.length ? `
+        <div style="display:flex;gap:6px;flex-wrap:wrap;margin-top:10px">
+          ${c.previews.map((u) => `<a href="${escEmail(u)}" target="_blank" rel="noopener">
+            <img src="${escEmail(u)}" alt="" loading="lazy"
+                 style="width:78px;height:78px;object-fit:contain;border-radius:8px;border:1px solid #e3e8f2;background:#fff"></a>`).join('')}
+        </div>` : ''}
         <div style="display:flex;gap:8px;flex-wrap:wrap;margin-top:12px">
           <a class="btn" style="padding:8px 16px;font-size:13px"
              href="/quote/new?email=${encodeURIComponent(c.email || '')}">Quote them</a>
@@ -8787,14 +8804,31 @@ async function renderBoard(VIEW, req, res) {
     const carts = (studio.carts || []).slice().sort((a, b) =>
       (Number(b.items) > 0) - (Number(a.items) > 0) || new Date(b.updated) - new Date(a.updated));
 
-    const body =
+    /* Two lanes. Left is what might become money; right is what already is.
+       Before this they were one stacked column, so a long list of enquiries
+       pushed the open quotes and orders off the bottom of the page — the exact
+       complaint that prompted the split. */
+    const laneLeft =
       group('New enquiries', 'from the website — no quote raised yet', leads, leadCard,
             { accent: '#b45309' }) +
       group('Unfinished carts', 'started a design, never checked out', carts, cartCard,
-            { accent: '#1848B8' }) +
+            { accent: '#1848B8' });
+
+    const laneRight =
       group('Orders', 'deposit in — work in hand', gOrders) +
       group('Open quotes', 'sent, nothing paid yet', gQuotes) +
       group('Cancelled', 'not going ahead', gCancelled);
+
+    /* Both lanes empty means an empty board; one empty lane is normal and still
+       renders, so the two columns do not jump around as work moves between
+       them. */
+    const body = (laneLeft || laneRight) ? `
+      <div class="board-lanes">
+        <div class="board-lane"><div class="quote-grid">${laneLeft ||
+          '<p class="muted" style="margin:0">No new enquiries or unfinished carts.</p>'}</div></div>
+        <div class="board-lane"><div class="quote-grid">${laneRight ||
+          '<p class="muted" style="margin:0">No open work.</p>'}</div></div>
+      </div>` : '';
 
     /* Folding, remembered. localStorage rather than a cookie: it is a per-browser
        display preference, it never needs to reach the server, and wrapped in
@@ -9011,7 +9045,7 @@ async function renderBoard(VIEW, req, res) {
             }).join('') || '<div class="kempty">—</div>'}
           </section>`).join('')}</div>
           ${live.length === 0 ? '<div class="card"><p class="muted">Nothing in production. Delivered jobs drop off this board.</p></div>' : ''}`;
-      })() : (body ? `<div class="quote-grid">${body}</div>${groupScript}` : '<div class="card"><p class="muted">No quotes yet.</p></div>')}
+      })() : (body ? `${body}${groupScript}` : '<div class="card"><p class="muted">No quotes yet.</p></div>')}
 
       ${studioOrdersSection(studio)}
       <script>

--- a/tests/board-grouping.test.js
+++ b/tests/board-grouping.test.js
@@ -138,12 +138,23 @@ test('a section heading spans every grid column', () => {
     'an inline-styled heading with no column span reintroduces the bug');
 });
 
-test('the headings live inside the same grid as the cards', () => {
-  /* They have to: a heading in its own container outside the grid would break
-     the masonry flow between sections and leave ragged gaps. Spanning the row
-     is what keeps one grid and still reads as sections. */
-  const render = src.slice(src.indexOf('const body =\n'), src.indexOf('const needCount'));
-  assert.match(render, /group\('Orders'/);
-  assert.match(src, /<div class="quote-grid">\$\{body\}<\/div>/,
-    'body — headings and cards together — is rendered inside one .quote-grid');
+test('each lane keeps its headings with its own cards', () => {
+  /* The board is two lanes now — opportunities left, work in hand right — so a
+     long enquiry list can no longer push the open quotes off the bottom.
+     Each lane wraps its own .quote-grid, and the heading still has to sit with
+     the cards it labels rather than in a container of its own. */
+  assert.match(board, /<div class="board-lane"><div class="quote-grid">\$\{laneLeft/);
+  assert.match(board, /<div class="board-lane"><div class="quote-grid">\$\{laneRight/);
+  assert.match(src, /\.board-lane \.quote-grid\{display:block\}/,
+    'inside a lane the cards stack single-file — a grid within a lane would ' +
+    'reintroduce the narrow two-column squeeze the lanes exist to avoid');
+});
+
+test('one empty lane still renders, so the columns do not jump', () => {
+  /* If an empty lane collapsed, the surviving lane would jump full-width and
+     back as work moved between them. */
+  assert.ok(board.includes('${laneLeft ||'), 'the left lane needs an empty fallback');
+  assert.ok(board.includes('${laneRight ||'), 'and so does the right');
+  assert.ok(board.includes('No new enquiries or unfinished carts.'));
+  assert.ok(board.includes('No open work.'));
 });

--- a/tests/carts-on-board.test.js
+++ b/tests/carts-on-board.test.js
@@ -88,3 +88,20 @@ test('a cart-prefilled quote posts as new, not as an edit', () => {
   const block = src.slice(src.indexOf('const cartEmail'), src.indexOf('const leadId'));
   assert.match(block, /code: null/, 'a prefilled quote must carry no code');
 });
+
+test('a design preview is shown only when the feed says one exists', () => {
+  /* The feed checks the disk inside the app that owns the files, because a cart
+     abandoned before the design was committed leaves a `file` reference with
+     nothing behind it. Guessing the URL from the board ships broken frames and
+     teaches the operator to distrust the page — one cart on file right now has
+     exactly that dangling reference. */
+  assert.match(board, /Array\.isArray\(c\.previews\) && c\.previews\.length \?/,
+    'no previews means no image block at all');
+  assert.match(feed, /is_file\(\$dir \. str_replace/,
+    'the feed must confirm the file exists before publishing a URL');
+  assert.match(feed, /allowed_classes.*=> false/,
+    'the cart blob is unserialised without instantiating objects');
+  assert.ok(feed.includes("preg_match('#^"), 'the path shape is checked rather than trusted');
+  assert.ok(feed.includes('data/designs') || feed.includes("'designs', 'user_data', 'orders'"),
+    'and only the known design folders are searched');
+});


### PR DESCRIPTION
## The layout complaint

Adding enquiries and carts pushed orders and open quotes to the bottom of a
single stacked column. The board is now **two lanes**:

| left — might become money | right — already is |
| --- | --- |
| New enquiries | Orders |
| Unfinished carts | Open quotes |
| | Cancelled |

The lanes are independent, so a long enquiry list can never again push the work
in hand off the page. Below 1100px they stack — side-by-side lanes on a phone
give two columns of nothing.

One empty lane still renders its heading, so the columns do not jump full-width
and back as work moves between them.

## Collapsing

Already shipped, and still working — every heading is a button with a caret, and
the folded state is remembered per browser in `localStorage`. If it is not
responding for you, tell me, because that is a bug rather than a missing feature.

## Seeing their designs

The cart cards now show the actual artwork, up to four thumbnails, opening
full-size.

**The feed decides what exists, not the board.** A cart's item carries a `file`
reference, but that is not always a saved design — a cart abandoned before the
design was committed leaves a path with nothing behind it. **One of your five
carts is exactly that case:** I probed six plausible URLs for it and every one
returned the site's HTML catch-all rather than an image.

So `orders_feed.php` decodes the cart, checks the file against the disk inside
the app that owns it, and publishes a URL only when the image is really there.
The board renders no image block at all when the array is empty. Guessing URLs
from the backend would have shipped broken frames and taught you to distrust the
page.

The blob is unserialised with `allowed_classes => false` and the path shape is
matched before anything touches the filesystem.

## About the 403 you saw

**That was me.** Pushing the first cart change restarted the designer at
15:30:17, and while a PHP app is restarting the feed cannot answer — the board
correctly reported it as unavailable rather than pretending. It cleared on its
own; I verified the feed returns 200 with all five carts.

This PR ships a second designer change, so expect the same brief flicker once
more. Worth knowing the board is honest about it rather than showing stale data
silently — and it does keep the last good list while it waits.

## Tests

406/406.