### PR TITLE
Warn before emailing a code that has already gone out

### DIFF
--- a/server.js
+++ b/server.js
@@ -7970,8 +7970,9 @@ app.get('/discounts', requireAdmin, async (req, res) => {
     <tr style="border-top:1px solid #eef1f8${live(c) ? '' : ';opacity:.55'}">
       <td style="padding:9px 6px"><b style="font-family:ui-monospace,SFMono-Regular,Menlo,monospace">${escEmail(c.code)}</b>
         ${c.assigned_to ? `<div style="font-size:12.5px;color:#1848B8">for ${escEmail(c.assigned_to)}${
-          c.sent_at ? ` <span class="muted">&middot; sent ${fmtDate(c.sent_at)}</span>`
-                    : ' <span class="muted">&middot; not sent yet</span>'}</div>` : ''}
+          c.sent_at ? ` <span class="muted">&middot; sent ${fmtDate(c.sent_at)}${
+            c.send_count > 1 ? ` (${c.send_count}&times;)` : ''}</span>`
+                    : ' <span style="color:#b45309">&middot; not sent yet</span>'}</div>` : ''}
         ${c.note ? `<div class="muted" style="font-size:12.5px">${escEmail(c.note)}</div>` : ''}</td>
       <td style="padding:9px 6px;white-space:nowrap"><b>${escEmail(worth(c))}</b>${
         (c.min_order > 0 || c.once_per_customer) ? `<div class="muted" style="font-size:11.5px">${
@@ -8016,7 +8017,10 @@ app.get('/discounts', requireAdmin, async (req, res) => {
     ${live(c) ? `
     <tr id="snd-${escEmail(c.code)}" style="display:none;background:#f7f9fc">
       <td colspan="6" style="padding:10px 6px">
-        <form method="POST" action="/discounts/send" style="display:flex;gap:8px;flex-wrap:wrap;align-items:center">
+        <form method="POST" action="/discounts/send" style="display:flex;gap:8px;flex-wrap:wrap;align-items:center"${
+          c.sent_at ? ` onsubmit="return confirm('${escEmail(c.code)} has already been emailed${
+            c.send_count > 1 ? ' ' + c.send_count + ' times' : ''} — last on ${
+            escEmail(fmtDate(c.sent_at))}${c.assigned_to ? ' to ' + escEmail(c.assigned_to) : ''}.\n\nSend it again?')"` : ''}>
           <input type="hidden" name="code" value="${escEmail(c.code)}">
           <span class="muted" style="font-size:12.5px">Email <b>${escEmail(c.code)}</b> to</span>
           <input name="email" type="email" required list="jt-customers"
@@ -8316,6 +8320,13 @@ app.post('/discounts/send', requireAdmin, async (req, res) => {
     return res.redirect('/discounts?err=' + encodeURIComponent('That email address looks wrong.'));
   }
   try {
+    /* How many times this has gone out already, read BEFORE sending so the
+       message afterwards can say "again" rather than reporting a repeat as if
+       it were the first time. */
+    const before = (await fetchPromoCodes()).codes
+      .find((x) => String(x.code).toUpperCase() === code);
+    const already = before ? Number(before.send_count) || 0 : 0;
+
     await sendDiscountEmail(code, email, extra);
     /* Record it AFTER the send succeeds. Stamping first would show a code as
        sent that never left. */
@@ -8324,7 +8335,9 @@ app.post('/discounts/send', requireAdmin, async (req, res) => {
       f.set('code', code); f.set('sent', '1'); f.set('assigned_to', email.toLowerCase());
       await studioFetch(PROMO_ADMIN(), { method: 'POST', body: f });
     } catch (e) { console.error('discount send stamp failed:', e.message); }
-    res.redirect('/discounts?msg=' + encodeURIComponent(`${code} sent to ${email}.`));
+    res.redirect('/discounts?msg=' + encodeURIComponent(
+      already ? `${code} sent to ${email} again — that is ${already + 1} times now.`
+              : `${code} sent to ${email}.`));
   } catch (e) {
     console.error('discount send failed:', e.message);
     /* Said plainly. A silent failure here means the shop believes a customer

--- a/tests/discounts-page.test.js
+++ b/tests/discounts-page.test.js
@@ -313,3 +313,44 @@ test('every code action reports its failure the same way', () => {
     assert.ok(src.includes(`promoAction(req, res, '${a}'`), `${a} must go through it`);
   }
 });
+
+/* ── Sending the same code twice ─────────────────────────────────────────── */
+
+test('re-sending a code warns first, naming when and to whom', () => {
+  /* The row already showed a sent date, but nothing said anything at the moment
+     of clicking — which is the only moment it can change the outcome. */
+  assert.match(page, /c\.sent_at \? ` onsubmit="return confirm\(/,
+    'a code that has been sent must confirm before going again');
+  assert.match(page, /has already been emailed/);
+  assert.match(page, /last on \$\{/, 'the warning must say WHEN');
+  assert.match(page, /' to ' \+ escEmail\(c\.assigned_to\)/, 'and to whom');
+});
+
+test('an unsent code sends without a confirmation', () => {
+  /* A prompt on the first send would train the operator to click through them,
+     and the warning would stop being read by the time it matters. */
+  assert.match(page, /c\.sent_at \? ` onsubmit/,
+    'the confirm is conditional on having been sent before');
+});
+
+test('a repeat is reported as a repeat', () => {
+  /* "TYLER30 sent to Tyler" after the third send reads as the first. */
+  const send = src.slice(src.indexOf("app.post('/discounts/send'"));
+  assert.match(send, /already \? `\$\{code\} sent to \$\{email\} again/);
+  assert.match(send, /that is \$\{already \+ 1\} times now/);
+});
+
+test('the count is read before the send, not after', () => {
+  /* Reading it afterwards would include the send just made and report every
+     first send as a second. */
+  const send = src.slice(src.indexOf("app.post('/discounts/send'"));
+  const read = send.indexOf('const already =');
+  const doSend = send.indexOf('await sendDiscountEmail');
+  assert.ok(read > -1 && read < doSend, 'the count must be taken first');
+});
+
+test('not-sent-yet is called out rather than muted', () => {
+  /* It is the state that needs an action, so it should not be styled like the
+     quiet metadata beside it. */
+  assert.match(page, /color:#b45309">&middot; not sent yet/);
+});


### PR DESCRIPTION
## What was wrong

The row showed a sent date, but **nothing said anything at the moment of
clicking** — which is the only moment the information can change what happens.
So TYLER30 went to Tyler twice with no indication either time.

## Now

Clicking **Send** on a code that has already been emailed asks first:

> TYLER30 has already been emailed — last on Aug 30 to tylwur@yahoo.com.
>
> Send it again?

A code that has never been sent goes without a prompt. A confirmation on the
first send would train you to click through them, and the warning would stop
being read by the time it mattered.

## A count, not just a date

`send_count` is now tracked, so the row reads **"sent Aug 30 (3×)"**. A date
alone answers "when did this last go out" but not "have I sent this three
times" — and the same code arriving repeatedly reads to the customer as
disorganised.

The message afterwards is honest about it too: *"TYLER30 sent to
tylwur@yahoo.com again — that is 2 times now."* The count is read **before** the
send, because reading it after would include the send just made and report every
first send as a second.

## Small thing

**"not sent yet"** is now amber rather than grey. It is the state that needs an
action from you, so it should not be styled like the quiet metadata beside it.

## Tests

462/462, 5 new — including that the confirm is conditional, and that the count is
read before the send rather than after.