### PR TITLE
Pin that the promo column migration is idempotent

### DIFF
--- a/tests/discounts-page.test.js
+++ b/tests/discounts-page.test.js
@@ -194,3 +194,22 @@ test('last week grace is shown as live, not as expired', () => {
   assert.ok(admin.includes("'source' => 'recovery'"),
     'and both recovery codes are published with their source');
 });
+
+test('adding the rule columns is safe to run on every request', () => {
+  /* This broke in production and is the nastiest shape of bug: MySQL has no
+     ADD COLUMN IF NOT EXISTS, and `@` does not silence an error the database
+     driver raises. The first call added the columns and every call after it
+     failed on "duplicate column" and answered 500 — so the page worked exactly
+     ONCE, looked fine when built, and was broken by the time anyone opened it.
+
+     The columns must be asked for before they are added, not attempted and
+     suppressed. */
+  const auth = fs.readFileSync(path.join(ROOT,
+    'Lumise/Lumise-Product-Designer-PHP-ver2.0/lumise/jt-auth.php'), 'utf8');
+  assert.match(auth, /SELECT COLUMN_NAME FROM information_schema\.COLUMNS/,
+    'existing columns must be read first');
+  assert.match(auth, /if \(isset\(\$have\[\$name\]\)\) continue;/,
+    'and only the missing ones added');
+  assert.doesNotMatch(auth, /@jt_db\(\)->rawQuery\("ALTER TABLE/,
+    'a suppressed ALTER is not idempotent — it still errors the request');
+});


### PR DESCRIPTION
Regression test for the 500 that broke the Discounts page. The fix itself is
already deployed on the designer (`3f69e37`).

## What happened

Two different failures, one after the other, and I reported the first as fixed
without confirming the page actually loaded.

**First — 403.** My studio calls sent no `User-Agent`, so Cloudflare refused
them. Fixed by routing everything through `studioFetch()`. That part worked.

**Then — 500.** The rule columns are added with `ALTER TABLE ADD COLUMN`. MySQL
has no `IF NOT EXISTS` for that, and `@` does not silence an error the database
driver raises. So the first call added the columns and **every call after it
failed on "duplicate column"**.

That is the nastiest shape this can take: the page worked **exactly once** — my
own verification call — and was broken by the time you opened it. My test was
what created the columns, which is precisely why it passed and yours did not.

## The fix

Read `information_schema.COLUMNS` first, add only what is missing. Verified with
three consecutive calls returning 200 where the second used to fail, then a full
round trip: create → read back → switch off.

The read-back also confirms the dollar-code rule applies on its own — a `$30`
code with no explicit limit came back as `max_uses: 1`.

## Tests

437/437, 1 new — asserting the columns are asked for before being added, and
that a suppressed `ALTER` never comes back.