### PR TITLE
Write the 50-piece minimum into the screen print method

### DIFF
--- a/tests/screenprint-minimum.test.js
+++ b/tests/screenprint-minimum.test.js
@@ -83,3 +83,45 @@ test('minQty reads the number out of the method\'s own calculate blob', () => {
   assert.strictEqual(minQty(DTF), 0);
   assert.strictEqual(minQty({ id: 9 }), 0);
 });
+
+/* ── The minimum has to be IN the method row ─────────────────────────────── */
+
+test('the combined method carries min_qty, so the storefront enforces it', () => {
+  /* core/cart.php already knows how to do this: it reads `min_qty`, and when an
+     order is short it reprices the line onto DTF and tells the customer. That
+     code ran the whole time against a method with no min_qty — it read 0, and
+     `if ($min <= 0) return` skipped every check. Screen printing was orderable
+     at any quantity, below the floor the shop has with its own printer.
+
+     It belongs in the GENERATOR because colorTable replaces the method's
+     calculate blob on every reprice: a value written by hand would be silently
+     dropped the next time prices moved. */
+  const { colorTable } = require('../tools/lib/screenprint');
+  const rows = [
+    { colors: 1, tiers: [[99, 3.85], [249, 3.45]] },
+    { colors: 2, tiers: [[99, 4.80], [249, 4.35]] },
+  ];
+  assert.strictEqual(colorTable(rows, 50).min_qty, '50');
+  assert.strictEqual(colorTable(rows, 50).values.front['99']['1-color'], '3.85',
+    'and the prices are untouched by it');
+});
+
+test('no minimum means no min_qty key at all', () => {
+  /* An explicit 0 would be a value the storefront then compares against, and
+     `min_qty: "0"` reads as a deliberate "no minimum" rather than an omission.
+     Absent is the honest shape for a method that has none. */
+  const { colorTable } = require('../tools/lib/screenprint');
+  const rows = [{ colors: 1, tiers: [[99, 3.85]] }];
+  assert.ok(!('min_qty' in colorTable(rows)));
+  assert.ok(!('min_qty' in colorTable(rows, 0)));
+  assert.ok(!('min_qty' in colorTable(rows, 'nonsense')));
+});
+
+test('the reprice tool passes the contracted floor', () => {
+  const fs = require('node:fs');
+  const path = require('node:path');
+  const tool = fs.readFileSync(path.join(__dirname, '..', 'tools', 'reprice-anchorfish-2026.js'), 'utf8');
+  assert.match(tool, /const SCREEN_MIN_QTY = 50;/);
+  assert.match(tool, /colorTable\(all, SCREEN_MIN_QTY\)/,
+    'the generator must be told the minimum, or it emits a method without one');
+});

--- a/tools/lib/screenprint.js
+++ b/tools/lib/screenprint.js
@@ -33,7 +33,7 @@ const colorKey = (n) => n + '-color';
  *        One entry per colour count. `tiers` is [band ceiling, price per piece].
  * @returns {{multi:boolean,type:string,show_detail:string,values:object}}
  */
-function colorTable(rows) {
+function colorTable(rows, minQty) {
   if (!rows || rows.length === 0) throw new Error('no per-colour tables to combine');
 
   const sorted = [...rows].sort((a, b) => a.colors - b.colors);
@@ -89,7 +89,22 @@ function colorTable(rows) {
   /* `multi:false` — one screen-print table, applied per stage that carries
      artwork. A second print location is a second set of screens, and both
      engines already charge each decorated stage against this same table. */
-  return { multi: false, type: 'color', show_detail: '1', values: { front } };
+  /* The 50-piece minimum, IN the method row.
+   *
+   * The storefront already knows how to enforce this — core/cart.php reads
+   * `min_qty`, and when the order is short it reprices the line onto DTF and
+   * says so. That code has been running the whole time against a method with no
+   * `min_qty` set, so it read 0, and `if ($min <= 0) return` skipped every
+   * check: screen printing has been orderable at any quantity, below the
+   * minimum the shop actually has with its printer.
+   *
+   * It belongs here rather than as a one-off UPDATE because this function
+   * REPLACES the method's calculate blob on every reprice — a value written by
+   * hand would be silently dropped the next time prices moved. */
+  const out = { multi: false, type: 'color', show_detail: '1', values: { front } };
+  const m = parseInt(minQty, 10);
+  if (Number.isFinite(m) && m > 0) out.min_qty = String(m);
+  return out;
 }
 
 module.exports = { colorTable, colorKey };

--- a/tools/reprice-anchorfish-2026.js
+++ b/tools/reprice-anchorfish-2026.js
@@ -115,6 +115,9 @@ const SP = {
    this tool is where the screen economics are written down, and because the
    sell price has to be changed in the same breath as the cost that justifies
    it. The charge itself is applied by the `screens` add-on in server.js. */
+/* The contracted floor. Under this the job goes to DTF or HTV, both of which
+   the designer already prices. */
+const SCREEN_MIN_QTY = 50;
 const SCREEN_COST = 20;   // what Anchorfish charges us, per screen
 const SCREEN_FEE  = 25;   // what we bill, per screen, ONCE per order (was 35 to 2026-08-30)
 
@@ -476,7 +479,10 @@ for (const m of SP_INSERTS) {
 {
   const all = [...Object.values(SP_METHODS), ...SP_INSERTS]
     .map((m) => ({ colors: m.colors, tiers: spTiers(m.colors) }));
-  const combined = enjson(colorTable(all));
+  /* SCREEN_MIN_QTY, written into the method so the storefront enforces it.
+     Without it core/cart.php reads 0 and lets a 12-piece screen job through at
+     the 50-99 rate — below the minimum the shop has with its own printer. */
+  const combined = enjson(colorTable(all, SCREEN_MIN_QTY));
   console.log('\n  The same prices are also written to the combined "Screen Printing" method,');
   console.log('  as columns 1-color..7-color plus a full-color backstop, so the editor can');
   console.log('  price from the design\'s own colour count.');


### PR DESCRIPTION
## The bug is real and still live

The storefront **already knows how to enforce this**. `core/cart.php` reads
`min_qty` off the method, and when an order is short it reprices the line onto
DTF and tells the customer why.

That code has been running against a method with **no `min_qty` set**. It read 0,
and `if ($min <= 0) return $out;` skipped the check every time. Verified against
the live database — method 22 "Screen Printing" has exactly four keys: `multi`,
`type`, `show_detail`, `values`.

So screen printing has been orderable at **any quantity** on design.jtees.net,
below the floor the shop has with its own printer, priced at the 50–99 rate.

## Why it goes in the generator

`colorTable()` **replaces** the method's `calculate` blob on every reprice. A
`min_qty` written by hand with a one-off UPDATE would be silently dropped the
next time prices moved — and prices moved four times today alone.

So `colorTable(rows, minQty)` emits it, and the reprice tool passes
`SCREEN_MIN_QTY = 50`. Confirmed by decoding the generated statement: the
combined method now carries `min_qty: "50"`.

Absent rather than `"0"` when there is no minimum — an explicit zero is a value
the storefront then compares against, and it reads as a deliberate "no minimum"
rather than an omission.

## Still to apply

This ships the generator. The live method only changes when `--apply` runs, so
**the storefront is still unprotected until then**.

## Tests

417/417, 3 new.