### PR TITLE
Pin that the order path re-checks a code before discounting

### DIFF
--- a/tests/discounts-page.test.js
+++ b/tests/discounts-page.test.js
@@ -407,3 +407,22 @@ test('every rule shows on the row', () => {
     assert.ok(page.includes(bit), `the row must show: ${bit}`);
   }
 });
+
+test('the order path re-checks BEFORE the discount is applied', () => {
+  /* This is what makes it safe to accept a locked code at the cart stage, where
+     there is no email yet. If the re-check ran after — or not at all — a
+     customer could enter someone else's code before filling in their address
+     and keep the discount.
+     The check clears both the local code AND the session, so jt_promo_discount
+     then reads an empty session and returns 0 regardless. */
+  const conn = fs.readFileSync(path.join(ROOT,
+    'Lumise/Lumise-Product-Designer-PHP-ver2.0/lumise/php_connector.php'), 'utf8');
+  const check = conn.indexOf('jt_promo_block_reason($jt_promo_code');
+  const apply = conn.indexOf('$order_total - jt_promo_discount($order_total)');
+  assert.ok(check > -1 && apply > -1, 'both steps must exist');
+  assert.ok(check < apply, 'the re-check must come first');
+
+  const between = conn.slice(check, apply);
+  assert.match(between, /\$jt_promo_code = '';/, 'a failed check clears the code');
+  assert.match(between, /set_session\('jt_promo', ''\)/, 'and the session with it');
+});


### PR DESCRIPTION
Regression test from verifying the customer lock against the live validator.

## What I tested

Created a real locked code on the studio and put it through
`jt-promo.php` — the same endpoint the checkout calls:

```
ACCEPTED  right customer, qualifies
refused   WRONG customer                  That code was issued to a different customer.
refused   right customer, order too small That code needs an order of at least $50.00.
ACCEPTED  no email yet (cart stage)
```

Three are plainly right. The fourth is the one worth explaining.

## Why "no email yet" is accepted

The cart does not always have an email when the code is entered. Refusing then
would block the person the code belongs to at the moment they type it, which is
the opposite of the intent.

So it is accepted into the session and **re-checked when the order is placed**,
where the email is always present. This test pins the property that makes that
safe: the re-check runs **before** the discount is applied, and clears both the
code and the session — so `jt_promo_discount()` reads an empty session and
returns 0 regardless.

If that ordering were ever reversed, someone could enter another customer's code
before filling in their address and keep the discount.

## Not tested

A full live checkout. I created and removed a disposable code rather than putting
a real order through, so the last link — Stripe actually charging the reduced
amount — is still unexercised. The arithmetic and the refusal are.

470/470.