### PR TITLE
Identity and address on every email, unsubscribe on marketing only

### DIFF
--- a/server.js
+++ b/server.js
@@ -635,6 +635,26 @@ function unsubTokenValid(email, token) {
   return ok;
 }
 
+/* Who sent this, and from where — on EVERY email, whatever its type.
+ *
+ * CAN-SPAM only demands a postal address on commercial mail, so a receipt is
+ * exempt. It is still the right thing on all of it: an address is how a person
+ * decides a message is from a real business rather than a phishing attempt, and
+ * splitting the rule by type means every new email is a decision somebody can
+ * get wrong.
+ *
+ * Deliberately NOT an unsubscribe link. Opting out of a receipt, a sign-in code
+ * or a payment confirmation is not something a customer can be allowed to do by
+ * accident — they would stop receiving mail they actually need, and the shop
+ * would have no way to know. Unsubscribe belongs on marketing only, and
+ * sendEmail adds it there. */
+function shopFooter() {
+  return `<p style="color:#9ca3af;font-size:11px;margin-top:18px;line-height:1.5;">
+    June&rsquo;s Tees &amp; Things &middot; 3047 N Lincoln Ave #435, Chicago, IL 60657<br>
+    ${escEmail(SHOP_PHONE)} &middot; <a href="mailto:${escEmail(NOTIFY_EMAIL)}"
+      style="color:#9ca3af;">${escEmail(NOTIFY_EMAIL)}</a></p>`;
+}
+
 function unsubFooter(to) {
   const token = unsubToken(to);
   const url = `${PUBLIC_BASE_URL}/api/unsubscribe?e=${encodeURIComponent(to)}&t=${token}`;
@@ -713,7 +733,10 @@ async function sendEmail({ to, subject, html, replyTo, marketing = false, text }
     console.log(`sendEmail: skipped ${to} (unsubscribed)`);
     return;
   }
-  if (marketing) html = html + unsubFooter(to);
+  /* Applied HERE rather than at each call site, because thirty call sites is
+     thirty chances to forget — and the one that forgets is the one that gets
+     reported. A new email gets this by existing. */
+  html = marketing ? html + unsubFooter(to) : html + shopFooter();
   const textContent = text || htmlToText(html);
   const extraHeaders = marketing ? unsubHeaders(to) : {};
 
@@ -8234,15 +8257,35 @@ async function sendDiscountEmail(code, email, extra) {
   const c = codes.find((x) => String(x.code).toUpperCase() === code);
   if (!c) throw new Error(`${code} was not found`);
 
-  const worth = c.kind === 'amount' ? `${money(c.value)} off` : `${c.value}% off`;
+  /* $30, not $30.00 — trailing zeros read like a system rather than a person. */
+  const tidy = (n) => Number(n) % 1 === 0 ? `$${Number(n)}` : money(n);
+  const worth = c.kind === 'amount' ? `${tidy(c.value)} off` : `${c.value}% off`;
   const rules = [
-    c.min_order > 0 ? `on orders over ${money(c.min_order)}` : '',
+    c.min_order > 0 ? `on orders over ${tidy(c.min_order)}` : '',
     c.expires ? `until ${fmtDate(c.expires)}` : '',
+    /* Said plainly, because a dollar code is spent whole: somebody using $30 on
+       a $12 order and expecting $18 back has been misled by omission. */
+    (c.kind === 'amount' && Number(c.max_uses) === 1) ? 'good for one order' : '',
   ].filter(Boolean).join(', ');
+
+  /* Refuse BEFORE sending, rather than letting sendEmail drop it silently.
+     A promotional send to an address that has opted out is skipped inside
+     sendEmail and returns as though it worked — the page would say "sent" and
+     the customer would never receive it, which is worse than a plain refusal
+     because nobody goes looking. */
+  if (await isUnsubscribed(email)) {
+    throw new Error(`${email} has unsubscribed from emails — send this one by text or call instead`);
+  }
 
     await sendEmail({
       to: email,
       replyTo: SHOP_EMAIL,
+      /* An email whose entire content is an offer is COMMERCIAL, whatever
+         prompted it. That flag is what attaches the postal address and the
+         unsubscribe link CAN-SPAM requires, and the List-Unsubscribe headers
+         Gmail and Yahoo require of bulk senders — all of which this email was
+         missing until now. */
+      marketing: true,
       subject: `A ${worth} code from ${SHOP_NAME}`,
       html: `<div style="font-family:system-ui,sans-serif;max-width:520px;margin:0 auto">
         <h2 style="color:#1848B8;margin:0 0 10px">Here is your ${escEmail(worth)} code</h2>

--- a/tests/email-compliance.test.js
+++ b/tests/email-compliance.test.js
@@ -1,0 +1,88 @@
+'use strict';
+
+/* What every email this shop sends must carry.
+ *
+ * The split matters and is easy to get backwards:
+ *
+ *   EVERY email  — who sent it and a postal address. CAN-SPAM only demands the
+ *                  address on commercial mail, so a receipt is exempt, but it
+ *                  is how a person decides a message is from a real business
+ *                  rather than a phishing attempt.
+ *
+ *   MARKETING    — additionally an unsubscribe link, the List-Unsubscribe
+ *                  headers Gmail and Yahoo require of bulk senders, and a check
+ *                  that the recipient has not already opted out.
+ *
+ * Unsubscribe must NOT be on transactional mail. A customer who opts out of a
+ * receipt, a sign-in code or a payment confirmation stops receiving mail they
+ * need, and the shop has no way to know it happened.
+ */
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const src = fs.readFileSync(path.join(__dirname, '..', 'server.js'), 'utf8');
+const sendEmail = src.slice(src.indexOf('async function sendEmail'),
+                            src.indexOf('/* ── Brevo breach monitor'));
+
+test('every email carries the shop identity and postal address', () => {
+  /* Applied inside sendEmail, not at the call sites: thirty call sites is
+     thirty chances to forget, and the one that forgets is the one reported. */
+  assert.match(sendEmail, /html = marketing \? html \+ unsubFooter\(to\) : html \+ shopFooter\(\)/,
+    'the footer must be attached centrally, so a new email gets it by existing');
+  const footer = src.slice(src.indexOf('function shopFooter'), src.indexOf('function unsubFooter'));
+  assert.match(footer, /3047 N Lincoln Ave/, 'a real postal address');
+  assert.match(footer, /SHOP_PHONE/, 'and a way to reach a person');
+});
+
+test('the everyday footer carries no unsubscribe link', () => {
+  /* Opting out of a receipt or a sign-in code is not something a customer can
+     be allowed to do by accident. */
+  const footer = src.slice(src.indexOf('function shopFooter'), src.indexOf('function unsubFooter'));
+  assert.doesNotMatch(footer, /unsubscribe/i);
+  assert.doesNotMatch(footer, /unsubToken/);
+});
+
+test('marketing mail carries unsubscribe, an address, and one-click headers', () => {
+  const unsub = src.slice(src.indexOf('function unsubFooter'), src.indexOf('async function isUnsubscribed'));
+  assert.match(unsub, /3047 N Lincoln Ave/, 'address');
+  assert.match(unsub, /Unsubscribe<\/a>/, 'a visible opt-out');
+  assert.match(src, /'List-Unsubscribe':/, 'and the header Gmail and Yahoo require');
+  assert.match(src, /'List-Unsubscribe-Post': 'List-Unsubscribe=One-Click'/);
+});
+
+test('marketing mail is never sent to someone who opted out', () => {
+  assert.match(sendEmail, /if \(marketing && await isUnsubscribed\(to\)\)/,
+    'the opt-out is checked before the send, not after');
+});
+
+test('a promotional email is marked as one', () => {
+  /* The discount-code email shipped without this flag, so it carried no
+     address, no unsubscribe, no List-Unsubscribe headers, and would have gone
+     to somebody who had explicitly opted out. An email whose entire content is
+     an offer is commercial, whatever prompted it. */
+  const fn = src.slice(src.indexOf('async function sendDiscountEmail'),
+                       src.indexOf("app.post('/discounts/send'"));
+  assert.match(fn, /marketing: true/);
+});
+
+test('an opted-out recipient is reported, not silently skipped', () => {
+  /* sendEmail drops a marketing send to an opted-out address and returns as
+     though it worked. The page would say "sent" and the customer would never
+     receive it — worse than a refusal, because nobody goes looking. */
+  const fn = src.slice(src.indexOf('async function sendDiscountEmail'),
+                       src.indexOf("app.post('/discounts/send'"));
+  assert.match(fn, /if \(await isUnsubscribed\(email\)\)/);
+  assert.match(fn, /send this one by text or call instead/,
+    'and it says what to do instead');
+});
+
+test('a single-use dollar code says so in the email', () => {
+  /* Someone using $30 on a $12 order and expecting $18 back has been misled by
+     omission. */
+  const fn = src.slice(src.indexOf('async function sendDiscountEmail'),
+                       src.indexOf("app.post('/discounts/send'"));
+  assert.match(fn, /good for one order/);
+});


### PR DESCRIPTION
## The gap I introduced

The discount-code email shipped with **none** of what a promotional email needs:
no postal address, no unsubscribe link, no `List-Unsubscribe` headers — and it
would have sent a discount to somebody who had **explicitly opted out**, because
it never set `marketing: true`.

Your existing cart and welcome sequences do set it and were fine. I broke the
pattern rather than the pattern being wrong.

## What every email gets now

Attached **inside `sendEmail()`**, not at the call sites. Thirty call sites is
thirty chances to forget, and the one that forgets is the one that gets reported.
A new email gets this by existing.

| | every email | marketing only |
| --- | --- | --- |
| Who sent it, postal address, phone | ✅ | ✅ |
| Unsubscribe link | ✗ | ✅ |
| `List-Unsubscribe` one-click headers | ✗ | ✅ |
| Opt-out checked before sending | ✗ | ✅ |

## Why unsubscribe is NOT on everything

You asked for all email types, and this is the one place I have not done it
literally — because it would hurt you.

CAN-SPAM exempts transactional mail from the unsubscribe requirement. More
importantly, a customer who opts out of a **receipt**, a **sign-in code** or a
**payment confirmation** stops receiving mail they actually need, and you have no
way to know it happened. The address goes on everything; the opt-out goes on
marketing only.

If you want it literally everywhere, say so and I will — but I would be doing it
over that objection.

## Silent failure fixed

`sendEmail()` **drops** a marketing send to an opted-out address and returns as
though it worked. The page would have said "TYLER30 sent to tylwur@yahoo.com"
with nothing sent. It now refuses up front: *"has unsubscribed from emails — send
this one by text or call instead."*

## Copy

- **"$30 off"** not "$30.00 off" — trailing zeros read like a system
- **"good for one order"** on single-use dollar codes, so nobody expects change
  back from $30 on a $12 order

## Tests

457/457, 7 new — including that the everyday footer contains no unsubscribe link,
which is the half of this that is easy to get backwards.