### PR TITLE
Pick a customer for a discount code, and record who it is for

### DIFF
--- a/server.js
+++ b/server.js
@@ -7920,6 +7920,22 @@ async function fetchPromoCodes() {
 
 app.get('/discounts', requireAdmin, async (req, res) => {
   const { codes, system, poolSize, error } = await fetchPromoCodes();
+  /* The real customer list, from the same function the Customers page uses, so
+     the two can never disagree about who exists. Typing an address by hand is
+     how a code goes to tylwur@yaho.com and nobody finds out until the customer
+     says they never got it. */
+  let people = [];
+  try { ({ people } = await allCustomers()); }
+  catch (e) { console.error('discount customer list failed:', e.message); }
+
+  /* A datalist rather than a select: it still accepts a new address — a code
+     for somebody who has never ordered is a normal thing — while offering every
+     known customer as you type. The name is in the label so you pick a person,
+     not an address you have to recognise. */
+  const customerList = `<datalist id="jt-customers">${people.map((c) =>
+    `<option value="${escEmail(c.email)}">${escEmail(
+      [c.name, c.spent > 0 ? money(c.spent) + ' spent' : 'no orders yet']
+        .filter(Boolean).join(' — '))}</option>`).join('')}</datalist>`;
   const msg = String(req.query.msg || '');
   const err = String(req.query.err || '');
 
@@ -7930,6 +7946,9 @@ app.get('/discounts', requireAdmin, async (req, res) => {
   const row = (c) => `
     <tr style="border-top:1px solid #eef1f8${live(c) ? '' : ';opacity:.55'}">
       <td style="padding:9px 6px"><b style="font-family:ui-monospace,SFMono-Regular,Menlo,monospace">${escEmail(c.code)}</b>
+        ${c.assigned_to ? `<div style="font-size:12.5px;color:#1848B8">for ${escEmail(c.assigned_to)}${
+          c.sent_at ? ` <span class="muted">&middot; sent ${fmtDate(c.sent_at)}</span>`
+                    : ' <span class="muted">&middot; not sent yet</span>'}</div>` : ''}
         ${c.note ? `<div class="muted" style="font-size:12.5px">${escEmail(c.note)}</div>` : ''}</td>
       <td style="padding:9px 6px;white-space:nowrap"><b>${escEmail(worth(c))}</b>${
         (c.min_order > 0 || c.once_per_customer) ? `<div class="muted" style="font-size:11.5px">${
@@ -7957,7 +7976,9 @@ app.get('/discounts', requireAdmin, async (req, res) => {
         <form method="POST" action="/discounts/send" style="display:flex;gap:8px;flex-wrap:wrap;align-items:center">
           <input type="hidden" name="code" value="${escEmail(c.code)}">
           <span class="muted" style="font-size:12.5px">Email <b>${escEmail(c.code)}</b> to</span>
-          <input name="email" type="email" required placeholder="them@example.com"
+          <input name="email" type="email" required list="jt-customers"
+                 value="${escEmail(c.assigned_to || '')}"
+                 placeholder="start typing a name or email"
                  style="flex:1 1 220px;padding:7px;font-size:13px">
           <input name="message" maxlength="300" placeholder="A line of your own (optional)"
                  style="flex:2 1 260px;padding:7px;font-size:13px">
@@ -7988,6 +8009,7 @@ app.get('/discounts', requireAdmin, async (req, res) => {
     </tr>`;
 
   res.send(adminPage('Discounts', `<h1>Discounts</h1>
+    ${customerList}
     <div class="sub">${liveCount} live &middot; ${codes.length} total &middot;
       <span class="muted" style="font-size:12px">codes you issue by hand, for design.jtees.net checkout</span></div>
 
@@ -8046,8 +8068,8 @@ app.get('/discounts', requireAdmin, async (req, res) => {
                  style="width:100%;padding:8px;font-size:14px">
         </div>
         <div style="margin-top:10px">
-          <label style="font-size:12px">Send it to <span class="muted">(optional — emails the code straight away)</span></label>
-          <input name="send_to" type="email" placeholder="them@example.com"
+          <label style="font-size:12px">Send it to <span class="muted">(optional — pick a customer, or type any address)</span></label>
+          <input name="send_to" type="email" list="jt-customers" placeholder="start typing a name or email"
                  style="width:100%;padding:8px;font-size:14px">
         </div>
         <button type="submit" class="btn" style="margin-top:12px;padding:9px 20px">Create code</button>
@@ -8108,6 +8130,12 @@ app.post('/discounts', requireAdmin, async (req, res) => {
   form.set('value', String(b.value || ''));
   form.set('expires', String(b.expires || '').trim());
   form.set('note', String(b.note || '').trim());
+  form.set('min_order', String(b.min_order || ''));
+  form.set('max_uses', String(b.max_uses || ''));
+  if (b.once_per_customer) form.set('once_per_customer', '1');
+  /* Assigning and sending are the same field: the code exists to reach one
+     person, so naming them is what makes it theirs. */
+  form.set('assigned_to', String(b.send_to || '').trim().toLowerCase());
   try {
     const r = await studioFetch(PROMO_ADMIN(), { method: 'POST', body: form });
     const d = await r.json().catch(() => ({}));
@@ -8195,6 +8223,13 @@ app.post('/discounts/send', requireAdmin, async (req, res) => {
   }
   try {
     await sendDiscountEmail(code, email, extra);
+    /* Record it AFTER the send succeeds. Stamping first would show a code as
+       sent that never left. */
+    try {
+      const f = new URLSearchParams();
+      f.set('code', code); f.set('sent', '1'); f.set('assigned_to', email.toLowerCase());
+      await studioFetch(PROMO_ADMIN(), { method: 'POST', body: f });
+    } catch (e) { console.error('discount send stamp failed:', e.message); }
     res.redirect('/discounts?msg=' + encodeURIComponent(`${code} sent to ${email}.`));
   } catch (e) {
     console.error('discount send failed:', e.message);
@@ -8221,44 +8256,54 @@ app.post('/discounts/off', requireAdmin, async (req, res) => {
   }
 });
 
-app.get('/customers', requireAdmin, async (_req, res) => {
-  try {
-    const { rows: quoteCustomers } = await pool.query(
-      `SELECT lower(email) AS email, max(name) AS name,
-              count(*) AS jobs, coalesce(sum(paid_amount), 0) AS paid,
-              max(created_at) AS last_seen
-         FROM quotes
-        WHERE email IS NOT NULL AND email <> ''
-        GROUP BY lower(email)`);
+/* Everyone the shop knows, from both halves of it: quotes live here, studio
+ * orders live on design.jtees.net, and a person who has done both is one
+ * customer rather than two rows.
+ *
+ * Extracted so the Customers page and the Discounts picker cannot disagree
+ * about who exists — a picker built from its own query would quietly miss the
+ * studio-only customers, which is most of the online ones. */
+async function allCustomers() {
+  const { rows: quoteCustomers } = await pool.query(
+    `SELECT lower(email) AS email, max(name) AS name,
+            count(*) AS jobs, coalesce(sum(paid_amount), 0) AS paid,
+            max(created_at) AS last_seen
+       FROM quotes
+      WHERE email IS NOT NULL AND email <> ''
+      GROUP BY lower(email)`);
 
-    const studio = await fetchStudioOrders();
-    const byEmail = new Map();
+  const studio = await fetchStudioOrders();
+  const byEmail = new Map();
 
-    for (const c of quoteCustomers) {
-      byEmail.set(c.email, {
-        email: c.email, name: c.name || '', quotes: Number(c.jobs),
-        orders: 0, spent: Number(c.paid || 0), last: c.last_seen, source: 'quotes',
+  for (const c of quoteCustomers) {
+    byEmail.set(c.email, {
+      email: c.email, name: c.name || '', quotes: Number(c.jobs),
+      orders: 0, spent: Number(c.paid || 0), last: c.last_seen, source: 'quotes',
+    });
+  }
+  for (const o of studio.orders) {
+    const key = String(o.email || '').toLowerCase();
+    if (!key) continue;
+    const cur = byEmail.get(key);
+    if (cur) {
+      cur.orders += 1;
+      cur.spent += Number(o.paid || 0);
+      cur.source = 'both';
+      if (!cur.name) cur.name = o.name || '';
+      if (o.created && new Date(o.created) > new Date(cur.last)) cur.last = o.created;
+    } else {
+      byEmail.set(key, {
+        email: key, name: o.name || '', quotes: 0, orders: 1,
+        spent: Number(o.paid || 0), last: o.created, source: 'studio',
       });
     }
-    for (const o of studio.orders) {
-      const key = String(o.email || '').toLowerCase();
-      if (!key) continue;
-      const cur = byEmail.get(key);
-      if (cur) {
-        cur.orders += 1;
-        cur.spent += Number(o.paid || 0);
-        cur.source = 'both';
-        if (!cur.name) cur.name = o.name || '';
-        if (o.created && new Date(o.created) > new Date(cur.last)) cur.last = o.created;
-      } else {
-        byEmail.set(key, {
-          email: key, name: o.name || '', quotes: 0, orders: 1,
-          spent: Number(o.paid || 0), last: o.created, source: 'studio',
-        });
-      }
-    }
+  }
+  return { people: [...byEmail.values()].sort((a, b) => Number(b.spent) - Number(a.spent)), studio };
+}
 
-    const people = [...byEmail.values()].sort((a, b) => Number(b.spent) - Number(a.spent));
+app.get('/customers', requireAdmin, async (_req, res) => {
+  try {
+    const { people, studio } = await allCustomers();
     const chip = { quotes: ['Quotes', '#eef2fd', '#1848B8'],
                    studio: ['Studio', '#eef1f8', '#46505f'],
                    both:   ['Both',   '#e7f6ec', '#166534'] };

--- a/tests/board-orders-feed.test.js
+++ b/tests/board-orders-feed.test.js
@@ -180,13 +180,22 @@ test('the customers list is admin-gated and reachable', () => {
 });
 
 test('the customers list merges both halves of the shop', () => {
-  const page = extractFn("app.get('/customers'");
-  assert.match(page, /FROM quotes/, 'quote customers live in Postgres');
-  assert.match(page, /fetchStudioOrders\(\)/, 'studio customers arrive on the orders feed');
-  assert.match(page, /byEmail/,
+  /* The merge moved into allCustomers() so the Customers page and the Discounts
+     picker cannot disagree about who exists. A picker with its own query would
+     quietly miss the studio-only customers, which is most of the online ones. */
+  const fn = extractFn('async function allCustomers()');
+  assert.match(fn, /FROM quotes/, 'quote customers live in Postgres');
+  assert.match(fn, /fetchStudioOrders\(\)/, 'studio customers arrive on the orders feed');
+  assert.match(fn, /byEmail/,
     'the same person can appear in both and must not be listed twice');
-  assert.match(page, /String\(o\.email \|\| ''\)\.toLowerCase\(\)/,
+  assert.match(fn, /String\(o\.email \|\| ''\)\.toLowerCase\(\)/,
     'merging on a case-sensitive email would split one person into two rows');
+});
+
+test('every customer list comes from that one function', () => {
+  /* Two lists of "who our customers are" drift within a month. */
+  assert.ok((src.match(/await allCustomers\(\)/g) || []).length >= 2,
+    'the Customers page and the Discounts picker must both call it');
 });
 
 test('a broken studio feed degrades the customer list rather than emptying it', () => {

--- a/tests/discounts-page.test.js
+++ b/tests/discounts-page.test.js
@@ -213,3 +213,54 @@ test('adding the rule columns is safe to run on every request', () => {
   assert.doesNotMatch(auth, /@jt_db\(\)->rawQuery\("ALTER TABLE/,
     'a suppressed ALTER is not idempotent — it still errors the request');
 });
+
+/* ── Assigning a code to a customer ──────────────────────────────────────── */
+
+test('the picker offers the real customer list', () => {
+  /* Typing an address by hand is how a code goes to tylwur@yaho.com and nobody
+     finds out until the customer says they never got it. */
+  assert.match(page, /await allCustomers\(\)/,
+    'the same function the Customers page uses');
+  assert.match(page, /<datalist id="jt-customers">/);
+  assert.match(page, /list="jt-customers"/, 'and both send fields use it');
+  assert.strictEqual((page.match(/list="jt-customers"/g) || []).length, 2,
+    'the create form and the per-code Send row');
+});
+
+test('a datalist, so an unknown address is still allowed', () => {
+  /* A select would make a code for somebody who has never ordered impossible,
+     which is a normal thing to want. */
+  assert.doesNotMatch(page, /<select[^>]*name="send_to"/);
+  assert.match(page, /name="send_to" type="email" list="jt-customers"/);
+});
+
+test('the rule fields actually reach the studio', () => {
+  /* They were on the form and dropped by the POST handler — the shop would set
+     a minimum order, see it accepted, and get a code with no minimum. */
+  const post = src.slice(src.indexOf("app.post('/discounts'"), src.indexOf("app.post('/discounts/send'"));
+  for (const f of ['min_order', 'max_uses', 'once_per_customer', 'assigned_to']) {
+    assert.ok(post.includes(`'${f}'`), `${f} must be forwarded`);
+  }
+});
+
+test('the send is stamped only after it succeeds', () => {
+  /* Stamping first would show a code as sent that never left, and the shop
+     would never chase it. */
+  const send = src.slice(src.indexOf("app.post('/discounts/send'"));
+  const i = send.indexOf('await sendDiscountEmail');
+  const j = send.indexOf("f.set('sent', '1')");
+  assert.ok(i > -1 && j > i, 'the stamp must come after the send');
+});
+
+test('an edit that leaves the assignee blank does not erase it', () => {
+  /* Changing a value on an existing code must not quietly detach it from the
+     customer it was promised to. */
+  assert.match(admin, /assigned_to = COALESCE\(VALUES\(assigned_to\), assigned_to\)/);
+});
+
+test('assigned but unsent is visible as such', () => {
+  /* "I made Tyler a code" and "Tyler has his code" are different states, and
+     only one of them needs an action. */
+  assert.match(page, /not sent yet/);
+  assert.match(page, /sent \$\{fmtDate\(c\.sent_at\)\}/);
+});


### PR DESCRIPTION
## The picker

Both send fields now offer **every customer the shop knows** — name, email and
what they have spent — from `allCustomers()`, the same function the Customers
page uses. A picker with its own query would quietly miss the studio-only
customers, which is most of the online ones.

Extracted rather than duplicated: two lists of "who our customers are" drift
within a month.

It is a **datalist, not a select**, so an address that has never ordered is
still allowed — a code for somebody new is a normal thing to want.

## Assigning, which is not the same as sending

A code now records **who it is for** and **when it went out**, separately:

```
TYLER30   for tylwur@yahoo.com · not sent yet
TYLER30   for tylwur@yahoo.com · sent Aug 30
```

"I made Tyler a code" and "Tyler has his code" are different states and only one
of them needs an action from you. The Send row prefills with whoever the code is
for, so sending it again goes to the right person by default.

The stamp is written **after** the send succeeds — stamping first would show a
code as sent that never left.

## A bug this surfaced

**The rule fields were never being forwarded.** The form had minimum order,
times-usable and one-per-customer; the POST handler built its body from
`code`, `kind`, `value`, `expires` and `note` only. You would have set a $75
minimum, seen the code created, and got a code with no minimum at all.

Now forwarded and verified against production:

```
after create : assigned=someone@example.com, min=75, once=true, max=1
after send   : sent=2026-08-30 22:14:31
after edit   : assigned=someone@example.com   <- survives a blank edit
```

That last line matters: editing a code's value with the assignee field empty
must not quietly detach it from the customer it was promised to.

## Tests

444/444, 7 new.