### PR TITLE
Discount cap, start date, minimum items, and lock a code to its customer

### DIFF
--- a/server.js
+++ b/server.js
@@ -7975,9 +7975,17 @@ app.get('/discounts', requireAdmin, async (req, res) => {
                     : ' <span style="color:#b45309">&middot; not sent yet</span>'}</div>` : ''}
         ${c.note ? `<div class="muted" style="font-size:12.5px">${escEmail(c.note)}</div>` : ''}</td>
       <td style="padding:9px 6px;white-space:nowrap"><b>${escEmail(worth(c))}</b>${
-        (c.min_order > 0 || c.once_per_customer) ? `<div class="muted" style="font-size:11.5px">${
-          [c.min_order > 0 ? 'on ' + money(c.min_order) + '+' : '',
-           c.once_per_customer ? 'one per customer' : ''].filter(Boolean).join(' &middot; ')}</div>` : ''}</td>
+        (() => {
+          const r = [
+            c.max_discount > 0 ? 'max ' + money(c.max_discount) : '',
+            c.min_order > 0 ? 'on ' + money(c.min_order) + '+' : '',
+            c.min_items > 0 ? c.min_items + '+ items' : '',
+            c.once_per_customer ? 'one per customer' : '',
+            c.locked_to_customer ? 'that customer only' : '',
+            c.starts_at ? 'from ' + fmtDate(c.starts_at) : '',
+          ].filter(Boolean);
+          return r.length ? `<div class="muted" style="font-size:11.5px">${r.join(' &middot; ')}</div>` : '';
+        })()}</td>
       <td style="padding:9px 6px;white-space:nowrap;font-size:12.5px" class="muted">${
         c.expires ? 'until ' + fmtDate(c.expires) : 'no end date'}</td>
       <td class="num" style="padding:9px 6px;white-space:nowrap">
@@ -7994,6 +8002,8 @@ app.get('/discounts', requireAdmin, async (req, res) => {
             code: c.code, kind: c.kind, value: c.value, expires: c.expires || '',
             note: c.note || '', min_order: c.min_order || '', max_uses: c.max_uses || '',
             once_per_customer: !!c.once_per_customer, assigned_to: c.assigned_to || '',
+            starts_at: c.starts_at || '', min_items: c.min_items || '',
+            max_discount: c.max_discount || '', locked_to_customer: !!c.locked_to_customer,
           })).replace(/"/g, '&quot;')})">Edit</button>
         ${live(c) ? `
         <button type="button" class="btn btn-ghost" style="padding:5px 10px;font-size:12.5px"
@@ -8088,9 +8098,26 @@ app.get('/discounts', requireAdmin, async (req, res) => {
             <input name="value" required type="number" step="0.01" min="0.01" placeholder="30"
                    style="width:100%;padding:8px;font-size:14px">
           </div>
+          <div style="flex:0 1 140px">
+            <label style="font-size:12px">Cap the discount <span class="muted">(% only)</span></label>
+            <input name="max_discount" type="number" step="0.01" min="0" placeholder="no cap"
+                   style="width:100%;padding:8px;font-size:14px">
+          </div>
+        </div>
+
+        <div style="display:flex;gap:10px;flex-wrap:wrap;align-items:flex-end;margin-top:10px">
+          <div style="flex:0 1 160px">
+            <label style="font-size:12px">Starts <span class="muted">(optional)</span></label>
+            <input name="starts_at" type="date" style="width:100%;padding:8px;font-size:14px">
+          </div>
           <div style="flex:0 1 160px">
             <label style="font-size:12px">Expires <span class="muted">(optional)</span></label>
             <input name="expires" type="date" style="width:100%;padding:8px;font-size:14px">
+          </div>
+          <div style="flex:0 1 150px">
+            <label style="font-size:12px">Minimum items <span class="muted">(optional)</span></label>
+            <input name="min_items" type="number" step="1" min="0" placeholder="any"
+                   style="width:100%;padding:8px;font-size:14px">
           </div>
         </div>
         <div style="display:flex;gap:10px;flex-wrap:wrap;align-items:flex-end;margin-top:10px">
@@ -8104,9 +8131,13 @@ app.get('/discounts', requireAdmin, async (req, res) => {
             <input name="max_uses" type="number" step="1" min="0" placeholder="1"
                    style="width:100%;padding:8px;font-size:14px">
           </div>
-          <label style="flex:1 1 200px;font-size:13px;display:flex;align-items:center;gap:6px;padding-bottom:8px">
+          <label style="flex:0 1 190px;font-size:13px;display:flex;align-items:center;gap:6px;padding-bottom:8px">
             <input type="checkbox" name="once_per_customer" value="1" style="width:auto">
             One per customer
+          </label>
+          <label style="flex:1 1 250px;font-size:13px;display:flex;align-items:center;gap:6px;padding-bottom:8px">
+            <input type="checkbox" name="locked_to_customer" value="1" style="width:auto">
+            Only the person it is sent to can use it
           </label>
         </div>
         <div style="margin-top:10px">
@@ -8134,6 +8165,10 @@ app.get('/discounts', requireAdmin, async (req, res) => {
           f.note.value = c.note || ''; f.min_order.value = c.min_order || '';
           f.max_uses.value = c.max_uses || '';
           f.once_per_customer.checked = !!c.once_per_customer;
+          f.locked_to_customer.checked = !!c.locked_to_customer;
+          f.starts_at.value = c.starts_at ? String(c.starts_at).slice(0,10) : '';
+          f.min_items.value = c.min_items || '';
+          f.max_discount.value = c.max_discount || '';
           f.send_to.value = c.assigned_to || '';
           /* The code itself is the primary key — changing it would create a
              second code rather than rename this one, and leave the original
@@ -8214,6 +8249,10 @@ app.post('/discounts', requireAdmin, async (req, res) => {
   /* Assigning and sending are the same field: the code exists to reach one
      person, so naming them is what makes it theirs. */
   form.set('assigned_to', String(b.send_to || '').trim().toLowerCase());
+  form.set('starts_at', String(b.starts_at || '').trim());
+  form.set('min_items', String(b.min_items || ''));
+  form.set('max_discount', String(b.max_discount || ''));
+  if (b.locked_to_customer) form.set('locked_to_customer', '1');
   try {
     const r = await studioFetch(PROMO_ADMIN(), { method: 'POST', body: form });
     const d = await r.json().catch(() => ({}));

--- a/tests/discounts-page.test.js
+++ b/tests/discounts-page.test.js
@@ -354,3 +354,56 @@ test('not-sent-yet is called out rather than muted', () => {
      quiet metadata beside it. */
   assert.match(page, /color:#b45309">&middot; not sent yet/);
 });
+
+/* ── The controls a real discount system has ─────────────────────────────── */
+
+test('a code issued to one customer can be locked to them', () => {
+  /* assigned_to was RECORDED and never ENFORCED: a $30 single-use code meant
+     for Tyler worked for anyone he forwarded it to — and once spent, the
+     customer it was for never got it. */
+  assert.match(auth, /!empty\(\$d\['locked_to_customer'\]\) && !empty\(\$d\['assigned_to'\]\)/);
+  assert.match(auth, /That code was issued to a different customer\./);
+  assert.match(page, /name="locked_to_customer"/);
+});
+
+test('the lock is not applied before we know who is ordering', () => {
+  /* The cart does not always have an email yet. Refusing then would block the
+     person the code belongs to, at the field where they enter it. */
+  assert.match(auth, /&& \$email !== ''\s*\n?\s*&& strtolower\(trim\(\$email\)\) !== \$d\['assigned_to'\]/);
+});
+
+test('a percentage discount can be capped', () => {
+  /* "20% off" on a $2,000 order is $400 the shop never meant to give. */
+  assert.match(auth, /if \(!empty\(\$d\['max_discount'\]\) && \$off > \(float\) \$d\['max_discount'\]\)/);
+  assert.match(page, /name="max_discount"/);
+});
+
+test('a cap is not stored on a fixed-amount code', () => {
+  /* On a $30 code the value IS the cap; a second number would imply a rule that
+     does nothing and invite someone to set it. */
+  assert.match(admin, /if \(\$kind === 'amount'\) \$maxDisc = 0;/);
+});
+
+test('a code can be scheduled to start later', () => {
+  assert.match(auth, /does not start until/);
+  assert.match(page, /name="starts_at"/);
+  assert.match(admin, /That code would expire before it starts\./,
+    'and a start after the expiry is refused rather than stored');
+});
+
+test('a minimum item count is enforced with the real cart', () => {
+  /* Minimum SPEND and minimum ITEMS are different offers — "any 3 shirts" is
+     not "$60 of shirts". */
+  assert.match(auth, /needs at least ' \. \(int\) \$d\['min_items'\] \. ' items/);
+  const conn = fs.readFileSync(path.join(ROOT,
+    'Lumise/Lumise-Product-Designer-PHP-ver2.0/lumise/php_connector.php'), 'utf8');
+  assert.match(conn, /count\(\(array\) \$cart_data\['items'\]\)/,
+    'the order path must pass the real item count');
+});
+
+test('every rule shows on the row', () => {
+  /* A rule that exists only in the form is one the shop cannot audit later. */
+  for (const bit of ['max ', 'on ', '+ items', 'one per customer', 'that customer only', 'from ']) {
+    assert.ok(page.includes(bit), `the row must show: ${bit}`);
+  }
+});


### PR DESCRIPTION
Modelled on how the major store platforms structure a discount — value, minimum
requirements, customer eligibility, usage limits, active dates — and mapped onto
what this shop actually needs.

## The hole worth fixing first

**`assigned_to` was recorded and never enforced.** A $30 single-use code issued
to Tyler worked for anyone he forwarded it to — and once spent, the customer it
was meant for never got it. Recording who a code is for while letting anyone
spend it is the worst of both.

**Only the person it is sent to can use it** now does what it says. It is
checked only once we know who is ordering: the cart does not always have an
email yet, and refusing earlier would block the person the code belongs to at
the moment they enter it. The order path always has it.

## What was missing, and now exists

| | why |
| --- | --- |
| **Cap the discount** | "20% off" on a $2,000 order is $400 nobody meant to give |
| **Starts** | a code can be made now and go live later |
| **Minimum items** | "any 3 shirts" is a different offer from "$60 of shirts" |
| **Locked to customer** | above |

Already there and unchanged: minimum spend, total uses, one-per-customer,
expiry.

## Details that matter

- A cap is **not stored on a fixed-amount code** — the value already is the cap,
  and a second number implies a rule that does nothing
- A start date **after** the expiry is refused rather than stored
- Minimum items is checked against the **real cart**, not a number in the session
- Every rule **shows on the row** — a rule visible only in the form is one you
  cannot audit later

## Also done

- **TYLER10 removed.** It was in `JT_PROMO_STANDING`; the variable is deleted, so
  only TYLER30 is live for him now.
- `send_count` back-filled to 1 for codes sent before the counter existed —
  TYLER30 showed a send date with a count of zero.

## Tests

469/469, 7 new.