### PR TITLE
Six screens including the base: stop selling seven colours

### DIFF
--- a/docs/pricing-2026.md
+++ b/docs/pricing-2026.md
@@ -95,7 +95,7 @@ they bill once per order at $35/screen (cost $20), screens = (colours + 1 on dar
   NEW  7 colour          $9.80      $9.25      $8.60      $8.15      $7.70      $7.30
 
   The same prices are also written to the combined "Screen Printing" method,
-  as columns 1-color..7-color plus a full-color backstop, so the editor can
+  as columns 1-color..6-color plus a full-color backstop, so the editor can
   price from the design's own colour count.
 
 
@@ -158,7 +158,7 @@ Whole job, decoration only — the blank is a separate line with its own markup:
 | 50pc, 1 colour, 1 location, white (the minimum job) | $227.50 | $110.00 | $117.50 | 51.6% |
 | 50pc, 1 colour, 1 location, dark | $262.50 | $130.00 | $132.50 | 50.5% |
 | 50pc, 1 colour, 2 locations, dark | $525.00 | $260.00 | $265.00 | 50.5% |
-| 50pc, 7 colours, 2 locations, dark (worst case) | $1,540.00 | $780.00 | $760.00 | 49.4% |
+| 50pc, 5 colours, 2 locations, dark (worst case — 12 screens) | $1,080.00 | $606.00 | $474.00 | 43.9% |
 | 100pc, 1 colour, 2 locations, dark | $830.00 | $410.00 | $420.00 | 50.6% |
 | 500pc, 1 colour, 2 locations, dark | $2,840.00 | $1,400.00 | $1,440.00 | 50.7% |
 
@@ -287,34 +287,58 @@ two sells at $13.83 against $6.92 (50.0%). On two-sided work this shop is struct
 competitor, and no amount of garment discounting closes that gap: the garment is
 only $2.82 of the $6.92.
 
+## Six screens, and the white underbase is one of them
+
+The press runs **six screens in one pass**, base included. So:
+
+| garment | most printed colours |
+| --- | --- |
+| light | **6** |
+| dark | **5** — the white underbase takes a station |
+
+The ceiling is **per pass, not per order**. A two-sided 5-colour job is two
+passes of six screens and is fine; a one-sided 6-colour job on a dark garment is
+seven on one pass and is not.
+
+Anything over that is a **DTF job**, not a more expensive screen-print job —
+there is no price for it because the shop cannot run it.
+
+**The 7-colour column was wrong and was being sold.** Its prices were a straight
++$0.47 extrapolation of the sixth column — invented, not quoted. The generator
+now refuses any row past the ceiling rather than pricing it, `full-color` is
+priced at the highest *producible* column, and `max_screens` travels in the
+method row so every surface reads one definition.
+
 ## Which method is cheaper — recomputed 2026-08-30
 
 Screen print moved twice in one day (anchor $4.25 → $3.85, screens $35 → $25), so
 every earlier crossover figure is wrong. The old note said *"DTF wins from 5
 colours below 500 pieces and 4 at 500+"*. It does not any more.
 
-**`s` = screen print cheaper · `D` = DTF cheaper**, by colour count 1–7:
+**`s` = screen print cheaper · `D` = DTF cheaper**, by colour count 1–6. There is
+no 7 — see the ceiling above; on a dark garment column 6 is unavailable too.
 
 ### One location
 
-| qty | 1 | 2 | 3 | 4 | 5 | 6 | 7 | DTF wins from |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| 50 | s | s | s | s | s | s | D | 7 colours |
-| 100 | s | s | s | s | s | D | D | 6 colours |
-| 250 | s | s | s | s | s | D | D | 6 colours |
-| 500 | s | s | s | s | D | D | D | 5 colours |
-| 1,000 | s | s | s | D | D | D | D | 4 colours |
-| 2,500 | s | s | s | D | D | D | D | 4 colours |
+| qty | 1 | 2 | 3 | 4 | 5 | 6 | DTF wins from |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| 50 | s | s | s | s | s | s | never — DTF only past 6 |
+| 100 | s | s | s | s | s | D | 6 colours |
+| 250 | s | s | s | s | s | D | 6 colours |
+| 500 | s | s | s | s | D | D | 5 colours |
+| 1,000 | s | s | s | D | D | D | 4 colours |
+| 2,500 | s | s | s | D | D | D | 4 colours |
 
-On a **dark** garment at 50 pieces DTF wins from 6 rather than 7 — the white
-underbase is an extra screen at every location. Everywhere else the dark and
+On a **dark** garment the top column is unavailable — six printed colours plus a
+base is seven screens. So at 50 pieces a dark garment goes to DTF at 6 colours
+where a light one could still be screen printed. Everywhere else the dark and
 light crossovers are the same.
 
 ### Two locations
 
-| qty | 1 | 2 | 3 | 4 | 5 | 6 | 7 | DTF wins from |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| 50–500 | s | s | s | D | D | D | D | 4 colours |
+| qty | 1 | 2 | 3 | 4 | 5 | 6 | DTF wins from |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| 50–500 | s | s | s | D | D | D | 4 colours |
 | 1,000+ | s | s | D | D | D | D | D | 3 colours |
 
 Dark and light are identical here.
@@ -324,7 +348,8 @@ Dark and light are identical here.
 DTF now wins **earlier at volume** and **later on small runs** than it used to.
 
 - Screen print got cheaper per piece, which pushes the crossover *out* on short
-  runs — a 50-piece job now stays screen print all the way to 7 colours.
+  runs — a 50-piece light garment stays screen print across every column the
+  press can run.
 - But screens are billed once per order, and at high quantity that fixed cost is
   spread thin while the per-piece gap decides everything. Cutting the screen fee
   to $25 did not save screen printing at 1,000 pieces; the per-piece rate is what

--- a/server.js
+++ b/server.js
@@ -3611,6 +3611,25 @@ function quotePricingSource() {
         return (c + (dark ? 1 : 0)) * l;
       }
 
+      /* Screens the press runs in one pass, INCLUDING the white underbase.
+         Read from the method when it carries the value, so the ceiling has one
+         definition in the database like the minimum does; the fallback is the
+         press the shop actually has. */
+      function maxScreens(method) {
+        var m = method && method.max_screens ? parseInt(method.max_screens, 10) : 0;
+        return m > 0 ? m : 6;
+      }
+
+      /* Screens ONE LOCATION needs. The ceiling is per pass, not per order — a
+         two-sided 5-colour job is two passes of six screens, which is fine; a
+         one-sided 6-colour job on a dark garment is seven on one pass, which is
+         not. Multiplying by locations first would refuse work the press can do
+         and accept work it cannot. */
+      function screensPerPass(colours, dark) {
+        var c = parseInt(colours, 10); if (!(c > 0)) c = 1;
+        return c + (dark ? 1 : 0);
+      }
+
       /* One add-on's charge. The whole point of the table is that this
          switch exists exactly once. */
       function addonAmount(a, qty, colours, decorationSubtotal, screens) {
@@ -3701,6 +3720,16 @@ function quotePricingSource() {
            language, which is how the two drift. It is also why this function has
            no free variables: the parity test lifts this source and executes it
            alone, so anything it cannot see would break that guarantee. */
+        /* Over the press's screen ceiling this is not a screen-print job. Said
+           here, in the source both engines run, so the quote form and the
+           designer refuse the same designs — and said as a fact about the
+           press rather than a price, because there is no price for it. */
+        var overScreens = false, screenCeiling = 0;
+        if (o.method && /screen\s*print/i.test(String(o.method.title || ''))) {
+          screenCeiling = maxScreens(o.method);
+          overScreens = screensPerPass(colours, !!o.dark) > screenCeiling;
+        }
+
         var decoMin = (o.method && o.method.min_order_qty) ? (parseInt(o.method.min_order_qty, 10) || 0) : 0;
         var belowDecoMin = decoMin > 0 && qty > 0 && qty < decoMin;
         if (belowDecoMin && decoration > 0) {
@@ -3762,6 +3791,10 @@ function quotePricingSource() {
              "4 screens x $35" is checkable by the customer, "$140 setup" is
              not — without re-deriving it and drifting. */
           colours: colours, locations: locations, screens: screens,
+          /* Surfaced, not silently priced: a design past the press's screen
+             ceiling has no screen-print price, and a surface that shows a
+             number anyway is selling a job the shop cannot run. */
+          overScreens: overScreens, screenCeiling: screenCeiling,
           lineTotal: lineTotal, listTotal: listTotal
         };
       }
@@ -4898,10 +4931,21 @@ ${quotePricingSource()}
           var warn = L.querySelector('.minwarn');
           var tooFew = meth && /screen\\s*print/i.test(meth.title) && qty > 0 && qty < ${SCREEN_MIN_QTY};
           if (warn) {
-            warn.style.display = tooFew ? 'block' : 'none';
-            warn.textContent = tooFew
-              ? 'Screen printing starts at ${SCREEN_MIN_QTY} pieces. For ' + qty +
-                ', quote DTF or heat-transfer vinyl instead.' : '';
+            /* Two different refusals, one line. Too many colours outranks too
+               few pieces: adding pieces fixes the second, nothing fixes the
+               first except changing method. */
+            if (r.overScreens) {
+              warn.style.display = 'block';
+              warn.textContent = 'The press runs ' + r.screenCeiling + ' screens including the white ' +
+                'underbase, so this is ' + r.screens / (r.locations || 1) + ' per pass — ' +
+                (dark ? r.screenCeiling - 1 : r.screenCeiling) + ' colours is the most on a ' +
+                (dark ? 'dark' : 'light') + ' garment. Quote DTF instead.';
+            } else {
+              warn.style.display = tooFew ? 'block' : 'none';
+              warn.textContent = tooFew
+                ? 'Screen printing starts at ${SCREEN_MIN_QTY} pieces. For ' + qty +
+                  ', quote DTF or heat-transfer vinyl instead.' : '';
+            }
           }
 
           /* Name the location in the line itself. A front+back line otherwise reads

--- a/tests/screen-fees.test.js
+++ b/tests/screen-fees.test.js
@@ -219,10 +219,14 @@ test('the reprice tool prices print only — screens are not folded back in', ()
   const AGREED = {
     1: [3.85, 3.45, 3.05, 2.70, 2.40, 2.00],
     3: [5.80, 5.30, 4.75, 4.35, 3.90, 3.50],
-    7: [9.80, 9.25, 8.60, 8.15, 7.70, 7.30],
+    /* SIX is the top, not seven. The press runs six screens including the white
+       underbase, so the 7-colour row this table used to assert was pricing a job
+       the shop cannot produce — and its numbers were a +$0.47 extrapolation of
+       the sixth rather than anything quoted. */
+    6: [8.80, 8.25, 7.65, 7.20, 6.75, 6.35],
   };
   const FLOORS = [50, 100, 250, 500, 1000, 2500];
-  for (const c of [1, 3, 7]) {
+  for (const c of [1, 3, 6]) {
     FLOORS.forEach((f, i) => {
       assert.strictEqual(sandbox.spPrice(f, c), AGREED[c][i],
         `${c} colour at the ${f} band should be print-only $${AGREED[c][i].toFixed(2)}`);

--- a/tests/screenprint-minimum.test.js
+++ b/tests/screenprint-minimum.test.js
@@ -122,6 +122,40 @@ test('the reprice tool passes the contracted floor', () => {
   const path = require('node:path');
   const tool = fs.readFileSync(path.join(__dirname, '..', 'tools', 'reprice-anchorfish-2026.js'), 'utf8');
   assert.match(tool, /const SCREEN_MIN_QTY = 50;/);
-  assert.match(tool, /colorTable\(all, SCREEN_MIN_QTY\)/,
-    'the generator must be told the minimum, or it emits a method without one');
+  assert.match(tool, /colorTable\(all, SCREEN_MIN_QTY, SCREEN_MAX\)/,
+    'the generator must be told the minimum AND the screen ceiling, or it emits ' +
+    'a method that sells colour counts the press cannot run');
+  assert.match(tool, /const SCREEN_MAX = 6;/,
+    'six screens including the white underbase');
+});
+
+/* ── Six screens, and the base is one of them ────────────────────────────── */
+
+test('the generator refuses a colour count the press cannot run', () => {
+  /* A price that exists is a price somebody will be quoted. The 7-colour column
+     was a +$0.47 extrapolation of the sixth — invented, published, and sold. */
+  const { colorTable } = require('../tools/lib/screenprint');
+  const rows = (n) => Array.from({ length: n }, (_, i) =>
+    ({ colors: i + 1, tiers: [[99, 3.85 + i], [249, 3.45 + i]] }));
+  assert.throws(() => colorTable(rows(7), 50, 6), /7 colours cannot be printed/);
+  assert.doesNotThrow(() => colorTable(rows(6), 50, 6));
+});
+
+test('full-color is priced at the highest PRODUCIBLE column', () => {
+  /* It is the backstop against a $0 decoration, not an offer. Pricing it above
+     the top column would quote a colour count that cannot be run. */
+  const { colorTable } = require('../tools/lib/screenprint');
+  const t = colorTable(Array.from({ length: 6 }, (_, i) =>
+    ({ colors: i + 1, tiers: [[99, 3.85 + i]] })), 50, 6);
+  const band = Object.values(t.values.front)[0];
+  assert.strictEqual(band['full-color'], band['6-color']);
+  assert.ok(!('7-color' in band), 'no column past the ceiling');
+});
+
+test('the ceiling travels in the method, like the minimum', () => {
+  /* One definition in the database, read by every surface — a constant restated
+     per engine is how the two drift. */
+  const { colorTable } = require('../tools/lib/screenprint');
+  const t = colorTable([{ colors: 1, tiers: [[99, 3.85]] }], 50, 6);
+  assert.strictEqual(t.max_screens, '6');
 });

--- a/tools/lib/screenprint.js
+++ b/tools/lib/screenprint.js
@@ -23,6 +23,13 @@
  * `full-color` MUST exist. Without it a design with more colours than any
  * column silently prices the decoration at $0 in both engines — screen printing
  * for free rather than an error anyone would see.
+ *
+ * It is priced at the HIGHEST PRODUCIBLE column, never at an invented one. The
+ * press runs six screens including the white underbase, so a design past that
+ * is not a cheaper screen-print job, it is a DTF job — and the honest thing for
+ * this backstop to do is charge the most screen printing can cost rather than
+ * quote a colour count the shop cannot run. The editor steers those designs to
+ * DTF; this only stops the fall-through from being free.
  */
 
 /** Column key for a colour count, matching what the admin UI writes (main.js:3323). */
@@ -33,8 +40,20 @@ const colorKey = (n) => n + '-color';
  *        One entry per colour count. `tiers` is [band ceiling, price per piece].
  * @returns {{multi:boolean,type:string,show_detail:string,values:object}}
  */
-function colorTable(rows, minQty) {
+function colorTable(rows, minQty, maxScreens) {
   if (!rows || rows.length === 0) throw new Error('no per-colour tables to combine');
+
+  /* Refuse a colour count the press cannot run, rather than publishing a column
+     for it. A price that exists is a price somebody will be quoted. */
+  const cap = parseInt(maxScreens, 10);
+  if (Number.isFinite(cap) && cap > 0) {
+    const over = rows.filter((r) => r.colors > cap);
+    if (over.length) {
+      throw new Error('the press runs ' + cap + ' screens, so ' +
+        over.map((r) => r.colors).join(' and ') + ' colours cannot be printed — ' +
+        'remove those rows rather than pricing them');
+    }
+  }
 
   const sorted = [...rows].sort((a, b) => a.colors - b.colors);
   const bands = sorted[0].tiers.map(([q]) => String(q));
@@ -104,6 +123,9 @@ function colorTable(rows, minQty) {
   const out = { multi: false, type: 'color', show_detail: '1', values: { front } };
   const m = parseInt(minQty, 10);
   if (Number.isFinite(m) && m > 0) out.min_qty = String(m);
+  /* Carried so every surface reads the ceiling from the method rather than
+     restating it — the same reason min_qty lives here. */
+  if (Number.isFinite(cap) && cap > 0) out.max_screens = String(cap);
   return out;
 }
 

--- a/tools/reprice-anchorfish-2026.js
+++ b/tools/reprice-anchorfish-2026.js
@@ -96,13 +96,22 @@ function backup(url, tag) {
    An earlier draft of this file folded (SCREEN_COST * colours) / band_floor
    into the base before applying the markup. That was written before screens
    became a separate fee; leaving it in would bill every screen twice. */
+/* SIX SCREENS, and the white underbase is one of them.
+ *
+ * The press runs six stations. On a light garment that is six printed colours;
+ * on a dark one it is five, because the base occupies a station. There is no
+ * seventh column — the 7-colour prices this table used to carry were a straight
+ * +$0.47 extrapolation of the sixth, which is to say invented, and they were
+ * being sold. A quote at that price is a job the shop cannot produce.
+ *
+ * SCREEN_MAX below is the real constraint; these rows stop at six to match it. */
 const SP = {
-   50: { ceil:  99, mk: 2.13, p: [1.80, 2.25, 2.72, 3.19, 3.66, 4.13, 4.60] },
-  100: { ceil: 249, mk: 2.09, p: [1.65, 2.06, 2.53, 3.00, 3.47, 3.94, 4.41] },
-  250: { ceil: 499, mk: 2.05, p: [1.47, 1.84, 2.31, 2.78, 3.25, 3.72, 4.19] },
-  500: { ceil: 999, mk: 2.03, p: [1.32, 1.65, 2.12, 2.59, 3.06, 3.53, 4.00] },
- 1000: { ceil:2499, mk: 2.02, p: [1.17, 1.46, 1.93, 2.40, 2.87, 3.34, 3.81] },
- 2500: { ceil:7000, mk: 2.02, p: [0.99, 1.24, 1.71, 2.18, 2.65, 3.12, 3.59] },
+   50: { ceil:  99, mk: 2.13, p: [1.80, 2.25, 2.72, 3.19, 3.66, 4.13] },
+  100: { ceil: 249, mk: 2.09, p: [1.65, 2.06, 2.53, 3.00, 3.47, 3.94] },
+  250: { ceil: 499, mk: 2.05, p: [1.47, 1.84, 2.31, 2.78, 3.25, 3.72] },
+  500: { ceil: 999, mk: 2.03, p: [1.32, 1.65, 2.12, 2.59, 3.06, 3.53] },
+ 1000: { ceil:2499, mk: 2.02, p: [1.17, 1.46, 1.93, 2.40, 2.87, 3.34] },
+ 2500: { ceil:7000, mk: 2.02, p: [0.99, 1.24, 1.71, 2.18, 2.65, 3.12] },
 };
 /* Anchorfish's actual per-SCREEN charge, confirmed on invoice #16899: 4 screens
    at $20 for a 2-colour job across 2 locations. Screens are therefore
@@ -118,11 +127,16 @@ const SP = {
 /* The contracted floor. Under this the job goes to DTF or HTV, both of which
    the designer already prices. */
 const SCREEN_MIN_QTY = 50;
+/* Screens the press can run in one pass, INCLUDING the white underbase. A dark
+   garment therefore tops out at five printed colours, a light one at six. Over
+   that the job is not a screen-print job at all and belongs on DTF. */
+const SCREEN_MAX = 6;
 const SCREEN_COST = 20;   // what Anchorfish charges us, per screen
 const SCREEN_FEE  = 25;   // what we bill, per screen, ONCE per order (was 35 to 2026-08-30)
 
-/* Anchorfish prices 5, 6 and 7 colours separately; the designer had one
-   combined "5-6 Colors" method, which had to quote one of them wrong. */
+/* The vendor prices 5 and 6 colours separately; the designer had one combined
+   "5-6 Colors" method, which had to quote one of them wrong. Nothing above six
+   is offered — see SCREEN_MAX. */
 const SP_METHODS = {
   2: { colors: 1, title: 'Screen Printing — 1 Color' },
   3: { colors: 2, title: 'Screen Printing — 2 Colors' },
@@ -132,7 +146,6 @@ const SP_METHODS = {
 };
 const SP_INSERTS = [
   { colors: 6, title: 'Screen Printing — 6 Colors' },
-  { colors: 7, title: 'Screen Printing — 7 Colors' },
 ];
 
 /* ── DTF (contracted to Anchorfish) ─────────────────────────────────────── */
@@ -482,7 +495,7 @@ for (const m of SP_INSERTS) {
   /* SCREEN_MIN_QTY, written into the method so the storefront enforces it.
      Without it core/cart.php reads 0 and lets a 12-piece screen job through at
      the 50-99 rate — below the minimum the shop has with its own printer. */
-  const combined = enjson(colorTable(all, SCREEN_MIN_QTY));
+  const combined = enjson(colorTable(all, SCREEN_MIN_QTY, SCREEN_MAX));
   console.log('\n  The same prices are also written to the combined "Screen Printing" method,');
   console.log('  as columns 1-color..7-color plus a full-color backstop, so the editor can');
   console.log('  price from the design\'s own colour count.');


### PR DESCRIPTION
## You are right, and it was being sold

The live combined method offers **`1-color` through `7-color`**. The press runs
six screens *including the white underbase*, so:

| garment | most printed colours |
| --- | --- |
| light | **6** |
| dark | **5** — the base takes a station |

**The 7-colour prices were invented.** Every step in that cost row is +$0.47 — a
straight linear extrapolation of the sixth column, not anything quoted. A
customer picking 7 colours got a real price for a job the shop cannot produce.

## What changed

- **The cost sheet stops at six.** The seventh value is gone from all six
  quantity bands, and the `Screen Printing — 7 Colors` method is no longer
  generated. (The standalone method id 21 was already inactive and offered by no
  product — the exposure was the combined method's column.)
- **The generator refuses** any row past the ceiling rather than pricing it: a
  price that exists is a price somebody will be quoted.
- **`full-color` is priced at the highest producible column.** It is the backstop
  against a $0 decoration, not an offer — pricing it above the top column quotes
  a colour count that cannot be run.
- **`max_screens` travels in the method row**, like `min_qty`, so every surface
  reads one definition instead of restating a constant.

## The dark-garment half

A dark 6-colour job is **seven screens** and equally unproducible. That is now
checked in `quotePricingSource()` — the source both the browser and the save path
run — so the quote form and the designer refuse the same designs.

The ceiling is **per pass, not per order**: a two-sided 5-colour job is two passes
of six and is fine; a one-sided 6-colour dark job is seven on one pass and is
not. Multiplying by locations first would refuse work the press can do and accept
work it cannot.

The quote form now says so plainly — *"the press runs 6 screens including the
white underbase … 5 colours is the most on a dark garment. Quote DTF instead."*
That warning outranks the too-few-pieces one: adding pieces fixes the second,
nothing fixes the first except changing method.

## Doc corrected

The crossover table I generated an hour ago had a 7-colour column. Rebuilt to
1–6, with the dark-garment note. The worst-case margin row also used a 7-colour
job; it is now **50pc / 5 colours / 2 locations / dark — 12 screens, 43.9%**,
which is the real worst case and lower than the figure it replaces.

## Still to apply

The generator is fixed; **the live method still carries the `7-color` column**
until the documented reprice command is run against the database.

## Tests

480/480, 3 new — the generator throws on an over-ceiling row, `full-color` equals
the top producible column, and `max_screens` is carried in the method.