### PR TITLE
Ship the current agent rules and gate engine

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -419,6 +419,21 @@ touches auth, billing, or a create/update/delete path, cover the failure
 cases too — an unauthenticated request, another user's id, and invalid input
 should each be tested to fail correctly.
 
+### Run the review yourself, do not wait to be asked
+
+These exist and they are yours to run. Nobody should have to type them for you.
+
+| Moment | Run |
+|---|---|
+| A batch of related work has landed | `/code-review` |
+| The diff touched auth, credentials, webhooks, uploads or billing | `/security-review` |
+| Before opening the pull request | the `pre-ship-check` skill |
+| A fix passed its tests but changes runtime behaviour | `/run` — exercise it for real |
+
+A review is reported, never applied in silence: a finding that is quietly fixed
+teaches nobody, and the pattern that produced it comes back. The gate still
+decides. This is only what reaches it already clean.
+
 ### Say what you did not do
 
 If part of the task is unfinished, blocked, or you are unsure it works, write


### PR DESCRIPTION
## What changed

Only the generated files: `AGENTS.md`, `CLAUDE.md`, and the vendored gate under
`.github/radar-gate/` with its workflow. No project code, and nothing else this
repo had uncommitted.

## Why

These are generated from the playbook and engine in `~/project-radar` and were
behind. `radar sync-agents --write` used to write them to disk and stop, so they
were regenerated often and delivered rarely — the engine went generations
without reaching any repo, and the checks that should have caught it read the
same working copy and reported everything current.

This pull request is opened by `radar sync-agents --write --deliver`, which
commits and pushes rather than leaving the files on somebody's Mac.

## Reviewing it

The `gate` check on this pull request is the new engine reviewing its own
delivery. Do not hand-edit anything under `.github/radar-gate/` or inside the
`radar-rules` markers in `AGENTS.md` — edit the playbook and re-run the sync.
