### PR TITLE
Stop discarding a size change on an accepted quote

### DIFF
--- a/server.js
+++ b/server.js
@@ -6762,11 +6762,18 @@ app.post('/q/:code/changes', orderRateLimit, async (req, res) => {
        proposal. Everything else can still be asked about. */
     if (Number(q.paid_amount || 0) > 0) return res.redirect('/q/' + code);
 
-    /* Structured edits only while the quote is still an offer. Once accepted,
-       the numbers are what was agreed to, so a change goes back through the
-       shop as a conversation rather than as a silent edit of the agreement. */
+    /* Editable until money has moved — the same rule the page renders by.
+     *
+     * This said `!q.accepted_at` while the page had just been changed to show
+     * the size boxes on an accepted quote. So the form offered the edit, the
+     * customer made it, and the handler silently threw the numbers away: no
+     * request was stored, nothing was on hold, and Accept and Pay stayed open
+     * at the ORIGINAL price. A form that accepts input and discards it is worse
+     * than one that is not there.
+     *
+     * The two rules must match. They are both "not paid, not cancelled". */
     const items = Array.isArray(q.items) ? q.items : [];
-    const editable = !q.accepted_at;
+    const editable = !q.cancelled_at;
     let requested = null;
     /* The same list the customer's page rendered from, derived the same way, so
        the names posted and the names read are the same set by construction. */

--- a/tests/quote-customer-edits.test.js
+++ b/tests/quote-customer-edits.test.js
@@ -164,9 +164,22 @@ test('a paid quote cannot be edited', () => {
     'once money has moved the quote is not a proposal any more');
 });
 
-test('an accepted quote takes the note but not the numbers', () => {
-  assert.match(handler, /const editable = !q\.accepted_at/,
-    'accepted means the numbers were agreed; a change goes back through the shop');
+test('the handler accepts edits on exactly the quotes the page offers them on', () => {
+  /* These two rules drifted and it cost money. The page was changed to show
+     size boxes on an accepted quote while the handler still read
+     `!q.accepted_at` — so the form took the edit, threw the numbers away, stored
+     no request, and left Accept and Pay open at the ORIGINAL price. The customer
+     saw their change accepted and then paid the old total.
+
+     A form that accepts input and discards it is worse than no form. Both rules
+     are now "not paid, not cancelled". */
+  assert.match(handler, /const editable = !q\.cancelled_at/);
+  assert.doesNotMatch(handler, /const editable = !q\.accepted_at/,
+    'gating the handler on acceptance silently discards a real edit');
+
+  const page = src.slice(src.indexOf("app.get('/q/:code'"));
+  assert.match(page, /const canEditQty = !paid && !q\.cancelled_at/,
+    'and the page must offer them on the same quotes');
 });
 
 test('the accepted-quote change request is no longer silently dropped', () => {


### PR DESCRIPTION
## The bug, and it cost money

The page was changed to show size boxes on an accepted quote. The **handler was
not**: it still read `const editable = !q.accepted_at`.

So the form took the edit and **silently threw the numbers away**. No request was
stored, nothing went on hold, and Accept and Pay stayed open at the **original
price**. The customer saw their change accepted and then paid the old total.

Confirmed in the database: quote 1110E4 shows `requested_items = f` after a real
edit was submitted. The money guards were never wrong — they had nothing to
guard against, because the request was discarded upstream.

**A form that accepts input and discards it is worse than no form.**

## The fix

Both rules are now "not paid, not cancelled":

```
page:     canEditQty = !paid && !q.cancelled_at
handler:  editable   = !q.cancelled_at
```

The handler already refuses a paid quote a few lines earlier, so the two agree on
every state.

## Why they drifted

I changed the page and did not follow the same rule down into the handler. The
test I wrote at the time pinned the OLD handler behaviour — "an accepted quote
takes the note but not the numbers" — so it passed while the feature was broken,
which is the worst thing a test can do.

That test now pins the **pair**: it asserts both rules and fails if either goes
back to gating on acceptance.

## To verify

Open a quote's customer link, change a size, submit. Accept and Pay should be
replaced by the on-hold banner, and both should refuse from a stale tab.

477/477.