### PR TITLE
Let a customer change sizes until they pay, not until they accept

### DIFF
--- a/server.js
+++ b/server.js
@@ -5721,7 +5721,18 @@ app.get('/q/:code', async (req, res) => {
        the line into a different volume band, so a total recalculated in the
        browser would be a number the shop never agreed to, shown to the customer
        as if it had. */
-    const canEditQty = !accepted && !paid;
+    /* Editable until money has moved, NOT until the quote is accepted.
+     *
+     * Gating on `accepted` made this feature invisible: every quote in the
+     * system is accepted, so no customer ever saw a size box. Worse, accepting
+     * is exactly when somebody re-reads their order and notices they need two
+     * more XLs — asking them to phone at that point is the friction this exists
+     * to remove.
+     *
+     * Accepting is not paying. Once a deposit lands the job is scheduled and
+     * blanks may be on order, so THAT is where a change becomes a conversation
+     * rather than a form. */
+    const canEditQty = !paid && !q.cancelled_at;
 
     /* Every size the garment comes in, in catalogue order — not just the ones
        already ordered. A customer whose quote is all mediums has to be able to
@@ -5938,7 +5949,7 @@ app.get('/q/:code', async (req, res) => {
         </div>
       </div>`}
 
-      ${(paid || accepted) ? '' : `
+      ${(paid || q.cancelled_at) ? '' : `
       <div class="card">
         <b style="color:#0B1F4B">Need something changed?</b>
         <p class="muted" style="margin:4px 0 10px">Change the sizes and quantities in the table above,
@@ -5953,15 +5964,9 @@ app.get('/q/:code', async (req, res) => {
         </form>
       </div>`}
 
-      ${(paid || !accepted) ? '' : `
-      <div class="card">
-        <b style="color:#0B1F4B">Need a change before we start?</b>
-        <p class="muted" style="margin:4px 0 10px">Nothing has been printed yet — tell ${SHOP_SIGNER} and the quote is updated.</p>
-        <form method="POST" action="/q/${q.code}/changes">
-          <textarea name="message" rows="2" required placeholder="What would you like different?"></textarea>
-          <button type="submit" class="btn-ghost" style="width:100%;margin-top:10px">Send to ${SHOP_SIGNER}</button>
-        </form>
-      </div>`}
+      ${/* The "before we start" form that used to appear only after accepting is
+           gone: one form now serves both states, because the change a customer
+           wants is the same question whether or not they have said yes. */ ''}
 
       ${q.change_request && !paid ? `
       <div class="card"><div class="ok">Change requested — ${SHOP_SIGNER} is updating this quote.

--- a/tests/quote-customer-edits.test.js
+++ b/tests/quote-customer-edits.test.js
@@ -232,10 +232,30 @@ test('the posted field names are the ones the handler reads', () => {
   assert.match(handler, /one\(b\['qty' \+ '_' \+ ix\]\)/);
 });
 
-test('sizes are only editable while the quote is still an offer', () => {
+test('sizes stay editable until money has moved, not until acceptance', () => {
+  /* Gating on `accepted` made this feature INVISIBLE — every quote in the
+     system is accepted, so no customer ever saw a size box. It also blocked the
+     change at the exact moment people ask for one: accepting is when somebody
+     re-reads their order and notices they need two more XLs.
+
+     Accepting is not paying. Once a deposit lands the job is scheduled and
+     blanks may be on order, so that is where a change becomes a conversation
+     rather than a form. */
   const page = src.slice(src.indexOf("app.get('/q/:code'"));
-  assert.match(page, /const canEditQty = !accepted && !paid/,
-    'an accepted or paid quote shows its numbers, it does not offer them for edit');
+  assert.match(page, /const canEditQty = !paid && !q\.cancelled_at/);
+  assert.doesNotMatch(page, /const canEditQty = !accepted/,
+    'gating on acceptance hides the feature from every quote that has one');
+});
+
+test('the change form is offered on an accepted quote too', () => {
+  /* It used to be two forms — one before accepting, one after — and the second
+     was the only one an accepted customer saw. One form now serves both, since
+     the change somebody wants is the same question either way. */
+  const page = src.slice(src.indexOf("app.get('/q/:code'"));
+  assert.match(page, /\$\{\(paid \|\| q\.cancelled_at\) \? '' : `/,
+    'only payment or cancellation removes the change form');
+  assert.doesNotMatch(page, /Need a change before we start\?/,
+    'the duplicate accepted-only form should be gone, not left dead');
 });
 
 test('one() is a module-level helper, reachable from every handler that reads a body', () => {


### PR DESCRIPTION
## Why it "didn't work" — it was invisible

The size boxes and the change form were gated on `!accepted`. **Every quote in
the system is accepted**, so no customer has ever seen either one. I verified it
against the live page: zero size inputs, no change form.

That gate was my mistake, and not only because of the data. **Accepting is
exactly when somebody re-reads their order and notices they need two more XLs.**
Closing the form at that moment is the friction the feature exists to remove.

## The corrected rule

Editable until **money has moved**, not until acceptance:

```
canEditQty = !paid && !cancelled
```

Accepting is not paying. Once a deposit lands the job is scheduled and blanks may
be on order, so that is where a change becomes a conversation rather than a form.

The page also carried **two** change forms — one before accepting, one after —
and the second was the only one an accepted customer saw. One form now serves
both states, since the change somebody wants is the same question either way.
The duplicate is removed, not left as a dead branch.

## Now testable

Open any quote's customer link, change a size, submit — Accept and the pay
options should be replaced by the on-hold banner, and both refuse server-side
even from a stale tab.

## Tests

477/477. The test that pinned the old rule now pins the new one and fails if
`!accepted` ever returns.