### PR TITLE
Rush turnaround, built on the Anchorfish contract sheets

### DIFF
--- a/docs/pricing-2026.md
+++ b/docs/pricing-2026.md
@@ -363,3 +363,80 @@ rule `screenCount()` uses in `server.js`.
 
 **Regenerate this table** whenever either price table moves — it is derived from
 both, so a reprice invalidates it silently.
+
+---
+
+## Rush turnaround — added 2026-09-01
+
+### The contract facts this is built on
+
+Read from the five Anchorfish sheets (screen print 2026, DTF 2026, embroidery,
+and the two standards documents):
+
+| Sheet | Standard turnaround | Rush offered? |
+|---|---|---|
+| Screen Printing 2026 | 7–10 business days, up to 2,400 prints | **No** |
+| DTF 2026 | 7–10 business days, up to 2,400 prints | **No** |
+| Embroidery | 7–15 business days, up to 1,000 logos | Yes — see ladder |
+
+Both print sheets add: *3:30pm CST business day cut-off*, *production time may
+vary depending on season*, *over 7,000 pieces by quote*. Turnaround is stated
+**from receipt of all goods and art approvals** — not from the order date.
+
+The embroidery sheet is the only one with rush, and it says why in its own
+heading: **"RUSH SERVICES AVAILABLE UPON APPROVAL — applies to embroidery
+only."** Its ladder:
+
+| Tier | Surcharge |
+|---|---|
+| Same day | 75% |
+| 1 day | 50% |
+| 2 day | 40% |
+| 3 day | 30% |
+| 4 day | 20% |
+
+### What the shop sells, and why it differs
+
+**Screen print and DTF cannot be rushed at any price.** They are contracted out
+and the contractor sells no rush product. This is enforced, not documented:
+`rushAvailable()` requires every decorated line to be embroidery, and the fee
+and the promised date are gated by that one call, so neither can be shown
+without the other.
+
+**Embroidery can, because it is sewn in house** — the shop owns the machine
+time. The percentages above are used as the ladder. Note what they are and are
+not: embroidery is **not** contracted to Anchorfish, so this is the market
+*shape*, not a cost the shop pays. Tune per tier with `JT_RUSH_PCT`
+(e.g. `rush2=45,rush0=90`) without editing code.
+
+The surcharge is a **percentage of the decoration subtotal**, never of the line
+total — a percentage of the line would bill a rush premium on the customer's
+own garments, which no amount of machine time makes arrive sooner.
+
+### What rush does not buy
+
+`prodDays` is machine time **after goods and artwork are in hand**, the same
+basis Anchorfish states its own on. `deliveryEstimate()` still adds
+`JT_LT_BLANKS` (default 5 business days) unless the job's `blanks_in_at`
+milestone is set, so "same day" on a job whose blanks have not arrived shows a
+date about a week out and says why. Quoting a rush from the order date is the
+single easiest way to miss a deadline the shop was paid extra to hit.
+
+Holiday mode doubles the **fee** and stretches **standard** production by
+`HOLIDAY_EXTRA_DAYS`, but never stretches a rush tier that was sold — taking
+40% for two days and then quietly making it five is charging for a date already
+decided against. In season, stop offering the tier instead.
+
+### Env knobs
+
+| Var | Default | What it does |
+|---|---|---|
+| `JT_RUSH_PCT` | — | per-tier surcharge overrides, `code=pct` comma separated |
+| `JT_CUTOFF` | `15:30` | business-day cut-off, shop local time |
+| `JT_TZ` | `America/Chicago` | the timezone that cut-off is read in |
+| `JT_LT_BLANKS` | `5` | supplier lead time for blanks, business days |
+| `JT_PROD_MIN` / `JT_PROD_MAX` | `7` / `10` | standard production window |
+| `JT_SHEET_CEILING` | `2400` | above this, dates are flagged as an estimate |
+
+Pinned by `tests/rush-turnaround.test.js` (25 tests), which lifts the real
+functions out of `server.js` rather than restating them.

--- a/docs/pricing-2026.md
+++ b/docs/pricing-2026.md
@@ -416,11 +416,32 @@ own garments, which no amount of machine time makes arrive sooner.
 ### What rush does not buy
 
 `prodDays` is machine time **after goods and artwork are in hand**, the same
-basis Anchorfish states its own on. `deliveryEstimate()` still adds
-`JT_LT_BLANKS` (default 5 business days) unless the job's `blanks_in_at`
-milestone is set, so "same day" on a job whose blanks have not arrived shows a
-date about a week out and says why. Quoting a rush from the order date is the
-single easiest way to miss a deadline the shop was paid extra to hit.
+basis Anchorfish states its own on. So a rush tier adds `JT_LT_BLANKS`
+(default 5 business days) unless the job's `blanks_in_at` milestone is set:
+"same day" on a job whose blanks have not arrived shows a date about a week out
+and says why. Quoting a rush from the order date is the single easiest way to
+miss a deadline the shop was paid extra to hit.
+
+**The standard window does NOT add it, and that asymmetry is deliberate.** The
+7–10 business days the site advertises is a door-to-door figure from the order
+date that has always absorbed the wait for blanks; adding the supplier lead
+time on top would move every existing quote a week later and quietly rewrite a
+promise the shop has made for years. The two numbers are measured from
+different places, which is the whole reason a rush tier has to say so.
+
+### A rush that is not sooner is refused
+
+With a 5-day blanks wait, a 4-day machine slot lands on day 9 while standard
+lands on day 7 — so the 20% tier would buy a *later* delivery. `rushImprovesDate()`
+compares the two dates and the short tiers are disabled, labelled "not sooner
+than standard on this job", in the form and refused at save. Once the garments
+are in hand every tier beats standard, which is why same-day is genuinely
+sellable on a reorder and not on a fresh job.
+
+**Which tiers are sellable therefore depends entirely on `JT_LT_BLANKS`.** At
+the default 5 only the 1-, 2- and 3-day tiers survive on a fresh job. If the
+real S&S lead time to Chicago is 2 days, set it — every tier down to 4-day
+becomes sellable and the dates get a week tighter.
 
 Holiday mode doubles the **fee** and stretches **standard** production by
 `HOLIDAY_EXTRA_DAYS`, but never stretches a rush tier that was sold — taking

--- a/server.js
+++ b/server.js
@@ -124,6 +124,12 @@ async function initDB() {
   // Added after the first release; ALTERs are idempotent so this is safe to re-run.
   for (const col of [
     'needed_by DATE',                 // when the customer needs it
+    /* Which rush tier was sold, not the dollars it came to. The fee is a
+       percentage of the decoration, so storing the amount would freeze
+       yesterday's figure against today's lines — the same reason
+       discount_value stores what was ENTERED. quoteTotals() derives it, and
+       re-derives it as ineligible if the lines stop being embroidery. */
+    'rush_code TEXT',
     'tax NUMERIC(10,2) DEFAULT 0',
     'total NUMERIC(10,2) DEFAULT 0',  // subtotal + tax (card fee is added at payment)
     'deposit NUMERIC(10,2) DEFAULT 0',
@@ -3270,16 +3276,103 @@ function addBusinessDays(from, days) {
   return d;
 }
 
-/** Estimated ready/delivery window, same env knobs the designer uses. */
-function deliveryEstimate(from = new Date()) {
+/* The shop's clock, not the server's.
+   Railway runs UTC. A quote saved at 21:00 UTC is 15:00 in Chicago — still
+   inside the printer's 3:30pm CST cut-off — but read as a UTC hour it looks
+   like the evening and the whole job would be quoted a day late. Every
+   cut-off decision below asks America/Chicago what time it is there. */
+const SHOP_TZ = process.env.JT_TZ || 'America/Chicago';
+
+/** Minutes past midnight, in the shop's timezone. */
+function shopMinutes(at) {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone: SHOP_TZ, hour12: false, hour: '2-digit', minute: '2-digit',
+  }).formatToParts(at);
+  const get = (t) => Number((parts.find((x) => x.type === t) || {}).value || 0);
+  /* hourCycle h23 still renders midnight as 24 in some ICU builds. */
+  return (get('hour') % 24) * 60 + get('minute');
+}
+
+/** The day the clock actually starts.
+ *
+ *  Anchorfish states a 3:30pm CST business-day cut-off: work handed over after
+ *  it is received the next business day, so day one has not begun. A weekend
+ *  is the same problem — nothing is produced on it. Counting from `from`
+ *  regardless is how an order taken at 5pm Friday gets quoted as though it
+ *  started Friday morning, three calendar days early. */
+const CUTOFF_MIN = (() => {
+  const m = /^(\d{1,2}):(\d{2})$/.exec(String(process.env.JT_CUTOFF || '15:30'));
+  return m ? Number(m[1]) * 60 + Number(m[2]) : 15 * 60 + 30;
+})();
+
+function productionStart(from) {
+  const d = new Date(from);
+  const dow = d.getDay();
+  if (dow === 0 || dow === 6 || shopMinutes(d) >= CUTOFF_MIN) return addBusinessDays(d, 1);
+  return d;
+}
+
+/* Anchorfish quotes 7–10 business days on up to 2,400 prints and says over
+   7,000 pieces is by quote; their embroidery sheet states its turnaround for
+   up to 1,000 logos. Past those the sheet promises nothing, so neither can a
+   date computed from it — `beyond_sheet` says so rather than inventing one. */
+const SHEET_PIECE_CEILING = parseInt(process.env.JT_SHEET_CEILING || '2400', 10);
+
+/** Estimated ready/delivery window, same env knobs the designer uses.
+ *
+ *  `opts.rushCode`  the tier chosen; ignored unless the job is rush-eligible,
+ *                   so the date and the fee are gated by ONE decision.
+ *  `opts.items`     the quote lines, for that eligibility check and the count.
+ *  `opts.blanksIn`  true when the garments are already in hand (customer
+ *                   supplied, or stock). Otherwise the supplier's lead time is
+ *                   added, because rush buys machine time and nothing else —
+ *                   a same-day embroidery slot cannot sew shirts that have not
+ *                   arrived. Quoting rush from the ORDER date rather than from
+ *                   goods-in is the single easiest way to miss a deadline the
+ *                   shop was paid extra to hit.
+ *  `opts.pickup`    collected from the shop, so no transit. */
+function deliveryEstimate(from = new Date(), opts = {}) {
   const pmin = parseInt(process.env.JT_PROD_MIN || '7', 10);
   const pmax = parseInt(process.env.JT_PROD_MAX || '10', 10);
-  const smin = parseInt(process.env.JT_SHIP_MIN || '2', 10);
-  const smax = parseInt(process.env.JT_SHIP_MAX || '5', 10);
+  const smin = opts.pickup ? 0 : parseInt(process.env.JT_SHIP_MIN || '2', 10);
+  const smax = opts.pickup ? 0 : parseInt(process.env.JT_SHIP_MAX || '5', 10);
+  const blanks = opts.blanksIn ? 0 : parseInt(process.env.JT_LT_BLANKS || '5', 10);
+
+  const holiday = opts.holiday != null ? opts.holiday : HOLIDAY_MODE;
+  /* `assumeEligible` is for showing what a tier WOULD give — the quote form
+     prices every tier up front so the browser never has to re-implement
+     business-day arithmetic and drift from this function. It says nothing
+     about whether the tier may be sold; that is rushAvailable()'s decision and
+     the fee still asks it separately. */
+  const rush = (opts.assumeEligible || rushAvailable(opts.items))
+    ? rushOption(opts.rushCode) : RUSH_OPTIONS[0];
+  const rushed = rush.prodDays != null;
+
+  /* Holiday mode stretches production, never the rush tier it sold: a job
+     bought as "2 business days" is still 2 business days of machine time, and
+     silently making it 5 would be charging 40% for a date the shop has already
+     decided not to hit. In season the honest move is to stop offering the tier,
+     which is what capacity means — not to take the money and slip the date. */
+  const extra = holiday ? HOLIDAY_EXTRA_DAYS : 0;
+  const prodMin = rushed ? rush.prodDays : pmin + extra;
+  const prodMax = rushed ? rush.prodDays : pmax + extra;
+
+  const start = productionStart(from);
+  const pieces = (Array.isArray(opts.items) ? opts.items : [])
+    .reduce((a, i) => a + (Number(i.qty) || 0), 0);
+
   return {
-    ready: addBusinessDays(from, pmin),
-    deliver_from: addBusinessDays(from, pmin + smin),
-    deliver_to: addBusinessDays(from, pmax + smax),
+    ready: addBusinessDays(start, blanks + prodMin),
+    deliver_from: addBusinessDays(start, blanks + prodMin + smin),
+    deliver_to: addBusinessDays(start, blanks + prodMax + smax),
+    /* What the figures above are actually made of, so a surface can explain a
+       date instead of asserting one. */
+    blanks_days: blanks,
+    production_days: rushed ? rush.prodDays : [prodMin, prodMax],
+    rush_code: rushed ? rush.code : '',
+    /* Over the contract sheet's stated ceiling this is an extrapolation, and
+       the surfaces say so rather than quoting it as a commitment. */
+    beyond_sheet: pieces > SHEET_PIECE_CEILING,
   };
 }
 
@@ -3445,17 +3538,98 @@ const ADDONS = [
     kind: 'percent_of_decoration', rate: 50 },
 ];
 
-/* Rush is per JOB, not per line — the shop is buying back calendar time once,
-   however many lines the quote has. Deliberately no 1-day or same-day option:
-   the shop does not offer it, and an option that has to be refused is worse
-   than no option. Holiday mode doubles the fee, because in season that time is
-   genuinely scarcer. */
+/* ── Rush ─────────────────────────────────────────────────────────────────
+ *
+ * Rush is per JOB, not per line — the shop is buying back calendar time once,
+ * however many lines the quote has.
+ *
+ * WHO DOES THE WORK decides whether rush can be sold at all, and this is the
+ * whole reason the gate below exists:
+ *
+ *   Screen print and DTF are CONTRACTED to Anchorfish. Both their 2026 sheets
+ *   state 7–10 business days and NEITHER offers a rush service at any price.
+ *   So the shop cannot shorten that job by paying more — there is no product
+ *   to buy. Quoting "ready in 2 days" on a screen-print job is a promise with
+ *   nothing behind it, and the previous version of this list sold exactly that
+ *   for $15.
+ *
+ *   Embroidery is sewn IN HOUSE, so the shop owns the machine time and can
+ *   genuinely bump a job up the queue. That is the only work rush applies to,
+ *   which is also what Anchorfish's own embroidery sheet says of theirs:
+ *   "RUSH SERVICES AVAILABLE UPON APPROVAL — applies to embroidery only".
+ *
+ * THE LADDER is a PERCENTAGE of the decoration, not a flat fee. Anchorfish's
+ * embroidery sheet prices rush at same-day 75%, 1-day 50%, 2-day 40%, 3-day
+ * 30%, 4-day 20%, and that shape is right for the same reason theirs is:
+ * jumping a 500-piece job costs far more machine time than jumping a 12-piece
+ * one, so a flat $15 gave away the whole of a big job's rush for nothing.
+ *
+ * Their sheet is the SHAPE, not the cost — embroidery is in house, so these
+ * are what the shop CHARGES, not what it pays. Tunable per tier with
+ * JT_RUSH_PCT (e.g. "rush2=45,rush0=90") without editing code.
+ *
+ * `prodDays` is production time AFTER goods and artwork are in hand — the same
+ * basis Anchorfish states its own on ("from receipt of all goods and art
+ * approvals"). It is not a promise to deliver in that many days from the order,
+ * because blanks still have to arrive; deliveryEstimate() adds that. */
+const RUSH_PCT_OVERRIDES = (() => {
+  const out = {};
+  for (const pair of String(process.env.JT_RUSH_PCT || '').split(',')) {
+    const [k, v] = pair.split('=').map((x) => String(x || '').trim());
+    const n = Number(v);
+    if (k && Number.isFinite(n) && n >= 0) out[k] = n;
+  }
+  return out;
+})();
+const rushPct = (code, dflt) =>
+  RUSH_PCT_OVERRIDES[code] != null ? RUSH_PCT_OVERRIDES[code] : dflt;
+
 const RUSH_OPTIONS = [
-  { code: '', label: 'Standard turnaround', days: 0, fee: 0 },
-  { code: 'rush3', label: 'Rush — 3 business days', days: 3, fee: 10 },
-  { code: 'rush2', label: 'Rush — 2 business days', days: 2, fee: 15 },
+  { code: '',      label: 'Standard turnaround',        prodDays: null, pct: 0 },
+  { code: 'rush4', label: 'Rush — 4 business days',     prodDays: 4, pct: rushPct('rush4', 20) },
+  { code: 'rush3', label: 'Rush — 3 business days',     prodDays: 3, pct: rushPct('rush3', 30) },
+  { code: 'rush2', label: 'Rush — 2 business days',     prodDays: 2, pct: rushPct('rush2', 40) },
+  { code: 'rush1', label: 'Rush — next business day',   prodDays: 1, pct: rushPct('rush1', 50) },
+  { code: 'rush0', label: 'Rush — same day',            prodDays: 0, pct: rushPct('rush0', 75) },
 ];
 const RUSH_CAVEAT = 'Rush is subject to availability and is confirmed before you pay — never guaranteed at quote time.';
+/* Said on the quote form, where the temptation to promise one lives. */
+const RUSH_UNAVAILABLE_NOTE =
+  'Rush applies to in-house embroidery only. Screen printing and DTF are contract-printed on a ' +
+  '7–10 business day schedule with no rush service, so a shorter date cannot be sold — if the ' +
+  'customer needs one, ask the printer first and quote what they confirm.';
+
+/** The rush tier for a code, or the standard (no-op) tier. */
+function rushOption(code) {
+  return RUSH_OPTIONS.find((x) => x.code === String(code || '')) || RUSH_OPTIONS[0];
+}
+
+/* Can this job be rushed at all?
+   EVERY decorated line must be embroidery. One screen-print line on the quote
+   puts the whole job on the contract printer's 7–10 day schedule, and the
+   customer receives ONE parcel — so the slowest line sets the date and there is
+   no calendar left to sell.
+
+   Fails CLOSED. A line whose method is unknown (typed by hand, or saved before
+   `method_title` was stored) is not evidence of embroidery, and guessing here
+   would sell the promise this function exists to prevent. */
+function rushAvailable(items) {
+  const list = Array.isArray(items) ? items : [];
+  const decorated = list.filter((i) => Number(i.qty) > 0 &&
+    !COST_SERVICE_WORDS.test(String(i.description || '')));
+  if (!decorated.length) return false;
+  return decorated.every((i) => EMBROIDERY_METHOD_RE.test(String(i.method_title || '')));
+}
+
+/** The decoration the rush percentage is charged on.
+ *
+ *  Decoration only, never the blanks: rush buys machine time, and no surcharge
+ *  makes a garment arrive from the supplier sooner. Charging it on the line
+ *  total would bill the customer 40% of their own shirts. */
+function decorationSubtotal(items) {
+  return round2((Array.isArray(items) ? items : [])
+    .reduce((a, i) => a + Number(i.decoration_total || 0), 0));
+}
 
 /* Holiday mode: rush costs double and everything takes 3 days longer. One
    switch rather than four settings, so the busy season cannot be half on. It
@@ -3479,11 +3653,20 @@ function addonsFor(methodTitle) {
   return t ? ADDONS.filter((a) => a.appliesTo.test(t)) : [];
 }
 
-/** The rush fee actually charged, holiday doubling applied. */
-function rushFeeFor(code, holiday = HOLIDAY_MODE) {
-  const r = RUSH_OPTIONS.find((x) => x.code === String(code || ''));
-  if (!r || !r.fee) return 0;
-  return round2(r.fee * (holiday ? 2 : 1));
+/** The rush fee actually charged: a percentage of the decoration, holiday
+ *  doubling applied.
+ *
+ *  Returns 0 for a job that cannot be rushed, so an ineligible `rush_code` —
+ *  stored before a line changed method, or posted straight at the route —
+ *  cannot bill for calendar time the shop is not able to sell. The date shown
+ *  is gated by the same call, so the customer is never charged for a promise
+ *  the quote does not make. */
+function rushFeeFor(code, items, holiday = HOLIDAY_MODE) {
+  const r = rushOption(code);
+  if (!r.pct || !rushAvailable(items)) return 0;
+  const base = decorationSubtotal(items);
+  if (base <= 0) return 0;
+  return round2(base * (r.pct / 100) * (holiday ? 2 : 1));
 }
 
 /* ── The pricing engine ───────────────────────────────────────────────────
@@ -3785,6 +3968,11 @@ function quotePricingSource() {
 
         return {
           blank: blank, decoration: decoration, sizeUpcharge: upcharge,
+          /* The decoration alone, x quantity. Rush is a percentage of THIS —
+             not of the line total, which would charge a rush premium on the
+             customer's blanks, and not of the per-piece rate, which loses the
+             quantity that makes jumping a big job expensive. */
+          decorationSubtotal: Math.round(decorationSubtotal * 100) / 100,
           addonLines: addonLines, addonTotal: Math.round(addonTotal * 100) / 100,
           unit: unit, listUnit: listUnit, manual: hasOverride,
           /* Returned so a surface can SHOW the count it is charging for —
@@ -3834,12 +4022,23 @@ function quoteDiscount(subtotal, kind, value) {
  *  what the job would have cost undiscounted. Taxing the full subtotal would
  *  have the shop remitting tax on money it never collected. */
 function quoteTotals(q) {
-  const subtotal = round2((q.items || []).reduce((a, i) => a + Number(i.line_total || 0), 0));
+  const lines = round2((q.items || []).reduce((a, i) => a + Number(i.line_total || 0), 0));
+  /* Rush sits INSIDE the subtotal, above the discount, for two reasons that
+     both bite if it is added later: a whole-job discount should come off the
+     rush too (it is part of what was agreed), and sales tax is owed on it —
+     it is a charge for the work, not a fee collected on somebody's behalf.
+     Adding it after tax would under-remit on every rushed job.
+
+     Recomputed here rather than trusted from the row, so a quote whose lines
+     were edited to screen print stops charging for an embroidery rush the
+     moment it is re-totalled. */
+  const rush = rushFeeFor(q.rush_code, q.items);
+  const subtotal = round2(lines + rush);
   const discount = quoteDiscount(subtotal, q.discount_kind, q.discount_value);
   const net = round2(subtotal - discount);
   const tax = Number(q.tax != null ? q.tax : 0);
   const total = round2(net + tax);
-  return { subtotal, discount, net, tax, total, deposit: depositFor(total) };
+  return { lines, rush, subtotal, discount, net, tax, total, deposit: depositFor(total) };
 }
 
 
@@ -4560,6 +4759,11 @@ app.get(['/quote/new', '/quote/:code/edit'], requireAdmin, async (req, res) => {
                Hidden entirely when a job burns none. -->
           <tr class="scrsplit" style="display:none"><td class="muted">Garments &amp; printing</td><td class="num" id="goods">$0.00</td></tr>
           <tr class="scrsplit" style="display:none"><td class="muted">Screens <span id="scrdetail" style="font-size:12px;color:#6b7280"></span></td><td class="num" id="scr">$0.00</td></tr>
+          <!-- Rush ADDS to the subtotal, unlike the two split rows above it,
+               so it sits before the subtotal line rather than after. Hidden
+               when the job is not rushed, which is most of them. -->
+          <tr class="rushrow" style="display:none"><td class="muted">Rush <span id="rushdetail" style="font-size:12px;color:#6b7280"></span></td>
+              <td class="num" id="rush">$0.00</td></tr>
           <tr><td class="muted">Subtotal</td><td class="num" id="sub">$0.00</td></tr>
           <tr><td class="muted">
             <div style="display:flex;align-items:center;gap:6px;flex-wrap:wrap">
@@ -4588,6 +4792,17 @@ app.get(['/quote/new', '/quote/:code/edit'], requireAdmin, async (req, res) => {
         <label>Needed by <span style="text-transform:none;font-weight:400">(optional)</span></label>
         <input name="needed_by" type="date" value="${E.needed_by ? String(E.needed_by).slice(0,10) : ''}">
         <p class="muted" id="eta" style="margin-top:8px"></p>
+
+        <label style="margin-top:14px">Turnaround</label>
+        <select name="rush_code" id="rushsel" onchange="calc()">
+          ${RUSH_OPTIONS.map((r) => `<option value="${r.code}"${
+            String(E.rush_code || '') === r.code ? ' selected' : ''
+          }>${escEmail(r.label)}${r.pct ? ` — +${r.pct}% of decoration` : ''}</option>`).join('')}
+        </select>
+        <!-- Why the selector can be disabled rather than simply absent: June
+             needs to see that rush EXISTS and why this job cannot have it,
+             otherwise the next step is promising one over the phone. -->
+        <p class="muted" id="rushnote" style="margin-top:6px;font-size:12.5px"></p>
         <label>Quote good for (days)</label>
         <input name="valid_days" type="number" value="14" inputmode="numeric">
         <label>Notes for the customer</label><textarea name="notes" rows="2" placeholder="Optional">${val(E.notes)}</textarea>
@@ -4617,6 +4832,17 @@ ${quotePricingSource()}
         auto: a.auto || null, note: a.note || null, appliesTo: a.appliesTo.source,
       })))};
       var RUSH = ${JSON.stringify(RUSH_OPTIONS)};
+      /* Every tier's dates, computed by deliveryEstimate() on the server.
+         The browser picks from this rather than re-implementing business-day
+         arithmetic, the 3:30pm cut-off and the holiday stretch — a second
+         implementation of those is a second set of dates to disagree. */
+      var ETA = ${JSON.stringify(Object.fromEntries(RUSH_OPTIONS.map((r) => {
+        const e = deliveryEstimate(new Date(), { rushCode: r.code, assumeEligible: true });
+        return [r.code, { ready: e.ready, deliver_from: e.deliver_from,
+                          deliver_to: e.deliver_to, blanks_days: e.blanks_days }];
+      })))};
+      var RUSH_UNAVAILABLE = ${JSON.stringify(RUSH_UNAVAILABLE_NOTE)};
+      var RUSH_CAVEAT = ${JSON.stringify(RUSH_CAVEAT)};
       var HOLIDAY = ${HOLIDAY_MODE ? 'true' : 'false'};
       var SCREEN_FEES_LIVE = ${SCREEN_FEES_LIVE ? 'true' : 'false'};
 
@@ -4735,6 +4961,14 @@ ${quotePricingSource()}
            No backticks in here: this comment is inside a server-side template
            literal, and one would end it. */
         var scrTotal = 0, scrCount = 0;
+        /* What rush is charged on, and whether it may be charged at all.
+           Mirrors decorationSubtotal() and rushAvailable() on the server.
+           embOnly starts true and any decorated non-embroidery line clears it,
+           which is the same fail-closed rule — a line with no method chosen is
+           not evidence of embroidery either.
+           No backticks in this comment: it sits inside a server-side template
+           literal, and one would end it. */
+        var decoTotal = 0, embOnly = true, decorated = 0;
         document.querySelectorAll('.line').forEach(function(L){
           var prod = CAT.products.find(function(x){return String(x.id)===L.querySelector('.p').value;});
           var meth = CAT.methods.find(function(x){return String(x.id)===L.querySelector('.m').value;});
@@ -4919,6 +5153,12 @@ ${quotePricingSource()}
 
           sub += lt;
 
+          if (qty > 0) {
+            decorated++;
+            decoTotal += r.decoration * qty;
+            if (!isEmb) embOnly = false;
+          }
+
           if (r.addonLines) r.addonLines.forEach(function(a){
             if (a.code !== 'screens') return;
             scrTotal += a.total;
@@ -4958,6 +5198,45 @@ ${quotePricingSource()}
             d.value = prod.name + (meth ? ' — ' + meth.title : '') + where;
           }
         });
+        /* Rush, before the discount and before tax — the order quoteTotals()
+           uses. Mirrors rushFeeFor(): a percentage of the DECORATION, zero
+           unless every decorated line is in-house embroidery. */
+        var rushSel  = document.getElementById('rushsel');
+        var rushOk   = decorated > 0 && embOnly;
+        var rushTier = RUSH.find(function(x){ return x.code === rushSel.value; }) || RUSH[0];
+        if (!rushOk && rushTier.pct) { rushSel.value = ''; rushTier = RUSH[0]; }
+        rushSel.disabled = !rushOk;
+        decoTotal = Math.round(decoTotal * 100) / 100;
+        var rushFee = (rushOk && rushTier.pct)
+          ? Math.round(decoTotal * (rushTier.pct/100) * (HOLIDAY ? 2 : 1) * 100) / 100 : 0;
+        sub = Math.round((sub + rushFee) * 100) / 100;
+
+        document.querySelector('.rushrow').style.display = rushFee > 0 ? '' : 'none';
+        document.getElementById('rush').textContent = m2(rushFee);
+        document.getElementById('rushdetail').textContent = rushFee > 0
+          ? '— ' + rushTier.pct + '% of ' + m2(decoTotal) + ' decoration' +
+            (HOLIDAY ? ', doubled for the holiday season' : '') : '';
+
+        /* One sentence that says what the shop can actually do, and by when. */
+        var rn = document.getElementById('rushnote');
+        var pick = ETA[rushOk ? rushTier.code : ''] || ETA[''];
+        var readyOn = new Date(pick.ready).toLocaleDateString('en-US',{month:'short',day:'numeric'});
+        if (!decorated) {
+          rn.textContent = 'Add an item with a quantity to see a date.';
+        } else if (!rushOk) {
+          rn.textContent = RUSH_UNAVAILABLE;
+        } else if (!rushTier.pct) {
+          rn.textContent = 'Standard: ready about ' + readyOn + '. ' +
+            'Rush is available on this job — embroidery is sewn in house.';
+        } else {
+          rn.textContent = rushTier.label + ': ' + rushTier.prodDays + ' business day' +
+            (rushTier.prodDays === 1 ? '' : 's') + ' on the machine once artwork and garments ' +
+            'are in hand, so ready about ' + readyOn +
+            (pick.blanks_days ? ' — that includes ' + pick.blanks_days +
+              ' days for blanks to arrive, which rush cannot shorten.' : '.') +
+            ' ' + RUSH_CAVEAT;
+        }
+
         /* Mirrors quoteDiscount() on the server, clamps included. If these two
            ever disagree the form shows one number and the customer is charged
            another, so keep them in step. */
@@ -4983,7 +5262,12 @@ ${quotePricingSource()}
           el.style.display = showScr ? '' : 'none';
         });
         if (showScr) {
-          document.getElementById('goods').textContent = m2(Math.round((sub - scrTotal) * 100) / 100);
+          /* Less the rush too — these two rows split what the LINES came to,
+             and rush has its own row above. Without this the goods figure
+             absorbs the rush and the three rows stop adding up to the
+             subtotal they claim to explain. */
+          document.getElementById('goods').textContent =
+            m2(Math.round((sub - scrTotal - rushFee) * 100) / 100);
           document.getElementById('scr').textContent = m2(scrTotal);
           document.getElementById('scrdetail').textContent = scrCount
             ? '— ' + scrCount + ' × ' + m2(scrTotal / scrCount) + ', one-time' : '— one-time';
@@ -5468,6 +5752,18 @@ app.post(['/api/quotes', '/api/quotes/:code'], requireAdmin, async (req, res) =>
         line_total: lineTotal,
         size_mix: mix,
         size_upcharge: priced.sizeUpcharge,
+        /* The decoration on this line, x quantity — what a rush percentage is
+           charged on. Stored rather than re-derived because quoteTotals() runs
+           on the saved row with no catalogue in reach, and re-pricing a quote
+           to total it would let a later price change silently restate money
+           the customer has already agreed to. */
+        decoration_total: priced.decorationSubtotal,
+        /* The method's NAME, not just its id, for the same reason: the rush
+           gate has to know whether this line is in-house embroidery or contract
+           screen print, and it runs where the method table is not loaded.
+           Absent on lines saved before this existed, which the gate treats as
+           "not known to be embroidery" and therefore not rushable. */
+        method_title: method ? method.title : null,
         /* Every extra, itemised, so the customer's page can name each one
            rather than showing an unexplained difference. */
         addons: priced.addonLines,
@@ -5508,7 +5804,16 @@ app.post(['/api/quotes', '/api/quotes/:code'], requireAdmin, async (req, res) =>
         </div>`));
     }
 
-    const subtotal = round2(items.reduce((a, i) => a + i.line_total, 0));
+    /* Rush, validated against the job rather than taken on trust: an unknown
+       code, or a real one on a job with a screen-print line, stores as NULL.
+       The form only offers it when it applies, but the form is not the only
+       way to reach this route, and a stored code is what every later total
+       re-reads. Order below mirrors quoteTotals(), which is the definition —
+       rush inside the subtotal, discount off that, tax on the remainder. */
+    const rushCode = rushAvailable(items) && rushOption(one(b.rush_code)).pct
+      ? rushOption(one(b.rush_code)).code : null;
+    const rushFee = rushFeeFor(rushCode, items);
+    const subtotal = round2(items.reduce((a, i) => a + i.line_total, 0) + rushFee);
 
     /* Discount off the top of the job. Stored as entered so that editing the
        lines later re-applies the same deal; the dollar figure is derived here
@@ -5541,13 +5846,13 @@ app.post(['/api/quotes', '/api/quotes/:code'], requireAdmin, async (req, res) =>
       ({ rows } = await pool.query(
         `UPDATE quotes SET name=$2, phone=$3, email=$4, items=$5, subtotal=$6, tax=$7,
                 total=$8, deposit=$9, notes=$10, valid_until=$11, needed_by=$12,
-                discount_kind=$13, discount_value=$14, discount_note=$15,
+                discount_kind=$13, discount_value=$14, discount_note=$15, rush_code=$16,
                 change_request=NULL, requested_items=NULL, revision=COALESCE(revision,1)+1,
                 status = CASE WHEN accepted_at IS NULL THEN 'sent' ELSE status END
           WHERE code=$1 RETURNING *`,
         [editing, name, phone, email, JSON.stringify(items), subtotal, tax, total, deposit,
          String(b.notes || '').trim().slice(0, 2000), validUntil, neededBy,
-         discountKind, discountValue, discountNote || null]));
+         discountKind, discountValue, discountNote || null, rushCode]));
       if (!rows.length) {
         return res.status(404).send(quotePage('Not found',
           `<div class="card"><div class="warn">That quote no longer exists.</div>
@@ -5566,13 +5871,14 @@ app.post(['/api/quotes', '/api/quotes/:code'], requireAdmin, async (req, res) =>
            would sit on the board until the contact-matching fallback happened
            to catch it, which it only does when the details match exactly. */
         `INSERT INTO quotes (code,name,phone,email,items,subtotal,tax,total,deposit,notes,status,valid_until,needed_by,
-                             discount_kind,discount_value,discount_note,from_submission_id)
-         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,'sent',$11,$12,$13,$14,$15,$16) RETURNING *`,
+                             discount_kind,discount_value,discount_note,from_submission_id,rush_code)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,'sent',$11,$12,$13,$14,$15,$16,$17) RETURNING *`,
         [code, name, phone, email, JSON.stringify(items), subtotal, tax, total, deposit,
          String(b.notes || '').trim().slice(0, 2000), validUntil, neededBy,
          discountKind, discountValue, discountNote || null,
          (Number.isFinite(parseInt(one(b.from_submission_id), 10))
-           ? parseInt(one(b.from_submission_id), 10) : null)]));
+           ? parseInt(one(b.from_submission_id), 10) : null),
+         rushCode]));
     }
 
     const q = rows[0];
@@ -5742,7 +6048,16 @@ app.get('/q/:code', async (req, res) => {
     const accepted = !!q.accepted_at;
     const paid = Number(q.paid_amount || 0) > 0;
     const balanceDue = balanceOf(q, t.total);
-    const eta = deliveryEstimate(q.accepted_at ? new Date(q.accepted_at) : new Date());
+    /* The date the customer is shown must be the one they PAID for, so the
+       rush tier and the lines go in — the same two inputs the fee was derived
+       from, so a job that stopped being rush-eligible loses the promise at the
+       same moment it stops being charged.
+       `blanks_in_at` is a milestone the shop already records; once the garments
+       are counted in, the supplier's lead time is no longer ahead of this job
+       and the estimate stops carrying it. */
+    const eta = deliveryEstimate(q.accepted_at ? new Date(q.accepted_at) : new Date(), {
+      rushCode: q.rush_code, items: q.items, blanksIn: !!q.blanks_in_at,
+    });
     /* A DATE column has no time, so converting it through a timezone shifts it
        a day backwards (2026-08-20 rendered as Aug 19). Format the calendar date
        literally; only real timestamps get timezone treatment. */
@@ -5874,8 +6189,11 @@ app.get('/q/:code', async (req, res) => {
           <th>Item</th><th class="num">Qty</th><th class="num">Each</th><th class="num">Amount</th>
         </tr></thead><tbody>
           ${lines}
-          <tr><td colspan="3" class="num muted" style="padding-top:12px">Subtotal</td>
-              <td class="num" style="padding-top:12px">${money(t.subtotal)}</td></tr>
+          ${t.rush > 0 ? `<tr><td colspan="3" class="num muted" style="padding-top:12px">
+              ${escEmail(rushOption(q.rush_code).label)}</td>
+              <td class="num" style="padding-top:12px">${money(t.rush)}</td></tr>` : ''}
+          <tr><td colspan="3" class="num muted" style="padding-top:${t.rush > 0 ? '0' : '12px'}">Subtotal</td>
+              <td class="num" style="padding-top:${t.rush > 0 ? '0' : '12px'}">${money(t.subtotal)}</td></tr>
           ${t.discount > 0 ? `<tr><td colspan="3" class="num" style="color:#166534">
               ${q.discount_note ? escEmail(q.discount_note) : 'Discount'}${
                 q.discount_kind === 'pct' ? ` (${Number(q.discount_value)}% off)` : ''}</td>
@@ -5900,6 +6218,13 @@ app.get('/q/:code', async (req, res) => {
           ${q.needed_by ? `<p class="muted"><b>You need it by:</b> ${dayFmt(q.needed_by)}</p>` : ''}
           <p class="muted"><b>Estimated:</b> ready ${dayFmt(eta.ready)}, delivered ${dayFmt(eta.deliver_from)}–${dayFmt(eta.deliver_to)}
             ${accepted ? '' : ' once the deposit is in'}.</p>
+          ${t.rush > 0 ? `<p class="muted"><b>Rush:</b> ${eta.production_days} business day${
+              eta.production_days === 1 ? '' : 's'} on the machine once we have your artwork
+            approved${eta.blanks_days ? ` and the garments in hand (about ${eta.blanks_days} days
+            for those to arrive, which a rush cannot shorten)` : ''}. ${escEmail(RUSH_CAVEAT)}</p>` : ''}
+          ${eta.beyond_sheet ? `<p class="muted">This is a large run, so the dates above are an
+            estimate rather than a commitment — we confirm the schedule with the press before
+            you pay.</p>` : ''}
           ${q.valid_until ? `<p class="muted">Quote good through ${fmtDate(q.valid_until)}.</p>` : ''}
         </div>
       </div>

--- a/server.js
+++ b/server.js
@@ -3324,20 +3324,24 @@ const SHEET_PIECE_CEILING = parseInt(process.env.JT_SHEET_CEILING || '2400', 10)
  *                   so the date and the fee are gated by ONE decision.
  *  `opts.items`     the quote lines, for that eligibility check and the count.
  *  `opts.blanksIn`  true when the garments are already in hand (customer
- *                   supplied, or stock). Otherwise the supplier's lead time is
- *                   added, because rush buys machine time and nothing else —
- *                   a same-day embroidery slot cannot sew shirts that have not
- *                   arrived. Quoting rush from the ORDER date rather than from
- *                   goods-in is the single easiest way to miss a deadline the
- *                   shop was paid extra to hit.
- *  `opts.pickup`    collected from the shop, so no transit. */
+ *                   supplied, or stock), which removes the supplier wait a
+ *                   RUSH tier would otherwise carry. See below.
+ *  `opts.pickup`    collected from the shop, so no transit.
+ *
+ *  WHY THE BLANKS WAIT APPLIES TO RUSH AND NOT TO STANDARD, which looks
+ *  inconsistent and is not: the two numbers are measured from different
+ *  places. The 7-10 business days the shop advertises is a DOOR TO DOOR figure
+ *  from the order date, and it has always absorbed the wait for blanks —
+ *  adding the supplier lead time on top would move every quote a week later
+ *  and quietly rewrite a promise the site has made for years. Anchorfish's
+ *  rush ladder measures the opposite thing: MACHINE time, stated "from receipt
+ *  of all goods and art approvals". So a 2-day tier that did not add the
+ *  supplier wait would promise a date before the shirts exist. */
 function deliveryEstimate(from = new Date(), opts = {}) {
   const pmin = parseInt(process.env.JT_PROD_MIN || '7', 10);
   const pmax = parseInt(process.env.JT_PROD_MAX || '10', 10);
   const smin = opts.pickup ? 0 : parseInt(process.env.JT_SHIP_MIN || '2', 10);
   const smax = opts.pickup ? 0 : parseInt(process.env.JT_SHIP_MAX || '5', 10);
-  const blanks = opts.blanksIn ? 0 : parseInt(process.env.JT_LT_BLANKS || '5', 10);
-
   const holiday = opts.holiday != null ? opts.holiday : HOLIDAY_MODE;
   /* `assumeEligible` is for showing what a tier WOULD give — the quote form
      prices every tier up front so the browser never has to re-implement
@@ -3356,6 +3360,9 @@ function deliveryEstimate(from = new Date(), opts = {}) {
   const extra = holiday ? HOLIDAY_EXTRA_DAYS : 0;
   const prodMin = rushed ? rush.prodDays : pmin + extra;
   const prodMax = rushed ? rush.prodDays : pmax + extra;
+  /* Only a rush tier carries it — see the note above. */
+  const blanks = (!rushed || opts.blanksIn)
+    ? 0 : parseInt(process.env.JT_LT_BLANKS || '5', 10);
 
   const start = productionStart(from);
   const pieces = (Array.isArray(opts.items) ? opts.items : [])
@@ -3619,6 +3626,29 @@ function rushAvailable(items) {
     !COST_SERVICE_WORDS.test(String(i.description || '')));
   if (!decorated.length) return false;
   return decorated.every((i) => EMBROIDERY_METHOD_RE.test(String(i.method_title || '')));
+}
+
+/* Does this tier actually land the job sooner than standard?
+ *
+ *  It can fail to, and the arithmetic is not obvious: a 4-day machine slot on
+ *  a job still waiting 5 days for blanks lands on day 9, while standard lands
+ *  on day 7. Offering that is selling a 20% surcharge for a LATER delivery —
+ *  the kind of thing nobody notices until a customer does.
+ *
+ *  Which tiers survive depends entirely on JT_LT_BLANKS. Once the garments are
+ *  in hand (`blanksIn`) every tier beats standard, which is why the shop can
+ *  genuinely sell same-day on a reorder and cannot on a fresh job.
+ *
+ *  Checked where the sale happens — the form offers only what passes, and the
+ *  save path stores only what passes. A code already agreed is then honoured,
+ *  the same way a discount is. */
+function rushImprovesDate(code, opts = {}) {
+  if (!rushOption(code).pct) return true;               // standard is always fine
+  const at = opts.from || new Date();
+  const base = { items: opts.items, blanksIn: opts.blanksIn, holiday: opts.holiday,
+                 pickup: opts.pickup, assumeEligible: true };
+  return deliveryEstimate(at, Object.assign({}, base, { rushCode: code })).ready <
+         deliveryEstimate(at, Object.assign({}, base, { rushCode: '' })).ready;
 }
 
 /** The decoration the rush percentage is charged on.
@@ -4841,6 +4871,12 @@ ${quotePricingSource()}
         return [r.code, { ready: e.ready, deliver_from: e.deliver_from,
                           deliver_to: e.deliver_to, blanks_days: e.blanks_days }];
       })))};
+      /* The tiers that actually land sooner than standard, decided by
+         rushImprovesDate() on the server so the form cannot offer one the save
+         path will then refuse. With blanks still to arrive the short tiers do
+         not help, and saying so beats a silent absence. */
+      var RUSH_HELPS = ${JSON.stringify(Object.fromEntries(
+        RUSH_OPTIONS.map((r) => [r.code, rushImprovesDate(r.code, {})])))};
       var RUSH_UNAVAILABLE = ${JSON.stringify(RUSH_UNAVAILABLE_NOTE)};
       var RUSH_CAVEAT = ${JSON.stringify(RUSH_CAVEAT)};
       var HOLIDAY = ${HOLIDAY_MODE ? 'true' : 'false'};
@@ -5204,8 +5240,20 @@ ${quotePricingSource()}
         var rushSel  = document.getElementById('rushsel');
         var rushOk   = decorated > 0 && embOnly;
         var rushTier = RUSH.find(function(x){ return x.code === rushSel.value; }) || RUSH[0];
-        if (!rushOk && rushTier.pct) { rushSel.value = ''; rushTier = RUSH[0]; }
+        if ((!rushOk || !RUSH_HELPS[rushTier.code]) && rushTier.pct) {
+          rushSel.value = ''; rushTier = RUSH[0];
+        }
         rushSel.disabled = !rushOk;
+        /* A tier that does not beat standard is shown, struck out of use and
+           labelled, rather than removed: June needs to see that same-day
+           exists and that this job cannot have it yet. */
+        Array.prototype.forEach.call(rushSel.options, function(o){
+          var helps = RUSH_HELPS[o.value];
+          o.disabled = !helps;
+          if (!helps && o.text.indexOf('(not sooner') === -1) {
+            o.text += ' (not sooner than standard on this job)';
+          }
+        });
         decoTotal = Math.round(decoTotal * 100) / 100;
         var rushFee = (rushOk && rushTier.pct)
           ? Math.round(decoTotal * (rushTier.pct/100) * (HOLIDAY ? 2 : 1) * 100) / 100 : 0;
@@ -5810,8 +5858,10 @@ app.post(['/api/quotes', '/api/quotes/:code'], requireAdmin, async (req, res) =>
        way to reach this route, and a stored code is what every later total
        re-reads. Order below mirrors quoteTotals(), which is the definition —
        rush inside the subtotal, discount off that, tax on the remainder. */
-    const rushCode = rushAvailable(items) && rushOption(one(b.rush_code)).pct
-      ? rushOption(one(b.rush_code)).code : null;
+    const wanted = rushOption(one(b.rush_code));
+    const rushCode = (rushAvailable(items) && wanted.pct &&
+                      rushImprovesDate(wanted.code, { items }))
+      ? wanted.code : null;
     const rushFee = rushFeeFor(rushCode, items);
     const subtotal = round2(items.reduce((a, i) => a + i.line_total, 0) + rushFee);
 

--- a/tests/leads-on-board.test.js
+++ b/tests/leads-on-board.test.js
@@ -53,7 +53,10 @@ test('the phone match ignores formatting', () => {
 test('a quote raised from a lead records which one', () => {
   /* Otherwise the lead only leaves the board if the contact details happen to
      match exactly — and the whole point is that they are typed fresh. */
-  assert.match(src, /from_submission_id\)\s*\n?\s*VALUES/,
+  /* Matched inside the column list rather than against the last column, so
+     adding a column after it (rush_code did) does not read as the link being
+     dropped. */
+  assert.match(src, /INSERT INTO quotes \([^)]*from_submission_id[^)]*\)\s*\n?\s*VALUES/,
     'the insert must carry the link');
   assert.match(src, /<input type="hidden" name="from_submission_id" value="\$\{lead\.id\}">/,
     'and the form must post it');

--- a/tests/quote-discount.test.js
+++ b/tests/quote-discount.test.js
@@ -51,13 +51,42 @@ function lift(name) {
    restating any of it, so a change to the deposit rule is reflected here. */
 const DEPOSIT_PC = Number(process.env.JT_DEPOSIT_PCT || 0.5);
 const DEPOSIT_FULL_UNDER = Number(process.env.JT_DEPOSIT_FULL_UNDER || 100);
-const { quoteDiscount, quoteTotals } = vm.runInThisContext(`(function(){
+/* quoteTotals now also derives the rush charge, so the little world has to
+   include the rush rule. Lifted the same way rather than restated: a change to
+   who may be rushed, or to the percentage, must show up in these totals. */
+const RUSH_OPTIONS = (() => {
+  /* From the env-override table through the end of the ladder — RUSH_OPTIONS
+     calls rushPct() per tier, so lifting the list alone leaves it undefined. */
+  const m = /const RUSH_PCT_OVERRIDES = [\s\S]*?\nconst RUSH_OPTIONS = \[[\s\S]*?\n\];/.exec(src);
+  assert.ok(m, 'RUSH_OPTIONS not found in server.js');
+  return m[0];
+})();
+const CONSTS = (() => {
+  const grab = (re, what) => {
+    const m = re.exec(src);
+    assert.ok(m, `${what} not found in server.js`);
+    return m[0];
+  };
+  return [
+    grab(/const COST_SERVICE_WORDS = .*;/, 'COST_SERVICE_WORDS'),
+    grab(/const EMBROIDERY_METHOD_RE = .*;/, 'EMBROIDERY_METHOD_RE'),
+  ].join('\n');
+})();
+
+const { quoteDiscount, quoteTotals, rushFeeFor } = vm.runInThisContext(`(function(){
   const DEPOSIT_PC = ${DEPOSIT_PC}, DEPOSIT_FULL_UNDER = ${DEPOSIT_FULL_UNDER};
   const round2 = (n) => Math.round((Number(n) || 0) * 100) / 100;
+  const HOLIDAY_MODE = false;
+  ${CONSTS}
+  ${RUSH_OPTIONS}
+  ${lift('rushOption')}
+  ${lift('rushAvailable')}
+  ${lift('decorationSubtotal')}
+  ${lift('rushFeeFor')}
   ${lift('depositFor')}
   ${lift('quoteDiscount')}
   ${lift('quoteTotals')}
-  return { quoteDiscount, quoteTotals };
+  return { quoteDiscount, quoteTotals, rushFeeFor };
 })()`);
 
 const lines = (...amounts) => ({ items: amounts.map((line_total) => ({ line_total })) });

--- a/tests/rush-turnaround.test.js
+++ b/tests/rush-turnaround.test.js
@@ -79,8 +79,10 @@ const W = vm.runInThisContext(`(function(){
   ${lift('shopMinutes')}
   ${lift('productionStart')}
   ${lift('deliveryEstimate')}
+  ${lift('rushImprovesDate')}
   return { RUSH_OPTIONS, rushOption, rushAvailable, decorationSubtotal,
-           rushFeeFor, addBusinessDays, productionStart, deliveryEstimate };
+           rushFeeFor, addBusinessDays, productionStart, deliveryEstimate,
+           rushImprovesDate };
 })()`);
 
 /* A decorated line, as the save path stores one. `decoration_total` is the
@@ -287,8 +289,8 @@ test('the save path validates the posted code against the job', () => {
   /* The form only offers rush when it applies, but the form is not the only
      way to reach the route, and the stored code is what every later total
      re-reads. */
-  assert.match(src, /rushAvailable\(items\) && rushOption\(one\(b\.rush_code\)\)\.pct/,
-    'an ineligible or unknown code must store as NULL');
+  assert.match(src, /rushAvailable\(items\) && wanted\.pct &&\s*\n?\s*rushImprovesDate\(wanted\.code, \{ items \}\)/,
+    'an ineligible or unknown code, or one that is no sooner than standard, must store as NULL');
   assert.match(src, /rush_code=\$16/, 'an edit must be able to clear it too');
 });
 
@@ -310,4 +312,40 @@ test('the browser prices rush the same way the server does', () => {
   assert.match(browser, /HOLIDAY \? 2 : 1/, 'and double it in season, as the server does');
   assert.match(browser, /rushOk\s+= decorated > 0 && embOnly/,
     'and gate it on the same embroidery-only rule');
+});
+
+/* ── A rush that is not sooner is not a rush ─────────────────────────────── */
+
+test('a tier that lands no sooner than standard is refused', () => {
+  /* The arithmetic that makes this necessary: a 4-day machine slot on a job
+     still waiting 5 days for blanks lands on day 9, while standard lands on
+     day 7. Selling that is a 20% surcharge for a LATER delivery. */
+  const at = { items: EMB(), from: WED_AM };
+  const four = W.deliveryEstimate(WED_AM, { items: EMB(), rushCode: 'rush4' });
+  const std  = W.deliveryEstimate(WED_AM, { items: EMB() });
+  assert.ok(four.ready > std.ready, 'the setup for this test must actually be the bad case');
+  assert.strictEqual(W.rushImprovesDate('rush4', at), false);
+});
+
+test('every tier helps once the garments are in hand', () => {
+  /* Which is why the shop can genuinely sell same-day on a reorder and cannot
+     on a fresh job — the difference is the supplier, not the machine. */
+  for (const r of W.RUSH_OPTIONS) {
+    assert.strictEqual(W.rushImprovesDate(r.code, { items: EMB(), from: WED_AM, blanksIn: true }),
+      true, `${r.code || 'standard'} must land sooner once the blanks are in`);
+  }
+});
+
+test('standard is never refused for not being sooner than itself', () => {
+  assert.strictEqual(W.rushImprovesDate('', { items: EMB(), from: WED_AM }), true);
+});
+
+test('the form offers only what the save path will accept', () => {
+  /* Otherwise June picks a tier, the quote saves without it, and the only
+     evidence is a fee that quietly did not appear. */
+  assert.match(src, /var RUSH_HELPS = /, 'the form needs the same verdict the server reached');
+  assert.match(src, /rushImprovesDate\(r\.code, \{\}\)/,
+    'and it must come from rushImprovesDate, not a second rule');
+  assert.match(src, /o\.disabled = !helps/, 'an unavailable tier is disabled, not hidden');
+  assert.match(src, /not sooner than standard/, 'and it says why');
 });

--- a/tests/rush-turnaround.test.js
+++ b/tests/rush-turnaround.test.js
@@ -1,0 +1,313 @@
+/* Regression tests for rush turnaround and the delivery estimate (server.js).
+ *
+ * Run: node --test tests/*.test.js
+ *
+ * The thing these guard is not arithmetic. It is a PROMISE.
+ *
+ * Screen printing and DTF are contracted to Anchorfish. Both their 2026 sheets
+ * state 7-10 business days and neither sells a rush service at any price — so
+ * the shop cannot buy that time back, however much a customer offers. Their
+ * embroidery sheet is the only one with a rush ladder, and it says so in as
+ * many words: "RUSH SERVICES AVAILABLE UPON APPROVAL - applies to embroidery
+ * only". Embroidery is the work June sews in house, which is exactly why it is
+ * the work she can bump up the queue.
+ *
+ * The version of this code these tests replaced offered "Rush - 2 business
+ * days" for a flat $15 on ANY job. On a screen-print order that is a date with
+ * nothing behind it, and it would have been discovered by a customer, on the
+ * day, with the shirts not made.
+ *
+ * So the tests below are mostly about REFUSAL: who cannot be sold a rush, and
+ * what a rush still cannot compress once it is sold.
+ */
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const SERVER = path.join(__dirname, '..', 'server.js');
+const src = fs.readFileSync(SERVER, 'utf8');
+
+/** Lift a top-level `function name(...) {...}` out of server.js.
+ *
+ *  The parameter list is walked FIRST, by parens. deliveryEstimate's signature
+ *  ends `opts = {}`, and a brace-counter started at the first `{` closes on
+ *  that empty default and returns the signature alone — which fails later as a
+ *  bare `return`, a long way from the cause. */
+function lift(name) {
+  const start = src.indexOf(`function ${name}(`);
+  assert.notStrictEqual(start, -1, `function ${name} not found in server.js`);
+  let i = src.indexOf('(', start), parens = 0;
+  for (; i < src.length; i++) {
+    if (src[i] === '(') parens++;
+    else if (src[i] === ')' && --parens === 0) { i++; break; }
+  }
+  let depth = 0;
+  for (let j = src.indexOf('{', i); j < src.length; j++) {
+    if (src[j] === '{') depth++;
+    else if (src[j] === '}' && --depth === 0) return src.slice(start, j + 1);
+  }
+  throw new Error(`unbalanced braces reading ${name} from server.js`);
+}
+
+/** Lift a `const` declaration verbatim, so an env default is the real one. */
+function liftConst(re, what) {
+  const m = re.exec(src);
+  assert.ok(m, `${what} not found in server.js`);
+  return m[0];
+}
+
+/* The real rule, not a restatement of it. If the ladder, the gate or the
+   business-day arithmetic changes in server.js, these tests run the change. */
+const W = vm.runInThisContext(`(function(){
+  const round2 = (n) => Math.round((Number(n) || 0) * 100) / 100;
+  const HOLIDAY_MODE = false;
+  ${liftConst(/const COST_SERVICE_WORDS = .*;/, 'COST_SERVICE_WORDS')}
+  ${liftConst(/const EMBROIDERY_METHOD_RE = .*;/, 'EMBROIDERY_METHOD_RE')}
+  ${liftConst(/const HOLIDAY_EXTRA_DAYS = .*;/, 'HOLIDAY_EXTRA_DAYS')}
+  ${liftConst(/const SHOP_TZ = .*;/, 'SHOP_TZ')}
+  ${liftConst(/const CUTOFF_MIN = \(\(\) => \{[\s\S]*?\}\)\(\);/, 'CUTOFF_MIN')}
+  ${liftConst(/const SHEET_PIECE_CEILING = .*;/, 'SHEET_PIECE_CEILING')}
+  ${liftConst(/const RUSH_PCT_OVERRIDES = [\s\S]*?\nconst RUSH_OPTIONS = \[[\s\S]*?\n\];/, 'RUSH_OPTIONS')}
+  ${lift('rushOption')}
+  ${lift('rushAvailable')}
+  ${lift('decorationSubtotal')}
+  ${lift('rushFeeFor')}
+  ${lift('addBusinessDays')}
+  ${lift('shopMinutes')}
+  ${lift('productionStart')}
+  ${lift('deliveryEstimate')}
+  return { RUSH_OPTIONS, rushOption, rushAvailable, decorationSubtotal,
+           rushFeeFor, addBusinessDays, productionStart, deliveryEstimate };
+})()`);
+
+/* A decorated line, as the save path stores one. `decoration_total` is the
+   decoration x quantity; `line_total` includes the blanks on top. */
+const line = (method_title, decoration_total, line_total, qty = 50) =>
+  ({ description: 'Tee', qty, method_title, decoration_total, line_total });
+
+const EMB = () => [line('Embroidery — Left Chest', 1000, 1600)];
+const SCREEN = () => [line('Screen Printing', 1000, 1600)];
+
+/* ── Who may be sold a rush ──────────────────────────────────────────────── */
+
+test('an all-embroidery job can be rushed', () => {
+  assert.strictEqual(W.rushAvailable(EMB()), true,
+    'embroidery is sewn in house, so the shop owns the machine time');
+});
+
+test('a screen-print job cannot be rushed at any price', () => {
+  assert.strictEqual(W.rushAvailable(SCREEN()), false);
+  assert.strictEqual(W.rushFeeFor('rush2', SCREEN()), 0,
+    'the contract printer sells no rush service, so there is nothing to charge for');
+});
+
+test('one screen-print line takes rush off the whole job', () => {
+  /* The customer gets ONE parcel, so the slowest line sets the date. A job
+     that is 90% embroidery still waits on the contract printer, and charging
+     40% for a date set by somebody else is selling air. */
+  const mixed = [...EMB(), ...SCREEN()];
+  assert.strictEqual(W.rushAvailable(mixed), false);
+  assert.strictEqual(W.rushFeeFor('rush1', mixed), 0);
+});
+
+test('a line whose method is unknown fails CLOSED', () => {
+  /* Hand-typed lines and quotes saved before `method_title` existed carry no
+     method. Absence of evidence is not embroidery — guessing the other way
+     sells the promise this whole gate exists to prevent. */
+  const typed = [{ description: '50 hoodies, logo front', qty: 50,
+                   decoration_total: 500, line_total: 900 }];
+  assert.strictEqual(W.rushAvailable(typed), false);
+  assert.strictEqual(W.rushFeeFor('rush0', typed), 0);
+});
+
+test('a quote with no decorated line cannot be rushed', () => {
+  assert.strictEqual(W.rushAvailable([]), false);
+  /* A digitizing fee on its own is a service line, not work to be jumped. */
+  assert.strictEqual(W.rushAvailable([{ description: 'Digitizing', qty: 1 }]), false);
+});
+
+/* ── What a rush costs ───────────────────────────────────────────────────── */
+
+test('rush is a percentage of the DECORATION, never of the line total', () => {
+  /* The line is $1,600, of which $1,000 is stitching and $600 is the shirts.
+     40% of the line would bill $640 — $240 of it a surcharge on the customer's
+     own garments, which no amount of machine time makes arrive sooner. */
+  assert.strictEqual(W.rushFeeFor('rush2', EMB()), 400);
+});
+
+test('a bigger job pays more for the same tier', () => {
+  /* The reason the flat fee this replaced was wrong: jumping a 500-piece run
+     costs far more machine time than jumping a dozen, and $15 covered both. */
+  const small = [line('Embroidery', 100, 260, 12)];
+  const big   = [line('Embroidery', 4000, 6400, 500)];
+  assert.ok(W.rushFeeFor('rush2', big) > W.rushFeeFor('rush2', small) * 10);
+});
+
+test('the ladder never pays less for a shorter turnaround', () => {
+  const tiers = W.RUSH_OPTIONS.filter((r) => r.prodDays != null)
+    .slice().sort((a, b) => b.prodDays - a.prodDays);
+  for (let i = 1; i < tiers.length; i++) {
+    assert.ok(tiers[i].pct > tiers[i - 1].pct,
+      `${tiers[i].code} is sooner than ${tiers[i - 1].code} and must cost more`);
+  }
+});
+
+test('standard turnaround is free and is the default', () => {
+  assert.strictEqual(W.RUSH_OPTIONS[0].code, '');
+  assert.strictEqual(W.rushFeeFor('', EMB()), 0);
+  assert.strictEqual(W.rushFeeFor(undefined, EMB()), 0);
+});
+
+test('an unknown rush code charges nothing rather than throwing', () => {
+  /* This route is reachable with a hand-posted body. */
+  assert.strictEqual(W.rushFeeFor('rush99', EMB()), 0);
+  assert.strictEqual(W.rushFeeFor({ evil: true }, EMB()), 0);
+});
+
+test('holiday mode doubles the fee', () => {
+  assert.strictEqual(W.rushFeeFor('rush2', EMB(), true), 800);
+});
+
+/* ── What a rush cannot compress ─────────────────────────────────────────── */
+
+const WED_AM = new Date('2026-09-02T15:00:00Z');   // 10:00 in Chicago, well before cut-off
+
+test('rush shortens the machine time, not the wait for blanks', () => {
+  /* The failure this prevents: quoting "same day" from the ORDER date on
+     garments that have not been ordered yet. Rush buys a slot on the machine.
+     It does not make a supplier's van arrive. */
+  const std  = W.deliveryEstimate(WED_AM, { items: EMB() });
+  const same = W.deliveryEstimate(WED_AM, { items: EMB(), rushCode: 'rush0' });
+  assert.ok(same.ready < std.ready, 'a rush must actually move the date');
+  assert.strictEqual(same.blanks_days > 0, true,
+    'with no garments in hand the supplier lead time is still ahead of the job');
+  assert.ok(same.ready > WED_AM,
+    'same-day cannot mean today when the shirts have not arrived');
+});
+
+test('garments already in hand remove the blanks wait, and only that', () => {
+  const waiting = W.deliveryEstimate(WED_AM, { items: EMB(), rushCode: 'rush2' });
+  const inHand  = W.deliveryEstimate(WED_AM, { items: EMB(), rushCode: 'rush2', blanksIn: true });
+  assert.strictEqual(inHand.blanks_days, 0);
+  assert.ok(inHand.ready < waiting.ready);
+});
+
+test('a rush the job is not eligible for does not move the date either', () => {
+  /* The fee and the date are gated by the SAME call, so a customer can never
+     be shown a date they were not charged for, or charged for one they were
+     not shown. */
+  const std     = W.deliveryEstimate(WED_AM, { items: SCREEN() });
+  const claimed = W.deliveryEstimate(WED_AM, { items: SCREEN(), rushCode: 'rush0' });
+  assert.deepStrictEqual(claimed.ready, std.ready);
+  assert.strictEqual(claimed.rush_code, '');
+});
+
+test('holiday mode stretches standard production but not a sold rush tier', () => {
+  /* Taking 40% for "2 business days" and then quietly making it 5 is the worst
+     of both: the customer paid for a date the shop had already decided to
+     miss. In season the honest move is to stop offering the tier. */
+  const stdBusy  = W.deliveryEstimate(WED_AM, { items: EMB(), holiday: true });
+  const stdCalm  = W.deliveryEstimate(WED_AM, { items: EMB(), holiday: false });
+  assert.ok(stdBusy.ready > stdCalm.ready, 'standard work does take longer in season');
+
+  const rushBusy = W.deliveryEstimate(WED_AM, { items: EMB(), rushCode: 'rush2', holiday: true });
+  const rushCalm = W.deliveryEstimate(WED_AM, { items: EMB(), rushCode: 'rush2', holiday: false });
+  assert.deepStrictEqual(rushBusy.ready, rushCalm.ready,
+    'a tier that was sold as 2 business days stays 2 business days');
+});
+
+/* ── The clock the promise is made on ────────────────────────────────────── */
+
+test('work handed over after the 3:30pm cut-off starts the next business day', () => {
+  /* Anchorfish states a 3:30pm CST cut-off and the shop's own machine has the
+     same problem: an order taken at 4pm has not begun. Counting from `from`
+     regardless is how a Friday-evening job gets quoted as a Friday-morning one. */
+  const before = W.productionStart(new Date('2026-09-02T19:00:00Z')); // 14:00 Chicago
+  const after  = W.productionStart(new Date('2026-09-02T21:00:00Z')); // 16:00 Chicago
+  assert.strictEqual(before.getDate(), 2, 'before the cut-off, the day has started');
+  assert.strictEqual(after.getDate(), 3, 'after it, the clock starts tomorrow');
+});
+
+test('the cut-off is read in the shop timezone, not the server one', () => {
+  /* Railway runs UTC. 21:00 UTC is 16:00 in Chicago — past the cut-off — but
+     18:00 UTC is 13:00 there and is NOT, though both read as afternoon in UTC. */
+  const utcAfternoon = W.productionStart(new Date('2026-09-02T18:00:00Z'));
+  assert.strictEqual(utcAfternoon.getDate(), 2,
+    'a UTC hour past the cut-off that is not one in Chicago must not lose a day');
+});
+
+test('a weekend order starts on Monday', () => {
+  const sat = W.productionStart(new Date('2026-09-05T15:00:00Z'));
+  assert.strictEqual(sat.getDay(), 1, 'nothing is produced at the weekend');
+});
+
+test('business-day arithmetic never lands on a weekend', () => {
+  for (let d = 1; d <= 20; d++) {
+    const day = W.addBusinessDays(WED_AM, d).getDay();
+    assert.ok(day !== 0 && day !== 6, `${d} business days landed on a weekend`);
+  }
+});
+
+/* ── Saying so when the sheet does not cover it ──────────────────────────── */
+
+test('a run past the contract sheet ceiling is flagged, not silently quoted', () => {
+  /* Anchorfish quotes 7-10 days up to 2,400 prints and says over 7,000 is by
+     quote. Past that the sheet promises nothing, so a date derived from it is
+     an extrapolation and the page has to say so. */
+  const normal = W.deliveryEstimate(WED_AM, { items: [line('Embroidery', 1000, 1600, 100)] });
+  const huge   = W.deliveryEstimate(WED_AM, { items: [line('Embroidery', 40000, 60000, 5000)] });
+  assert.strictEqual(normal.beyond_sheet, false);
+  assert.strictEqual(huge.beyond_sheet, true);
+});
+
+/* ── The wiring, where a correct rule can still be bypassed ──────────────── */
+
+test('the fee is re-derived from the lines, never trusted from the row', () => {
+  /* A quote saved as embroidery + rush, then edited to screen print, must stop
+     charging for the rush at the same moment it stops promising the date.
+     quoteTotals() calls rushFeeFor(q.rush_code, q.items) rather than reading a
+     stored dollar figure, which is what makes that true. */
+  assert.match(src, /const rush = rushFeeFor\(q\.rush_code, q\.items\);/,
+    'quoteTotals must derive the rush from the CURRENT lines');
+  assert.doesNotMatch(src, /rush_amount|rush_fee\s+NUMERIC/,
+    'storing the dollars would freeze yesterday figure against today lines');
+});
+
+test('rush is inside the subtotal, so it is discounted and taxed', () => {
+  /* Added after tax it would be untaxed revenue the shop still owes tax on,
+     and a whole-job discount would not reach it. */
+  assert.match(src, /const subtotal = round2\(lines \+ rush\);/,
+    'rush belongs in the subtotal the discount and tax are computed from');
+});
+
+test('the save path validates the posted code against the job', () => {
+  /* The form only offers rush when it applies, but the form is not the only
+     way to reach the route, and the stored code is what every later total
+     re-reads. */
+  assert.match(src, /rushAvailable\(items\) && rushOption\(one\(b\.rush_code\)\)\.pct/,
+    'an ineligible or unknown code must store as NULL');
+  assert.match(src, /rush_code=\$16/, 'an edit must be able to clear it too');
+});
+
+test('the quote form offers the tier and the customer page shows it', () => {
+  assert.match(src, /name="rush_code" id="rushsel"/, 'the admin form needs the selector');
+  assert.match(src, /rushSel\.disabled = !rushOk/,
+    'it must be visibly unavailable, not silently missing — otherwise the next ' +
+    'step is promising a rush over the phone');
+  assert.match(src, /RUSH_UNAVAILABLE/, 'and it must say why');
+  assert.match(src, /t\.rush > 0 \? `<tr>/, 'the customer must see what they were charged');
+});
+
+test('the browser prices rush the same way the server does', () => {
+  /* Two implementations of a money rule is two prices. The browser mirrors
+     rushFeeFor; these assertions are what catch one of them being changed. */
+  const browser = src.slice(src.indexOf('var rushSel'), src.indexOf('Mirrors quoteDiscount'));
+  assert.match(browser, /decoTotal \* \(rushTier\.pct\/100\)/,
+    'the browser must charge on the decoration too');
+  assert.match(browser, /HOLIDAY \? 2 : 1/, 'and double it in season, as the server does');
+  assert.match(browser, /rushOk\s+= decorated > 0 && embOnly/,
+    'and gate it on the same embroidery-only rule');
+});

--- a/tests/template-literal-leak.test.js
+++ b/tests/template-literal-leak.test.js
@@ -109,8 +109,11 @@ test('the totals SPLIT the subtotal for screens rather than adding to it', () =>
      OUT of the subtotal. A row that also added would overstate the job by its
      own value — $140 on a 4-screen job — and it would be the customer-facing
      number that was wrong. */
-  assert.match(src, /getElementById\('goods'\)\.textContent = m2\(Math\.round\(\(sub - scrTotal\)/,
-    'the garments-and-printing row must be sub MINUS screens');
+  /* Rush is subtracted here too, for a different reason: it ADDS to the
+     subtotal from its own row, so leaving it in `goods` would double-count it
+     and the three rows would stop adding up to the subtotal they explain. */
+  assert.match(src, /getElementById\('goods'\)\.textContent =\s*\n?\s*m2\(Math\.round\(\(sub - scrTotal - rushFee\)/,
+    'the garments-and-printing row must be sub MINUS screens and MINUS rush');
 
   assert.match(src, /id="goods"/, 'the split needs a goods row');
   assert.match(src, /id="scr"/, 'the split needs a screens row');


### PR DESCRIPTION
`RUSH_OPTIONS` offered "Rush — 2 business days" for a flat $15 on any job. None of it was wired up, so nothing shipped wrong — this builds it on what the contract sheets actually say.

**Screen print and DTF cannot be rushed at any price.** Both Anchorfish 2026 sheets state 7–10 business days and neither sells a rush service. Quoting a 2-day date on a screen-print job is a promise with nothing behind it.

**Embroidery can, because it is sewn in house.** That is also what Anchorfish's own embroidery sheet says of theirs: *"RUSH SERVICES AVAILABLE UPON APPROVAL — applies to embroidery only."* Their ladder (same-day 75%, 1-day 50%, 2-day 40%, 3-day 30%, 4-day 20%) is used as the shape; `JT_RUSH_PCT` overrides per tier.

### What this changes

- `rushAvailable()` fails closed — one screen-print line, or a line whose method is unknown, takes rush off the whole job. The customer gets one parcel, so the slowest line sets the date.
- The fee is a percentage of the **decoration**, not the line total (which would bill a rush premium on the customer's own garments) and not a flat fee (which gave away the whole of a 500-piece job's rush).
- `deliveryEstimate()` honours the 3:30pm CST cut-off **in the shop's timezone** — the server runs UTC, where 21:00 is 16:00 in Chicago and past it, while 18:00 is not.
- A rush tier adds the blanks lead time; standard does not, because the advertised 7–10 is door-to-door from the order date and already absorbs it. Adding it to standard moved every existing quote a week later, which is why it does not.
- `rushImprovesDate()` refuses a tier that lands no sooner than standard — at a 5-day blanks wait, a 4-day machine slot lands on day 9 against standard's day 7.
- Money: rush sits inside the subtotal, so a discount reaches it and tax is owed on it. `quoteTotals` derives it from the current lines, so editing a quote to screen print stops the charge at the same moment it stops promising the date.

### Verification

524 tests pass (25 new in `tests/rush-turnaround.test.js`, which lift the real functions rather than restating them). Existing quotes are unaffected: `rush_code` is NULL, so the subtotal and the standard estimate are byte-identical to before.

### One input still needed

Which tiers are sellable depends entirely on `JT_LT_BLANKS` (default 5). At 5, only the 1-, 2- and 3-day tiers survive on a fresh job. If the real S&S lead time to Chicago is shorter, set it and more tiers open up.

Full write-up in `docs/pricing-2026.md`.