### PR TITLE
A Discounts page: see the live codes, make new ones

### DIFF
--- a/server.js
+++ b/server.js
@@ -4157,6 +4157,7 @@ const ADMIN_NAV = [
   { key: 'customers', href: '/customers',     label: 'Customers' },
   { key: 'leads',     href: '/admin',         label: 'Leads' },
   { key: 'money',     href: '/books',         label: 'Finances' },
+  { key: 'discounts', href: '/discounts',     label: 'Discounts' },
   { key: 'reviews',   href: '/admin/reviews', label: 'Reviews' },
 ];
 /* Ordered the way a shop is actually worked, not the way the routes grew:
@@ -7874,6 +7875,174 @@ app.get('/q/:code/vcard', async (req, res) => {
    through a quote live in Postgres, people who ordered through the studio live
    in the designer's MySQL and arrive on the orders feed. Neither list on its
    own is "your customers", and until now neither page pretended to be. */
+/* ── Discount codes ───────────────────────────────────────────────────────
+ *
+ * The codes LIVE on design.jtees.net, because that is where checkout validates
+ * them — a code that depended on this service being up would fail at exactly
+ * the moment it matters. This page is a client: it reads and writes over the
+ * same shared-secret endpoint pattern as the orders feed.
+ *
+ * So every failure here is a network failure, and the page says so rather than
+ * showing an empty list that reads as "you have no codes".
+ */
+const PROMO_ADMIN = () => `${STUDIO_BASE}/jt-promo-admin.php?key=${encodeURIComponent(process.env.JT_INTERNAL_KEY || '')}`;
+
+async function fetchPromoCodes() {
+  if (!process.env.JT_INTERNAL_KEY) return { codes: [], error: 'JT_INTERNAL_KEY not set' };
+  try {
+    const r = await fetch(PROMO_ADMIN(), { signal: AbortSignal.timeout(8000) });
+    if (!r.ok) throw new Error(`studio answered ${r.status}`);
+    const d = await r.json();
+    return { codes: Array.isArray(d.codes) ? d.codes : [], error: null };
+  } catch (e) {
+    console.error('promo codes fetch failed:', e.message);
+    return { codes: [], error: e.message };
+  }
+}
+
+app.get('/discounts', requireAdmin, async (req, res) => {
+  const { codes, error } = await fetchPromoCodes();
+  const msg = String(req.query.msg || '');
+  const err = String(req.query.err || '');
+
+  const today = new Date().toISOString().slice(0, 10);
+  const live = (c) => c.active && (!c.expires || String(c.expires).slice(0, 10) >= today);
+  const worth = (c) => c.kind === 'amount' ? money(c.value) + ' off' : c.value + '% off';
+
+  const row = (c) => `
+    <tr style="border-top:1px solid #eef1f8${live(c) ? '' : ';opacity:.55'}">
+      <td style="padding:9px 6px"><b style="font-family:ui-monospace,SFMono-Regular,Menlo,monospace">${escEmail(c.code)}</b>
+        ${c.note ? `<div class="muted" style="font-size:12.5px">${escEmail(c.note)}</div>` : ''}</td>
+      <td style="padding:9px 6px;white-space:nowrap"><b>${escEmail(worth(c))}</b></td>
+      <td style="padding:9px 6px;white-space:nowrap;font-size:12.5px" class="muted">${
+        c.expires ? 'until ' + fmtDate(c.expires) : 'no end date'}</td>
+      <td class="num" style="padding:9px 6px">${c.uses || 0}</td>
+      <td style="padding:9px 6px;white-space:nowrap">${live(c)
+        ? '<span style="color:#166534;font-weight:600;font-size:12.5px">live</span>'
+        : `<span class="muted" style="font-size:12.5px">${c.active ? 'expired' : 'switched off'}</span>`}</td>
+      <td style="padding:9px 6px;text-align:right">${live(c) ? `
+        <form method="POST" action="/discounts/off" style="display:inline"
+              onsubmit="return confirm('Switch off ${escEmail(c.code)}? Anyone who has it will stop being able to use it.')">
+          <input type="hidden" name="code" value="${escEmail(c.code)}">
+          <button type="submit" class="btn btn-ghost" style="padding:5px 12px;font-size:12.5px">Switch off</button>
+        </form>` : ''}</td>
+    </tr>`;
+
+  const liveCount = codes.filter(live).length;
+
+  res.send(adminPage('Discounts', `<h1>Discounts</h1>
+    <div class="sub">${liveCount} live &middot; ${codes.length} total &middot;
+      <span class="muted" style="font-size:12px">codes you issue by hand, for design.jtees.net checkout</span></div>
+
+    ${err ? `<div class="warn" style="margin-bottom:12px">${escEmail(err)}</div>` : ''}
+    ${msg ? `<div class="ok" style="margin-bottom:12px">${escEmail(msg)}</div>` : ''}
+    ${error ? `<div class="warn" style="margin-bottom:12px"><b>Could not reach the studio.</b>
+      The list below may be incomplete — this is a connection problem, not an empty list.
+      <span class="muted">(${escEmail(error)})</span></div>` : ''}
+
+    <div class="card" style="margin-bottom:16px">
+      <b style="color:#0B1F4B">New code</b>
+      <form method="POST" action="/discounts" style="margin-top:10px">
+        <div style="display:flex;gap:10px;flex-wrap:wrap;align-items:flex-end">
+          <div style="flex:1 1 150px">
+            <label style="font-size:12px">Code</label>
+            <input name="code" required maxlength="32" placeholder="TYLER30"
+                   pattern="[A-Za-z0-9]{3,32}" title="3-32 letters or digits"
+                   style="width:100%;padding:8px;font-size:14px;text-transform:uppercase">
+          </div>
+          <div style="flex:0 1 130px">
+            <label style="font-size:12px">Type</label>
+            <select name="kind" style="width:100%;padding:8px;font-size:14px">
+              <option value="amount">$ off</option>
+              <option value="percent">% off</option>
+            </select>
+          </div>
+          <div style="flex:0 1 110px">
+            <label style="font-size:12px">Value</label>
+            <input name="value" required type="number" step="0.01" min="0.01" placeholder="30"
+                   style="width:100%;padding:8px;font-size:14px">
+          </div>
+          <div style="flex:0 1 160px">
+            <label style="font-size:12px">Expires <span class="muted">(optional)</span></label>
+            <input name="expires" type="date" style="width:100%;padding:8px;font-size:14px">
+          </div>
+        </div>
+        <div style="margin-top:10px">
+          <label style="font-size:12px">What it is for <span class="muted">(only you see this)</span></label>
+          <input name="note" maxlength="200" placeholder="e.g. Tyler W — free shirt, two-week delay on his order"
+                 style="width:100%;padding:8px;font-size:14px">
+        </div>
+        <button type="submit" class="btn" style="margin-top:12px;padding:9px 20px">Create code</button>
+      </form>
+      <p class="muted" style="margin:10px 0 0;font-size:12.5px">
+        A <b>$ off</b> code never takes a total below zero — a $30 code on a $12 order takes off $12.
+        Codes are case-insensitive. Reusing an existing code updates it.</p>
+    </div>
+
+    <div class="card" style="overflow-x:auto">
+      <table style="width:100%;border-collapse:collapse;min-width:620px">
+        <thead><tr style="text-align:left">
+          <th style="padding:6px">Code</th><th style="padding:6px">Worth</th>
+          <th style="padding:6px">Expires</th><th class="num" style="padding:6px">Used</th>
+          <th style="padding:6px">State</th><th></th>
+        </tr></thead>
+        <tbody>${codes.map(row).join('') || `<tr><td colspan="6" class="muted" style="padding:12px 6px">${
+          error ? 'Could not load the list.' : 'No codes yet — make one above.'}</td></tr>`}</tbody>
+      </table>
+    </div>
+
+    <p class="muted" style="margin-top:14px;font-size:12.5px">
+      These are separate from the weekly abandoned-cart codes, which rotate on their own and are
+      capped at one per customer. A code you make here is not capped — it is a promise to one person,
+      and it keeps working for them.</p>`, 'discounts'));
+});
+
+app.post('/discounts', requireAdmin, async (req, res) => {
+  const b = req.body || {};
+  const form = new URLSearchParams();
+  form.set('code', String(b.code || '').trim().toUpperCase());
+  form.set('kind', b.kind === 'percent' ? 'percent' : 'amount');
+  form.set('value', String(b.value || ''));
+  form.set('expires', String(b.expires || '').trim());
+  form.set('note', String(b.note || '').trim());
+  try {
+    const r = await fetch(PROMO_ADMIN(), {
+      method: 'POST', body: form, signal: AbortSignal.timeout(8000),
+    });
+    const d = await r.json().catch(() => ({}));
+    /* The studio validates too — bounds on the value, the code shape, the date
+       format. Its message is shown rather than a generic failure, because "a
+       percentage must be between 1 and 100" is actionable and "could not save"
+       is not. */
+    if (!r.ok || d.error) {
+      return res.redirect('/discounts?err=' + encodeURIComponent(d.error || `studio answered ${r.status}`));
+    }
+    res.redirect('/discounts?msg=' + encodeURIComponent(`${d.code} is live.`));
+  } catch (e) {
+    console.error('promo save failed:', e.message);
+    res.redirect('/discounts?err=' + encodeURIComponent('Could not reach the studio: ' + e.message));
+  }
+});
+
+app.post('/discounts/off', requireAdmin, async (req, res) => {
+  const form = new URLSearchParams();
+  form.set('code', String((req.body || {}).code || '').trim().toUpperCase());
+  form.set('delete', '1');
+  try {
+    const r = await fetch(PROMO_ADMIN(), {
+      method: 'POST', body: form, signal: AbortSignal.timeout(8000),
+    });
+    const d = await r.json().catch(() => ({}));
+    if (!r.ok || d.error) {
+      return res.redirect('/discounts?err=' + encodeURIComponent(d.error || `studio answered ${r.status}`));
+    }
+    res.redirect('/discounts?msg=' + encodeURIComponent(`${d.deactivated} switched off.`));
+  } catch (e) {
+    console.error('promo deactivate failed:', e.message);
+    res.redirect('/discounts?err=' + encodeURIComponent('Could not reach the studio: ' + e.message));
+  }
+});
+
 app.get('/customers', requireAdmin, async (_req, res) => {
   try {
     const { rows: quoteCustomers } = await pool.query(

--- a/tests/discounts-page.test.js
+++ b/tests/discounts-page.test.js
@@ -1,0 +1,87 @@
+'use strict';
+
+/* The discount-code admin page.
+ *
+ * The codes LIVE on design.jtees.net, because that is where checkout validates
+ * them — a code whose validity depended on this service being up would fail at
+ * exactly the moment it matters, mid-payment. This page is a client over the
+ * same shared-secret endpoint as the orders feed.
+ *
+ * That makes every failure here a NETWORK failure, and the distinction matters:
+ * an unreachable studio rendered as an empty table reads as "you have no
+ * codes", which is a lie that would have the shop issue a duplicate.
+ */
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.join(__dirname, '..');
+const src = fs.readFileSync(path.join(ROOT, 'server.js'), 'utf8');
+const page = src.slice(src.indexOf("app.get('/discounts'"), src.indexOf("app.post('/discounts'"));
+const admin = fs.readFileSync(path.join(ROOT,
+  'Lumise/Lumise-Product-Designer-PHP-ver2.0/lumise/jt-promo-admin.php'), 'utf8');
+
+test('the page is in the admin nav and gated', () => {
+  assert.match(src, /\{ key: 'discounts', href: '\/discounts',\s*label: 'Discounts' \}/);
+  for (const r of ["'/discounts'", "'/discounts/off'"]) {
+    assert.ok(src.includes(`app.get(${r}, requireAdmin`) || src.includes(`app.post(${r}, requireAdmin`),
+      `${r} must require admin — these codes are money`);
+  }
+});
+
+test('an unreachable studio is not shown as an empty list', () => {
+  /* The failure that would actually cost money: the shop sees no codes, assumes
+     none exist, and issues a second one to the same customer. */
+  assert.match(page, /Could not reach the studio/);
+  assert.match(page, /this is a connection problem, not an empty list/);
+  assert.match(src, /promo codes fetch failed/, 'and it is logged');
+});
+
+test('the studio validation message is shown, not swallowed', () => {
+  /* "A percentage must be between 1 and 100" is actionable. "Could not save"
+     sends the operator back to guess which field was wrong. */
+  const post = src.slice(src.indexOf("app.post('/discounts'"), src.indexOf("app.post('/discounts/off'"));
+  assert.match(post, /d\.error \|\| `studio answered \$\{r\.status\}`/);
+});
+
+test('an amount code cannot take a total below zero', () => {
+  /* A negative total is a refund the shop never agreed to, and the charge is
+     computed from that number. Clamped in the one place the discount is
+     calculated, so both the checkout page and the order path get it. */
+  const auth = fs.readFileSync(path.join(ROOT,
+    'Lumise/Lumise-Product-Designer-PHP-ver2.0/lumise/jt-auth.php'), 'utf8');
+  assert.match(auth, /return min\(round\(\$d\['value'\], 2\), \$sub\);/);
+  assert.match(page, /never takes a total below zero/, 'and the page says so');
+});
+
+test('the studio bounds every value it stores', () => {
+  /* These arrive from a form and are subtracted from a charge. */
+  assert.match(admin, /\$value < 1 \|\| \$value > 100/, 'percent bounds');
+  assert.match(admin, /\$value <= 0 \|\| \$value > 1000/, 'amount bounds');
+  assert.match(admin, /\^\[A-Z0-9\]\{3,32\}\$/, 'code shape');
+  assert.match(admin, /\^\\d\{4\}-\\d\{2\}-\\d\{2\}\$/, 'expiry shape');
+});
+
+test('switching a code off never deletes it', () => {
+  /* A used code is the record of what a customer was given. Deleting it loses
+     the answer to "why was this order $30 light". */
+  assert.match(admin, /SET active=0 WHERE code=/);
+  assert.doesNotMatch(admin, /DELETE FROM/);
+});
+
+test('expired and switched-off codes are told apart', () => {
+  /* They need different actions: one is reissued, the other was deliberate. */
+  assert.match(page, /c\.active \? 'expired' : 'switched off'/);
+});
+
+test('hand-issued codes are not capped like recovery codes', () => {
+  /* The cap exists because the weekly codes are shared with every abandoned
+     cart. A code issued to one person by name is a promise to them. */
+  assert.match(page, /it is a promise to one person/);
+  const auth = fs.readFileSync(path.join(ROOT,
+    'Lumise/Lumise-Product-Designer-PHP-ver2.0/lumise/jt-auth.php'), 'utf8');
+  assert.match(auth, /return \$d && \$d\['source'\] === 'recovery';/,
+    'only recovery codes are capped');
+});


### PR DESCRIPTION
## What was missing

I built the storage and the endpoint last round and never built the page, so
there was nowhere to actually see or make a code. This is that page —
**Discounts** in the admin nav.

- Every code, with what it is worth, when it expires, how many times it has been
  used, and whether it is live
- A form to make one: code, **$ off or % off**, value, optional expiry, and a
  private note for why it was issued
- **Switch off** on live codes

## Where the codes live, and why it shows through

They live on **design.jtees.net**, because that is where checkout validates
them. A code whose validity depended on this service being up would fail at
exactly the moment it matters — mid-payment.

So this page is a client over the same shared-secret endpoint as the orders
feed, and **every failure here is a network failure**. That distinction is the
thing worth getting right: an unreachable studio rendered as an empty table
reads as "you have no codes", and the shop issues a duplicate to the same
customer. It says "could not reach the studio — this is a connection problem,
not an empty list" instead.

The studio's own validation message is passed through rather than swallowed:
"a percentage must be between 1 and 100" is actionable; "could not save" sends
you back to guess which field was wrong.

## Money safety

- A **$ off** code is clamped to the order total — $30 off a $12 order takes off
  $12, never producing a negative total, and it is clamped in the single place
  the discount is calculated so both the checkout page and the order path get it
- The studio bounds percent (1–100), amount ($0.01–$1000), the code shape and
  the expiry format — all four arrive from a form and are subtracted from a
  charge
- **Switching off never deletes.** A used code is the record of what a customer
  was given, and the answer to "why was this order $30 light"
- Expired and switched-off are shown differently: one gets reissued, the other
  was deliberate

## Tests

425/425, 8 new.

## To do after merge

Make Tyler's: **TYLER30**, $ off, 30, note "free shirt — two-week delay". The
`TYLER10` standing code from earlier is still live and should be switched off so
he cannot use the wrong one — it is an env var, `JT_PROMO_STANDING` on
Lumise_Designer, and I would rather you clear it than have me guess.