### PR TITLE
Edit, turn on/off, remove unused codes, and show the use count

### DIFF
--- a/server.js
+++ b/server.js
@@ -7956,19 +7956,39 @@ app.get('/discounts', requireAdmin, async (req, res) => {
            c.once_per_customer ? 'one per customer' : ''].filter(Boolean).join(' &middot; ')}</div>` : ''}</td>
       <td style="padding:9px 6px;white-space:nowrap;font-size:12.5px" class="muted">${
         c.expires ? 'until ' + fmtDate(c.expires) : 'no end date'}</td>
-      <td class="num" style="padding:9px 6px">${c.uses || 0}${
-        c.max_uses ? `<span class="muted"> / ${c.max_uses}</span>` : ''}</td>
+      <td class="num" style="padding:9px 6px;white-space:nowrap">
+        <b style="font-size:15px;color:${c.uses ? '#166534' : '#8a93a5'}">${c.uses || 0}</b>${
+        c.max_uses ? `<span class="muted"> of ${c.max_uses}</span>` : ''}
+        ${c.max_uses && c.uses >= c.max_uses
+          ? '<div class="muted" style="font-size:11.5px;color:#b45309">fully claimed</div>' : ''}</td>
       <td style="padding:9px 6px;white-space:nowrap">${live(c)
         ? '<span style="color:#166534;font-weight:600;font-size:12.5px">live</span>'
         : `<span class="muted" style="font-size:12.5px">${c.active ? 'expired' : 'switched off'}</span>`}</td>
-      <td style="padding:9px 6px;text-align:right;white-space:nowrap">${live(c) ? `
-        <button type="button" class="btn btn-ghost" style="padding:5px 12px;font-size:12.5px"
+      <td style="padding:9px 6px;text-align:right;white-space:nowrap">
+        <button type="button" class="btn btn-ghost" style="padding:5px 10px;font-size:12.5px"
+          onclick="jtEditCode(${JSON.stringify(JSON.stringify({
+            code: c.code, kind: c.kind, value: c.value, expires: c.expires || '',
+            note: c.note || '', min_order: c.min_order || '', max_uses: c.max_uses || '',
+            once_per_customer: !!c.once_per_customer, assigned_to: c.assigned_to || '',
+          })).replace(/"/g, '&quot;')})">Edit</button>
+        ${live(c) ? `
+        <button type="button" class="btn btn-ghost" style="padding:5px 10px;font-size:12.5px"
           onclick="document.getElementById('snd-${escEmail(c.code)}').style.display='table-row'">Send</button>
         <form method="POST" action="/discounts/off" style="display:inline"
               onsubmit="return confirm('Switch off ${escEmail(c.code)}? Anyone who has it will stop being able to use it.')">
           <input type="hidden" name="code" value="${escEmail(c.code)}">
-          <button type="submit" class="btn btn-ghost" style="padding:5px 12px;font-size:12.5px">Switch off</button>
-        </form>` : ''}</td>
+          <button type="submit" class="btn btn-ghost" style="padding:5px 10px;font-size:12.5px">Switch off</button>
+        </form>` : `
+        <form method="POST" action="/discounts/on" style="display:inline">
+          <input type="hidden" name="code" value="${escEmail(c.code)}">
+          <button type="submit" class="btn btn-ghost" style="padding:5px 10px;font-size:12.5px">Turn back on</button>
+        </form>
+        ${!c.uses ? `
+        <form method="POST" action="/discounts/remove" style="display:inline"
+              onsubmit="return confirm('Remove ${escEmail(c.code)} completely? It has never been used, so nothing is lost.')">
+          <input type="hidden" name="code" value="${escEmail(c.code)}">
+          <button type="submit" class="btn btn-ghost" style="padding:5px 10px;font-size:12.5px;color:#b91c1c">Remove</button>
+        </form>` : ''}`}</td>
     </tr>
     ${live(c) ? `
     <tr id="snd-${escEmail(c.code)}" style="display:none;background:#f7f9fc">
@@ -8020,8 +8040,8 @@ app.get('/discounts', requireAdmin, async (req, res) => {
       <span class="muted">(${escEmail(error)})</span></div>` : ''}
 
     <div class="card" style="margin-bottom:16px">
-      <b style="color:#0B1F4B">New code</b>
-      <form method="POST" action="/discounts" style="margin-top:10px">
+      <b style="color:#0B1F4B" id="jt-code-title">New code</b>
+      <form method="POST" action="/discounts" style="margin-top:10px" id="jt-code-form">
         <div style="display:flex;gap:10px;flex-wrap:wrap;align-items:flex-end">
           <div style="flex:1 1 150px">
             <label style="font-size:12px">Code</label>
@@ -8072,8 +8092,39 @@ app.get('/discounts', requireAdmin, async (req, res) => {
           <input name="send_to" type="email" list="jt-customers" placeholder="start typing a name or email"
                  style="width:100%;padding:8px;font-size:14px">
         </div>
-        <button type="submit" class="btn" style="margin-top:12px;padding:9px 20px">Create code</button>
+        <button type="submit" class="btn" style="margin-top:12px;padding:9px 20px" id="jt-code-save">Create code</button>
+        <button type="button" class="btn btn-ghost" style="margin-top:12px;padding:9px 16px;display:none"
+                id="jt-code-cancel" onclick="jtEditCancel()">Cancel</button>
       </form>
+      <script>
+        /* Editing loads the row back into this same form, so there is one
+           definition of what a code's fields are. A separate edit form would
+           drift from the create form within a change or two. */
+        function jtEditCode(json){
+          var c = JSON.parse(json), f = document.getElementById('jt-code-form');
+          f.code.value = c.code; f.kind.value = c.kind; f.value.value = c.value;
+          f.expires.value = c.expires ? String(c.expires).slice(0,10) : '';
+          f.note.value = c.note || ''; f.min_order.value = c.min_order || '';
+          f.max_uses.value = c.max_uses || '';
+          f.once_per_customer.checked = !!c.once_per_customer;
+          f.send_to.value = c.assigned_to || '';
+          /* The code itself is the primary key — changing it would create a
+             second code rather than rename this one, and leave the original
+             live in somebody's inbox. */
+          f.code.readOnly = true; f.code.style.background = '#f2f4f8';
+          document.getElementById('jt-code-title').textContent = 'Editing ' + c.code;
+          document.getElementById('jt-code-save').textContent = 'Save changes';
+          document.getElementById('jt-code-cancel').style.display = '';
+          f.scrollIntoView({ block:'start', behavior:'smooth' });
+        }
+        function jtEditCancel(){
+          var f = document.getElementById('jt-code-form');
+          f.reset(); f.code.readOnly = false; f.code.style.background = '';
+          document.getElementById('jt-code-title').textContent = 'New code';
+          document.getElementById('jt-code-save').textContent = 'Create code';
+          document.getElementById('jt-code-cancel').style.display = 'none';
+        }
+      </script>
       <p class="muted" style="margin:10px 0 0;font-size:12.5px">
         A <b>$ off</b> code is <b>spent, not drawn down</b>: $30 off a $12 order takes off $12 and the
         code is finished — there is no remaining $18 to come back for. That is why dollar codes default
@@ -8239,22 +8290,33 @@ app.post('/discounts/send', requireAdmin, async (req, res) => {
   }
 });
 
-app.post('/discounts/off', requireAdmin, async (req, res) => {
+/* Switch off, turn back on, remove — one shape, so a new action cannot forget
+   to report its failure. `flag` is what the studio endpoint keys on. */
+async function promoAction(req, res, flag, said) {
   const form = new URLSearchParams();
   form.set('code', String((req.body || {}).code || '').trim().toUpperCase());
-  form.set('delete', '1');
+  form.set(flag, '1');
   try {
     const r = await studioFetch(PROMO_ADMIN(), { method: 'POST', body: form });
     const d = await r.json().catch(() => ({}));
     if (!r.ok || d.error) {
       return res.redirect('/discounts?err=' + encodeURIComponent(d.error || `studio answered ${r.status}`));
     }
-    res.redirect('/discounts?msg=' + encodeURIComponent(`${d.deactivated} switched off.`));
+    res.redirect('/discounts?msg=' + encodeURIComponent(said(d)));
   } catch (e) {
-    console.error('promo deactivate failed:', e.message);
+    console.error(`promo ${flag} failed:`, e.message);
     res.redirect('/discounts?err=' + encodeURIComponent('Could not reach the studio: ' + e.message));
   }
-});
+}
+
+app.post('/discounts/off', requireAdmin, (req, res) =>
+  promoAction(req, res, 'delete', (d) => `${d.deactivated} switched off.`));
+
+app.post('/discounts/on', requireAdmin, (req, res) =>
+  promoAction(req, res, 'reactivate', (d) => `${d.reactivated} is live again.`));
+
+app.post('/discounts/remove', requireAdmin, (req, res) =>
+  promoAction(req, res, 'remove', (d) => `${d.removed} removed.`));
 
 /* Everyone the shop knows, from both halves of it: quotes live here, studio
  * orders live on design.jtees.net, and a person who has done both is one

--- a/tests/discounts-page.test.js
+++ b/tests/discounts-page.test.js
@@ -69,7 +69,25 @@ test('switching a code off never deletes it', () => {
   /* A used code is the record of what a customer was given. Deleting it loses
      the answer to "why was this order $30 light". */
   assert.match(admin, /SET active=0 WHERE code=/);
-  assert.doesNotMatch(admin, /DELETE FROM/);
+});
+
+test('a code that has been used can never be removed', () => {
+  /* Remove exists so a mistyped code does not sit on the page forever. It is
+     refused the moment the code has a use against it — and the DELETE itself
+     carries `AND uses = 0`, so even a bypassed check cannot destroy a record. */
+  assert.match(admin, /\(int\) \$r\[0\]\['uses'\] > 0/,
+    'the use count is checked before removal');
+  assert.match(admin, /so it is kept as a record\. Switch it off instead\./,
+    'and the refusal says what to do instead');
+  assert.match(admin, /DELETE FROM `" \. jt_px\(\) \. "jt_promo_codes`\s*\n\s*WHERE code='" \. jt_esc\(\$code\) \. "' AND uses = 0/,
+    'the DELETE is itself guarded, not merely preceded by a check');
+});
+
+test('a switched-off code can be turned back on', () => {
+  /* Otherwise a code switched off by mistake has to be retyped, which is how
+     its rules get lost. */
+  assert.match(admin, /SET active=1 WHERE code=/);
+  assert.match(src, /app\.post\('\/discounts\/on', requireAdmin/);
 });
 
 test('expired and switched-off codes are told apart', () => {
@@ -263,4 +281,35 @@ test('assigned but unsent is visible as such', () => {
      only one of them needs an action. */
   assert.match(page, /not sent yet/);
   assert.match(page, /sent \$\{fmtDate\(c\.sent_at\)\}/);
+});
+
+test('editing reuses the create form', () => {
+  /* A separate edit form drifts from the create form within a change or two,
+     and then a rule can be set in one place and not the other. */
+  assert.match(page, /function jtEditCode\(json\)/);
+  assert.match(page, /id="jt-code-form"/);
+  assert.match(page, /f\.min_order\.value|f\.max_uses\.value/,
+    'the rules must load back in, or editing silently clears them');
+});
+
+test('the code itself cannot be renamed by an edit', () => {
+  /* The code is the primary key. Changing it would create a SECOND code rather
+     than rename this one — and leave the original live in somebody's inbox. */
+  assert.match(page, /f\.code\.readOnly = true/);
+});
+
+test('the use count is shown as a count, with its limit', () => {
+  assert.match(page, /c\.uses \|\| 0/);
+  assert.match(page, /of \$\{c\.max_uses\}/);
+  assert.match(page, /fully claimed/,
+    'a code at its limit must say so — it looks live otherwise');
+});
+
+test('every code action reports its failure the same way', () => {
+  /* One helper, so a new action cannot forget to surface an error and leave the
+     shop believing something happened that did not. */
+  assert.match(src, /async function promoAction\(req, res, flag, said\)/);
+  for (const a of ['delete', 'reactivate', 'remove']) {
+    assert.ok(src.includes(`promoAction(req, res, '${a}'`), `${a} must go through it`);
+  }
 });


### PR DESCRIPTION
## Why nothing was clickable

The only two codes on the page were **my own automated test codes**, and both
were already switched off. A switched-off code showed **no buttons at all** — so
there was genuinely nothing to click, and no way to bring one back.

That is my mess in two ways: I left the test rows behind, and I built actions
for live codes only.

## What you can do now

Every row has **Edit**. Live rows also have **Send** and **Switch off**;
switched-off rows have **Turn back on**, and **Remove** when the code has never
been used.

**Edit reuses the create form** rather than adding a second one — a separate edit
form drifts from the create form within a change or two, and then a rule gets set
in one place and not the other. The code field goes read-only while editing: the
code is the primary key, so changing it would create a *second* code rather than
rename this one, and leave the original live in somebody's inbox.

## Remove is guarded, twice

A code with any use against it **cannot** be removed — it is the record of a
discount a customer actually received, and the answer to "why was this order $30
light". The check refuses with what to do instead, and the `DELETE` itself
carries `AND uses = 0`, so even a bypassed check cannot destroy a record.

## The use count

Shown as a number, with its limit and a **fully claimed** note when it is spent:

```
Used   3 of 5
Used   1 of 1   fully claimed
```

A code at its limit looks live otherwise, which is how you end up promising one
that will be refused.

## On the 403

I could not reproduce it and I am not going to claim it is fixed. What I checked:
`/discounts` GET and POST both return **401** (auth, correct — not a Cloudflare
block), the studio endpoint answers **200** repeatedly, and the server log shows
**no** studio failure. The container restarted at 17:15, so an error from before
that is gone.

If it is still there after this deploy, tell me **which action** produces it —
loading the page, or a specific button — and I will have it from the difference.

## Tests

450/450, 7 new.