### PR TITLE
Pin that raster art cannot be screen printed

### DIFF
--- a/tests/screenprint-minimum.test.js
+++ b/tests/screenprint-minimum.test.js
@@ -206,3 +206,41 @@ test('an unknown garment colour does not refuse the job', () => {
      toward dark would refuse a light-garment order on a guess. */
   assert.match(cartPhp, /if \(!preg_match\('\/\^#\?\(\[0-9a-f\]\{6\}\)\$\/i', trim\(\$hex\), \$m\)\) return false;/);
 });
+
+/* ── A photograph is not a screen-print job ──────────────────────────────── */
+
+test('raster art is checked on its own, not folded into the colour count', () => {
+  /* `states_data[stage].colors` is built in app.js from o.colors, o.stroke and
+     o.fill — vector and text only. A raster image has none of the three and
+     contributes ZERO colours, so a `$colors > 0` guard skipped a photo-only
+     design entirely.
+     What that produced, verified against the real pricing logic:
+       photo only            -> no rule matched, decoration priced at $0.00
+       photo + one text word -> counted as ONE colour, sold at $3.85/pc
+     A full-colour photograph at single-colour rates, or free. */
+  assert.match(cartPhp, /\$raster = \$this->printing_has_raster\( \$item \);/);
+  assert.match(cartPhp, /if \(\$raster \|\| \(\$colors > 0 &&/,
+    'raster must short-circuit BEFORE the colour count, which reads zero for it');
+});
+
+test('any stage carrying an image is enough', () => {
+  /* A vector front with a photographed back is still a photograph. */
+  assert.match(cartPhp, /isset\(\$o\['images'\]\) && intval\(\$o\['images'\]\) > 0\) return true;/);
+});
+
+test('the note names the real reason', () => {
+  /* "7 colours" would be wrong and confusing on a design whose countable colour
+     total is zero. */
+  assert.match(cartPhp, /uses a photo or uploaded image, which has more colours than/);
+  assert.match(cartPhp, /which prints any number of colours/);
+});
+
+test('erring toward DTF is deliberate and recorded', () => {
+  /* A one-colour logo uploaded as a PNG goes to DTF too. That direction is
+     safe — DTF prints it correctly and the shop can offer screen printing by
+     hand once it has seen the art. The opposite error makes a job the press
+     cannot produce. */
+  /* Whitespace-tolerant: the comment wraps, and a test that breaks on
+     reformatting teaches people to stop trusting the suite. */
+  assert.match(cartPhp, /shop can offer screen printing by hand once it has seen the art/);
+});


### PR DESCRIPTION
Tests for the designer fix already deployed (`f7ac866`). **You were right, and it
was worse than the question.**

## What was happening

`states_data[stage].colors` is built in `app.js` from `o.colors`, `o.stroke` and
`o.fill` — **vector and text only**. A raster image has none of the three, so it
contributes **zero** colours. Run against the real pricing logic:

| design | colors[] | screen-print price |
| --- | --- | --- |
| text, 2 colours | 2 | $4.80 ✓ |
| **uploaded photo only** | 0 | **$0.00** |
| **photo + 1 text colour** | 1 | **$3.85** |
| photo + 3 text colours | 3 | $5.80 |

A photo-only design priced the decoration at **nothing** — no rule matched, so no
price was added. A photo with one word of text sold a **full-colour photograph at
the single-colour rate**.

My colour ceiling did not catch it either: the check was `$colors > 0 && …`, and
a photo reads as zero, so it skipped the design entirely.

## The fix

Raster art is checked **on its own**, before the colour count, because there is
no colour count to check. A bitmap's palette cannot be known without reading the
pixels, and would be in the thousands regardless — so it is simply not a
screen-print job and goes to DTF.

Any stage carrying an image is enough: a vector front with a photographed back is
still a photograph.

The note names the real reason rather than a colour number that would read as
nonsense on a design counting zero:

> This design uses a photo or uploaded image, which has more colours than Screen
> Printing can separate, so this line is priced as DTF Printing — which prints
> any number of colours. Your design is unchanged.

## The trade I made deliberately

A **one-colour logo uploaded as a PNG** goes to DTF too. That direction is the
safe one: DTF prints it correctly, and you can offer screen printing by hand once
you have seen the art. The opposite error produces a job the press cannot make —
or gives it away free. Recorded in the code so it is not "fixed" later by
accident.

Verified across nine cases: photo-only → DTF, photo + text → DTF, 6-colour vector
on white → screen print, 6-colour vector on black → DTF, vector front + photo
back → DTF, empty design → no decision.

489/489.