### PR TITLE
Write down the money that arrives outside the quote flow

### DIFF
--- a/server.js
+++ b/server.js
@@ -396,6 +396,55 @@ async function initDB() {
       created_at  TIMESTAMPTZ DEFAULT NOW()
     )`);
 
+  /* ── Money that arrived outside the quote flow ────────────────────────────
+     The design studio at design.jtees.net runs its own Stripe Checkout against
+     this same webhook, sending its ORDER NUMBER as client_reference_id. That
+     fails QUOTE_CODE_RE, so bankStripeSession correctly declines it — an order
+     is not a quote and has its own ledger. Alerting the shop closed the
+     silence, but an email is not a record: the money still appeared in no
+     table, no export, and no tax position. Sales tax is filed on receipts, so
+     revenue that exists only in an inbox understates the ST-1.
+
+     A separate table rather than a row in quote_payments, because quote_code
+     is NOT NULL there and syncPaidAmount() rolls that ledger up onto the
+     quote. A payment belonging to no quote cannot go in it without corrupting
+     the rollup that every other reader depends on.
+
+     tax_portion is NULLABLE and defaults to NULL, which means UNKNOWN — never
+     0. The studio holds its own tax detail; this side genuinely does not know
+     it. Writing 0 would assert no tax was collected, and that assertion would
+     flow straight into a filed return. NULL says "go and find out", and
+     taxPositionByMonth reports it as undetermined rather than quietly adding
+     nothing. */
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS unlinked_payments (
+      id             BIGSERIAL PRIMARY KEY,
+      amount         NUMERIC(10,2) NOT NULL,   -- signed; negative = refund
+      fee            NUMERIC(10,2) DEFAULT 0,
+      currency       TEXT NOT NULL DEFAULT 'usd',
+      channel        TEXT NOT NULL DEFAULT 'unknown', -- studio | unknown
+      order_ref      TEXT,               -- design studio order id, when it sent one
+      client_ref     TEXT,               -- whatever client_reference_id arrived as
+      kind           TEXT NOT NULL DEFAULT 'payment', -- payment | refund
+      source         TEXT NOT NULL DEFAULT 'stripe_webhook',
+      stripe_session TEXT,
+      stripe_pi      TEXT,
+      ext_ref        TEXT,               -- the Stripe object that makes this row unique
+      customer_email TEXT,
+      customer_name  TEXT,
+      reason         TEXT,               -- why it did not bank against a quote
+      tax_portion    NUMERIC(10,2),      -- NULL = UNKNOWN. Never write 0 to mean "none".
+      resolved_at    TIMESTAMPTZ,        -- set once the tax portion has been established
+      note           TEXT,
+      created_at     TIMESTAMPTZ DEFAULT NOW()
+    )`);
+  /* Same idempotency guarantee the quote ledger has, and for the same reason:
+     Stripe retries any non-2xx, and a retried payment must not become two. */
+  await pool.query(`CREATE UNIQUE INDEX IF NOT EXISTS unlinked_payments_extref_uniq
+                      ON unlinked_payments (ext_ref) WHERE ext_ref IS NOT NULL`);
+  await pool.query(`CREATE INDEX IF NOT EXISTS unlinked_payments_date_idx
+                      ON unlinked_payments (created_at)`);
+
   /* Backfill the tax portion for payments recorded before this column existed,
      apportioned by how much of the job that payment covered. */
   await pool.query(`
@@ -461,22 +510,55 @@ async function taxPositionByMonth(limit = 24) {
     `SELECT period, COALESCE(SUM(amount),0) AS remitted, MAX(paid_at) AS last_paid
        FROM tax_remittances GROUP BY 1`);
 
+  /* Money that arrived outside the quote flow. Its tax portion is usually
+     unknown on this side, so it is reported SEPARATELY rather than folded into
+     `collected`: a period carrying undetermined receipts is a period whose
+     ST-1 figure is a floor, not a total. Adding an unknown as zero would make
+     the number look finished when it is not. */
+  const { rows: unlinked } = await pool.query(
+    `SELECT to_char(date_trunc('month', created_at), 'YYYY-MM') AS period,
+            COALESCE(SUM(amount),0)                              AS gross,
+            COUNT(*)                                             AS payments,
+            COALESCE(SUM(tax_portion),0)                         AS tax_known,
+            COUNT(*) FILTER (WHERE tax_portion IS NULL)          AS tax_unknown
+       FROM unlinked_payments
+      GROUP BY 1`).catch(() => ({ rows: [] }));
+
+  const blank = (period) => ({
+    period, collected: 0, gross: 0, payments: 0, remitted: 0, last_paid: null,
+    unlinkedGross: 0, unlinkedPayments: 0, unlinkedTaxKnown: 0, unlinkedTaxUnknown: 0,
+  });
+
   const byPeriod = {};
   for (const r of collected) {
     byPeriod[r.period] = {
-      period: r.period, collected: round2(Number(r.collected)),
+      ...blank(r.period),
+      collected: round2(Number(r.collected)),
       gross: round2(Number(r.gross)), payments: Number(r.payments),
-      remitted: 0, last_paid: null,
     };
   }
   for (const r of remitted) {
-    byPeriod[r.period] ||= { period: r.period, collected: 0, gross: 0, payments: 0, remitted: 0, last_paid: null };
+    byPeriod[r.period] ||= blank(r.period);
     byPeriod[r.period].remitted = round2(Number(r.remitted));
     byPeriod[r.period].last_paid = r.last_paid;
   }
+  for (const r of unlinked) {
+    byPeriod[r.period] ||= blank(r.period);
+    byPeriod[r.period].unlinkedGross = round2(Number(r.gross));
+    byPeriod[r.period].unlinkedPayments = Number(r.payments);
+    byPeriod[r.period].unlinkedTaxKnown = round2(Number(r.tax_known));
+    byPeriod[r.period].unlinkedTaxUnknown = Number(r.tax_unknown);
+  }
 
   const list = Object.values(byPeriod)
-    .map((p) => ({ ...p, outstanding: round2(p.collected - p.remitted) }))
+    .map((p) => ({
+      ...p,
+      /* Tax known about this period: the quote ledger, plus whatever unlinked
+         tax has since been established by hand. */
+      outstanding: round2(p.collected + p.unlinkedTaxKnown - p.remitted),
+      // True while any receipt in the period still has no tax portion decided.
+      undetermined: p.unlinkedTaxUnknown > 0,
+    }))
     .sort((a, b) => (a.period < b.period ? 1 : -1))
     .slice(0, limit);
 
@@ -484,6 +566,11 @@ async function taxPositionByMonth(limit = 24) {
     months: list,
     // What must be sitting in the bank right now, across every unpaid period.
     setAside: round2(list.reduce((s, p) => s + p.outstanding, 0)),
+    /* Loud on purpose. A caller that files a return off `setAside` while this
+       is non-zero is filing a number known to be incomplete. */
+    undeterminedPayments: list.reduce((s, p) => s + p.unlinkedTaxUnknown, 0),
+    undeterminedGross: round2(list.reduce(
+      (s, p) => s + (p.unlinkedTaxUnknown > 0 ? p.unlinkedGross : 0), 0)),
   };
 }
 
@@ -1857,6 +1944,39 @@ app.post('/webhooks/clover', async (req, res) => {
       'SELECT * FROM submissions WHERE clover_order_id=$1',
       [payment.order?.id]
     );
+
+    /* Write the money down BEFORE deciding what it belongs to. `submissions`
+       has no amount column at all, so until now a Clover payment left no
+       figure anywhere in this database — it flipped a status to 'paid' and put
+       the number in an email. Worse, both the early returns below (no matching
+       submission, already marked paid) dropped the payment entirely.
+
+       Money that arrived is a fact independent of whether this side can match
+       it to a row, and sales tax is owed on it either way. Recorded on the
+       unlinked ledger, idempotent on the Clover payment id. */
+    await recordUnlinkedPayment(
+      { id: `clover:${paymentId}`,
+        amount_total: amount,               // Clover sends cents, as Stripe does
+        currency: payment.currency || 'usd',
+        client_reference_id: payment.order?.id || null,
+        payment_intent: null,
+        metadata: {},
+        customer_details: { email: rows[0]?.email || null, name: rows[0]?.name || null } },
+      rows.length ? 'clover payment against a website enquiry' : 'clover payment with no matching enquiry',
+      { channel: 'clover', source: 'clover_webhook',
+        extRef: `clover:${paymentId}`,
+        note: payment.order?.id ? `Clover order ${payment.order.id}` : null },
+    ).catch((e) => {
+      /* Swallowed deliberately, unlike the Stripe path: this handler already
+         sent 200 at the top, so there is no retry left to earn by throwing —
+         only an unhandled rejection. But a payment that failed to record is
+         exactly the thing nobody finds out about later, so it goes in the
+         error table that gets digested to the shop rather than a log line. */
+      console.error('clover payment not recorded:', e.message);
+      recordError('clover-payment-unrecorded', e.message,
+        `payment ${paymentId}, order ${payment.order?.id || '?'}, ${money((amount || 0) / 100)}`)
+        .catch(() => {});
+    });
 
     if (!rows.length) return;
     const sub = rows[0];
@@ -7135,6 +7255,53 @@ async function sendErrorDigest() {
   return `${total} error(s) reported`;
 }
 
+/**
+ * Record a payment Stripe took that the quote ledger cannot claim.
+ *
+ * Unlike the alert below, this one DOES throw. A failed write here means money
+ * that arrived is in no table, and the only mechanism that will try again is
+ * Stripe's own retry — which only happens if the webhook returns non-2xx. An
+ * alert may be swallowed because a lost email costs a notification; a lost
+ * payment costs a wrong tax return.
+ *
+ * The gross is recorded, not a net. The 4% surcharge split in bankStripeSession
+ * is a convention of the quote checkout, and the studio's checkout is not
+ * obliged to share it — dividing by 1.04 here would invent a fee that may not
+ * exist and understate revenue. What Stripe says was charged is the one fact
+ * available, so that is what is stored.
+ */
+async function recordUnlinkedPayment(session, reason, opts = {}) {
+  const gross = round2((session.amount_total || 0) / 100);
+  if (!(gross > 0) && !opts.allowZero) return { ok: false, reason: 'no amount' };
+
+  const orderRef = String(session.metadata?.order_id || '').trim() || null;
+  const clientRef = String(session.client_reference_id || '').trim() || null;
+  const pi = typeof session.payment_intent === 'string' ? session.payment_intent : null;
+  const extRef = opts.extRef || session.id || pi;
+
+  try {
+    await pool.query(
+      `INSERT INTO unlinked_payments
+         (amount, fee, currency, channel, order_ref, client_ref, kind, source,
+          stripe_session, stripe_pi, ext_ref, customer_email, customer_name, reason, note)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)`,
+      [round2(opts.amount ?? gross), round2(opts.fee || 0),
+       String(session.currency || 'usd').toLowerCase(),
+       opts.channel || (orderRef ? 'studio' : 'unknown'),
+       orderRef, clientRef,
+       opts.kind || 'payment', opts.source || 'stripe_webhook',
+       session.id || null, pi, extRef,
+       session.customer_details?.email || null,
+       session.customer_details?.name || null,
+       reason || null, opts.note || null]);
+  } catch (err) {
+    // 23505 = unique_violation on ext_ref. The other handler got here first.
+    if (err.code === '23505') return { ok: true, duplicate: true };
+    throw err;
+  }
+  return { ok: true, duplicate: false, amount: round2(opts.amount ?? gross) };
+}
+
 /* A payment Stripe took that the quote ledger did not claim. Never throws —
    an alert must not fail a webhook and make Stripe retry a settled payment. */
 async function alertUnbankedPayment(session, reason) {
@@ -7406,7 +7573,18 @@ async function handleStripeEvent(event) {
            ledger. Saying nothing is not. Tell the shop, and hand over the
            Stripe receipt URL so a customer asking "where is my receipt" can be
            answered from the email rather than from the dashboard. */
-        if (!out.ok && !out.duplicate) await alertUnbankedPayment(obj, out.reason);
+        if (!out.ok && !out.duplicate) {
+          /* Record first, alert second. The alert closed the silence; it did
+             not close the hole. An email is not a record — the money still
+             reached no table, no export and no tax position, and sales tax is
+             filed on receipts. Writing the row first also means a Stripe retry
+             hits the ext_ref unique index and returns duplicate, which is now
+             what suppresses a second alert. Previously `out.duplicate` only
+             described the quote ledger, so a retried studio payment re-alerted
+             every time. */
+          const kept = await recordUnlinkedPayment(obj, out.reason);
+          if (!kept.duplicate) await alertUnbankedPayment(obj, out.reason);
+        }
         break;
       }
 
@@ -7433,7 +7611,37 @@ async function handleStripeEvent(event) {
              FROM quote_payments WHERE stripe_pi = $1 AND amount > 0
             GROUP BY quote_code`, [pi]);
         if (!rows.length) {
-          console.warn(`Stripe refund ${obj.id} — no matching quote for PI ${pi}`);
+          /* No quote claimed the original payment — so it is one of the
+             unlinked ones, and the refund has to come back out of the same
+             place or the books keep money that was returned. Recorded as a
+             negative row, matching how the quote ledger expresses a refund. */
+          const { rows: unl } = await pool.query(
+            `SELECT id, order_ref, client_ref, customer_email, customer_name
+               FROM unlinked_payments WHERE stripe_pi = $1 AND amount > 0
+              ORDER BY created_at LIMIT 1`, [pi]);
+          if (!unl.length) {
+            console.warn(`Stripe refund ${obj.id} — no matching quote or unlinked payment for PI ${pi}`);
+            break;
+          }
+          const u = unl[0];
+          const back = await recordUnlinkedPayment(
+            { id: null, payment_intent: pi, amount_total: 0,
+              currency: obj.currency,
+              client_reference_id: u.client_ref,
+              metadata: { order_id: u.order_ref },
+              customer_details: { email: u.customer_email, name: u.customer_name } },
+            'refund of an unlinked payment',
+            { amount: -refunded, kind: 'refund', allowZero: true,
+              extRef: obj.id + ':' + obj.amount_refunded,
+              note: `Refund of ${money(refunded)} via Stripe` });
+          if (!back.duplicate) {
+            console.log(`Stripe refund for unlinked payment ${u.order_ref || pi}: -${money(refunded)}`);
+            await alertShop(`↩️ Refund — ${u.order_ref ? `design studio order #${u.order_ref}` : 'unlinked payment'}, ${money(refunded)}`,
+              `<p>A refund of <b>${money(refunded)}</b> was issued on a payment that belongs to
+                  no quote${u.order_ref ? ` (design studio order #${escEmail(u.order_ref)})` : ''}.</p>
+               <p style="color:#6b7280">Recorded against the unlinked ledger so the books do not
+                  keep money that went back.</p>`);
+          }
           break;
         }
         const code = rows[0].quote_code;
@@ -8443,17 +8651,48 @@ app.get('/exports', requireAdmin, async (_req, res) => {
              FROM quote_payments GROUP BY 1
          ) x GROUP BY m ORDER BY m DESC`);
 
-    const rows = months.map((m) => `
+    /* Asked separately, and allowed to fail, so a deploy that races the
+       migration loses one column rather than the whole records page. */
+    const { rows: unl } = await pool.query(
+      `SELECT to_char(date_trunc('month', created_at), 'YYYY-MM') AS ym,
+              count(*) AS n, COALESCE(SUM(amount),0) AS amt,
+              count(*) FILTER (WHERE tax_portion IS NULL) AS unknown_tax
+         FROM unlinked_payments GROUP BY 1`).catch(() => ({ rows: [] }));
+    const unlByMonth = Object.fromEntries(unl.map((u) => [u.ym, u]));
+
+    /* A month whose only revenue came through the design studio would not
+       appear at all otherwise — the same lie as an empty export. */
+    const seen = new Set(months.map((m) => m.ym));
+    for (const u of unl) {
+      if (seen.has(u.ym)) continue;
+      const [y, mo] = u.ym.split('-');
+      months.push({
+        ym: u.ym, quotes: 0, payments: 0, collected: 0,
+        label: new Date(Number(y), Number(mo) - 1, 1)
+          .toLocaleDateString('en-US', { month: 'short', year: 'numeric' }),
+      });
+    }
+    months.sort((a, b) => (a.ym < b.ym ? 1 : -1));
+
+    const rows = months.map((m) => {
+      const u = unlByMonth[m.ym];
+      return `
       <tr>
         <td style="padding:8px 4px"><b>${escEmail(m.label)}</b></td>
         <td class="num" style="padding:8px 4px">${m.quotes}</td>
         <td class="num" style="padding:8px 4px">${m.payments}</td>
         <td class="num" style="padding:8px 4px">${money(m.collected)}</td>
+        <td class="num" style="padding:8px 4px">${
+          u ? `<span title="Money that belongs to no quote — mostly design studio orders"
+                 style="color:${Number(u.unknown_tax) > 0 ? '#b45309' : '#334155'}">${money(u.amt)}${
+                 Number(u.unknown_tax) > 0 ? ' *' : ''}</span>` : '<span class="muted">—</span>'}</td>
         <td style="padding:8px 4px;text-align:right;white-space:nowrap">
           <a href="/exports/quotes.csv?month=${m.ym}">quotes</a> &middot;
           <a href="/exports/payments.csv?month=${m.ym}">payments</a> &middot;
-          <a href="/exports/expenses.csv?month=${m.ym}">expenses</a></td>
-      </tr>`).join('');
+          <a href="/exports/expenses.csv?month=${m.ym}">expenses</a>${
+          u ? ` &middot; <a href="/exports/unlinked.csv?month=${m.ym}">unlinked</a>` : ''}</td>
+      </tr>`;
+    }).join('');
 
     res.send(adminPage('Records', `<h1>Records</h1>
       <div class="sub">Download a month, keep it somewhere that is not this app</div>
@@ -8477,15 +8716,21 @@ app.get('/exports', requireAdmin, async (_req, res) => {
             <th class="num" style="padding:6px 4px">Quotes</th>
             <th class="num" style="padding:6px 4px">Payments</th>
             <th class="num" style="padding:6px 4px">Collected</th>
+            <th class="num" style="padding:6px 4px">Outside quotes</th>
             <th style="padding:6px 4px;text-align:right">Download</th>
           </tr></thead>
-          <tbody>${rows || '<tr><td colspan="5" class="muted" style="padding:10px 4px">Nothing recorded yet.</td></tr>'}</tbody>
+          <tbody>${rows || '<tr><td colspan="6" class="muted" style="padding:10px 4px">Nothing recorded yet.</td></tr>'}</tbody>
         </table>
         <p class="muted" style="margin-top:12px;font-size:13px">Everything, all months:
           <a href="/exports/quotes.csv">quotes</a> &middot;
           <a href="/exports/payments.csv">payments</a> &middot;
           <a href="/exports/expenses.csv">expenses</a> &middot;
+          <a href="/exports/unlinked.csv">outside quotes</a> &middot;
           <a href="/tax.csv">sales tax detail</a></p>
+        <p class="muted" style="margin-top:6px;font-size:12px"><b>Outside quotes</b> is money Stripe took
+          that no quote claimed — mostly design studio orders, which keep their own ledger on
+          design.jtees.net. A <b>*</b> means the sales tax inside some of it has not been worked out
+          yet, so that month's tax figure is a floor rather than a total.</p>
       </div>`, 'money'));
   } catch (err) {
     console.error('exports page failed:', err.message);
@@ -8571,28 +8816,83 @@ app.get('/exports/expenses.csv', requireAdmin, async (req, res) => {
 
 app.get('/tax.csv', requireAdmin, async (req, res) => {
   try {
+    /* The STORED tax portion, not a fresh calculation from the quote.
+       recordPayment() works it out when the money lands and writes it on the
+       row precisely so that editing the quote afterwards cannot rewrite what
+       was collected in a period already reported. Recomputing here re-derived
+       it from today's quote total, so this file could disagree with the tax
+       page — and the two are meant to be the same number filed twice. */
     const { rows } = await pool.query(
       `SELECT p.created_at, p.quote_code, q.name, q.subtotal, q.tax, q.total,
-              p.amount, p.method, p.kind,
-              CASE WHEN q.total > 0 THEN round(q.tax * (p.amount / q.total), 2) ELSE 0 END AS tax_portion
+              p.amount, p.method, p.kind, p.tax_portion
          FROM quote_payments p JOIN quotes q ON q.code = p.quote_code
         ORDER BY p.created_at`);
-    const esc = (v) => {
-      const s = String(v == null ? '' : v);
-      return /[",\n]/.test(s) ? '"' + s.replace(/"/g, '""') + '"' : s;
-    };
-    const head = ['date','quote','customer','job_subtotal','job_tax','job_total',
-                  'payment','method','kind','tax_portion_of_payment'];
-    const body = rows.map(r => [
-      new Date(r.created_at).toISOString().slice(0, 10), r.quote_code, r.name,
-      r.subtotal, r.tax, r.total, r.amount, r.method, r.kind, r.tax_portion,
-    ].map(esc).join(','));
-    res.set('Content-Type', 'text/csv; charset=utf-8');
-    res.set('Content-Disposition', `attachment; filename="jtees-sales-tax-${new Date().toISOString().slice(0,10)}.csv"`);
-    res.set('Cache-Control', 'no-store');
-    res.send([head.join(','), ...body].join('\n'));
+
+    /* Receipts from the design studio and anything else that arrived outside
+       the quote flow. They belong in this file because the ST-1 is filed on
+       everything taken in, not on everything that happened to have a quote.
+       An unknown tax portion is left BLANK rather than written as 0 — a blank
+       cell asks the bookkeeper a question, a zero answers it wrongly. */
+    const { rows: unlinked } = await pool.query(
+      `SELECT created_at, order_ref, client_ref, stripe_pi, customer_name,
+              amount, kind, tax_portion, channel
+         FROM unlinked_payments ORDER BY created_at`).catch(() => ({ rows: [] }));
+
+    const day = (d) => new Date(d).toISOString().slice(0, 10);
+    const all = [
+      ...rows.map((r) => ({
+        at: r.created_at,
+        cells: [day(r.created_at), r.quote_code, r.name, r.subtotal, r.tax,
+                r.total, r.amount, r.method, r.kind, r.tax_portion, 'quote'],
+      })),
+      ...unlinked.map((u) => ({
+        at: u.created_at,
+        cells: [day(u.created_at),
+                u.order_ref ? `studio #${u.order_ref}` : (u.client_ref || u.stripe_pi || ''),
+                u.customer_name || '', '', '', '', u.amount, 'card', u.kind,
+                u.tax_portion == null ? '' : u.tax_portion, u.channel],
+      })),
+    ].sort((a, b) => new Date(a.at) - new Date(b.at));
+
+    sendCsv(res, `jtees-sales-tax-${new Date().toISOString().slice(0, 10)}.csv`,
+      ['date', 'quote', 'customer', 'job_subtotal', 'job_tax', 'job_total',
+       'payment', 'method', 'kind', 'tax_portion_of_payment', 'source'],
+      all.map((r) => r.cells));
   } catch (err) {
     console.error('tax csv failed:', err.message);
+    res.status(500).send('error');
+  }
+});
+
+/* Every receipt that belongs to no quote, in full. The tax file above carries
+   these too, but flattened to the columns a quote payment has; this one keeps
+   the Stripe identifiers needed to go and find the order in the studio's own
+   records and settle what tax it carried. */
+app.get('/exports/unlinked.csv', requireAdmin, async (req, res) => {
+  const r = monthRange(req.query.month);
+  try {
+    const { rows } = await pool.query(
+      `SELECT created_at, channel, order_ref, client_ref, amount, fee, currency,
+              kind, source, stripe_session, stripe_pi, customer_name,
+              customer_email, reason, tax_portion, resolved_at, note
+         FROM unlinked_payments
+        ${r ? 'WHERE created_at >= $1 AND created_at < $2' : ''}
+        ORDER BY created_at`, r ? [r.from, r.to] : []);
+    sendCsv(res, `jtees-unlinked-${r ? r.label : 'all'}.csv`,
+      ['date', 'channel', 'order_ref', 'client_ref', 'amount', 'card_fee',
+       'currency', 'kind', 'source', 'stripe_session', 'stripe_payment_intent',
+       'customer', 'email', 'why_unlinked', 'tax_portion', 'tax_settled_at', 'note'],
+      rows.map((u) => [
+        new Date(u.created_at).toISOString().slice(0, 10), u.channel,
+        u.order_ref || '', u.client_ref || '', u.amount, u.fee, u.currency,
+        u.kind, u.source, u.stripe_session || '', u.stripe_pi || '',
+        u.customer_name || '', u.customer_email || '', u.reason || '',
+        // Blank, not zero: nobody has decided this yet.
+        u.tax_portion == null ? '' : u.tax_portion,
+        u.resolved_at ? new Date(u.resolved_at).toISOString().slice(0, 10) : '',
+        u.note || '']));
+  } catch (err) {
+    console.error('unlinked csv failed:', err.message);
     res.status(500).send('error');
   }
 });

--- a/server.js
+++ b/server.js
@@ -7279,12 +7279,36 @@ async function recordUnlinkedPayment(session, reason, opts = {}) {
   const pi = typeof session.payment_intent === 'string' ? session.payment_intent : null;
   const extRef = opts.extRef || session.id || pi;
 
+  /* The tax inside this payment, if the payer told us.
+     The design studio computes sales tax at checkout (subtotal x rate, tax on
+     the goods only, not on shipping) and used to fold it into one opaque
+     Stripe line item — so the money arrived with no way to tell revenue from
+     tax held for the state. It now stamps `jt_tax` on the session metadata,
+     which travels with the payment and needs no access to its database.
+
+     Left NULL when absent rather than 0: an older order, or a payment from
+     somewhere else entirely, genuinely has an unknown tax portion, and 0 would
+     assert there was none. A negative row (a refund) carries its tax back out
+     in proportion, the way the quote ledger does. */
+  let taxPortion = null;
+  if (opts.taxPortion !== undefined) {
+    taxPortion = opts.taxPortion;
+  } else {
+    const stamped = Number(session.metadata?.jt_tax);
+    if (Number.isFinite(stamped)) {
+      const amt = round2(opts.amount ?? gross);
+      taxPortion = round2(amt < 0 && gross > 0 ? -Math.abs(stamped) : stamped);
+    }
+  }
+
   try {
     await pool.query(
       `INSERT INTO unlinked_payments
          (amount, fee, currency, channel, order_ref, client_ref, kind, source,
-          stripe_session, stripe_pi, ext_ref, customer_email, customer_name, reason, note)
-       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)`,
+          stripe_session, stripe_pi, ext_ref, customer_email, customer_name, reason, note,
+          tax_portion, resolved_at)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,
+               $16, CASE WHEN $16::numeric IS NULL THEN NULL ELSE NOW() END)`,
       [round2(opts.amount ?? gross), round2(opts.fee || 0),
        String(session.currency || 'usd').toLowerCase(),
        opts.channel || (orderRef ? 'studio' : 'unknown'),
@@ -7293,7 +7317,7 @@ async function recordUnlinkedPayment(session, reason, opts = {}) {
        session.id || null, pi, extRef,
        session.customer_details?.email || null,
        session.customer_details?.name || null,
-       reason || null, opts.note || null]);
+       reason || null, opts.note || null, taxPortion]);
   } catch (err) {
     // 23505 = unique_violation on ext_ref. The other handler got here first.
     if (err.code === '23505') return { ok: true, duplicate: true };

--- a/server.js
+++ b/server.js
@@ -8256,6 +8256,16 @@ app.get('/books', requireAdmin, async (req, res) => {
         WHERE EXTRACT(YEAR FROM paid_at) = $1`, [year]);
     const pos = await taxPositionByMonth(60);
 
+    /* Receipts still carrying an unknown tax portion, oldest first — the ones
+       holding a period open. Guarded like every other read of this table so a
+       deploy racing the migration loses one card rather than the whole page. */
+    const { rows: unsettled } = await pool.query(
+      `SELECT id, created_at, amount, channel, order_ref, client_ref,
+              stripe_pi, customer_name, reason, kind
+         FROM unlinked_payments
+        WHERE tax_portion IS NULL
+        ORDER BY created_at LIMIT 50`).catch(() => ({ rows: [] }));
+
     /* Overheads by month, and the recent list for the register below. */
     const { rows: expMonths } = await pool.query(
       `SELECT to_char(date_trunc('month', spent_on), 'YYYY-MM') AS period,
@@ -8547,7 +8557,48 @@ app.get('/books', requireAdmin, async (req, res) => {
           <a href="/tax.csv" style="color:#1848B8">Download the payment-level detail</a>,
           or <a href="/exports" style="color:#1848B8">keep a month's records</a>.
         </div>
-      </div>`, 'money'));
+      </div>
+
+      ${unsettled.length ? `
+      <div class="card" style="margin-top:14px">
+        <h2 style="margin:0 0 4px;font-size:16px">Receipts with the tax still to work out</h2>
+        <p class="muted" style="font-size:12px;margin:0 0 10px">
+          Money that arrived outside a quote, so this side never learned what tax it carried.
+          Every period holding one of these reports a <b>floor, not a total</b> — the figures above
+          are incomplete until they are settled. Leave the box empty to put one back to unknown;
+          type <b>0</b> to say it genuinely carried no tax. Those are different answers.
+        </p>
+        <table style="width:100%;border-collapse:collapse;font-size:13px">
+          <tr style="text-align:left;color:#6b7280;font-size:11px;text-transform:uppercase">
+            <th style="padding:6px 4px">Arrived</th>
+            <th style="padding:6px 4px">What</th>
+            <th class="num" style="padding:6px 4px">Payment</th>
+            <th style="padding:6px 4px">Sales tax in it</th>
+          </tr>
+          ${unsettled.map((u) => `
+          <tr style="border-top:1px solid #e5e7eb">
+            <td style="padding:7px 4px;white-space:nowrap">${new Date(u.created_at).toISOString().slice(0, 10)}</td>
+            <td style="padding:7px 4px">
+              ${u.order_ref ? `design studio order #${escEmail(String(u.order_ref))}`
+                : u.client_ref ? escEmail(String(u.client_ref))
+                : `<span class="muted">${escEmail(String(u.stripe_pi || 'unknown'))}</span>`}
+              ${u.customer_name ? `<span class="muted"> — ${escEmail(String(u.customer_name))}</span>` : ''}
+              ${u.kind === 'refund' ? '<span style="color:#b45309"> (refund)</span>' : ''}
+              <div class="muted" style="font-size:11px">${escEmail(String(u.reason || ''))}</div>
+            </td>
+            <td class="num" style="padding:7px 4px;font-variant-numeric:tabular-nums">${money(u.amount)}</td>
+            <td style="padding:7px 4px">
+              <form method="post" action="/unlinked/${u.id}/tax" style="display:flex;gap:6px;margin:0">
+                <input type="hidden" name="back" value="/books?year=${year}">
+                <input name="tax" type="number" step="0.01" inputmode="decimal"
+                       placeholder="unknown"
+                       style="width:96px;padding:5px 7px;font-size:13px">
+                <button class="btn" style="padding:5px 12px;font-size:13px">Settle</button>
+              </form>
+            </td>
+          </tr>`).join('')}
+        </table>
+      </div>` : ''}`, 'money'));
   } catch (err) {
     console.error('books failed:', err.message);
     res.status(500).send('error');
@@ -12589,7 +12640,12 @@ async function taxMonthlyCheck() {
     const pos = await taxPositionByMonth(36);
     const row = pos.months.find((m) => m.period === period);
     const outstanding = row ? row.outstanding : 0;
-    if (outstanding <= 0) return;    // nothing collected, or already remitted
+    /* Receipts in this period whose tax nobody has worked out. A month can owe
+       nothing on paper and still be unfileable, and that is precisely the month
+       that needs the email — staying silent because `outstanding` is zero hides
+       the one case where the figure is not a total but a floor. */
+    const undetermined = row ? row.unlinkedTaxUnknown : 0;
+    if (outstanding <= 0 && !undetermined) return;  // nothing collected, or already remitted
 
     await pool.query(`CREATE TABLE IF NOT EXISTS jt_tax_reminders (
       period TEXT NOT NULL, kind TEXT NOT NULL, sent_at TIMESTAMPTZ DEFAULT NOW(),
@@ -12599,11 +12655,13 @@ async function taxMonthlyCheck() {
        ON CONFLICT DO NOTHING RETURNING period`, [period, kind]);
     if (!claim.rowCount) return;
 
-    const subject = kind === 'close'
-      ? `🧾 ${periodLabel(period)} closed — set aside ${money(outstanding)} sales tax`
-      : kind === 'due-soon'
-        ? `🧾 ${money(outstanding)} sales tax due the 20th (${periodLabel(period)})`
-        : `⏰ Sales tax due TOMORROW — ${money(outstanding)} for ${periodLabel(period)}`;
+    const subject = (outstanding <= 0 && undetermined)
+      ? `⚠️ ${periodLabel(period)} cannot be filed yet — ${undetermined} receipt(s) with tax unworked`
+      : kind === 'close'
+        ? `🧾 ${periodLabel(period)} closed — set aside ${money(outstanding)} sales tax`
+        : kind === 'due-soon'
+          ? `🧾 ${money(outstanding)} sales tax due the 20th (${periodLabel(period)})`
+          : `⏰ Sales tax due TOMORROW — ${money(outstanding)} for ${periodLabel(period)}`;
 
     const others = pos.months.filter((m) => m.period !== period && m.outstanding > 0);
 
@@ -12615,13 +12673,24 @@ async function taxMonthlyCheck() {
            : '<b style="color:#b91c1c">Due tomorrow.</b> A late ST-1 costs a penalty plus interest.'}</p>
 
        <table style="width:100%;border-collapse:collapse;font-size:14px">
-         <tr><td style="padding:8px 0;color:#6b7280">Collected in ${periodLabel(period)}</td>
+         <tr><td style="padding:8px 0;color:#6b7280">Collected on quotes</td>
              <td style="padding:8px 0;text-align:right;font-variant-numeric:tabular-nums">${money(row.collected)}</td></tr>
+         ${/* Its own line, or the three figures below do not add up: `outstanding`
+              has included settled unlinked tax since the studio ledger existed,
+              while this table only ever showed the quote ledger. */
+           row.unlinkedTaxKnown > 0 ? `<tr><td style="padding:0 0 8px;color:#6b7280">Collected outside quotes</td>
+             <td style="padding:0 0 8px;text-align:right;font-variant-numeric:tabular-nums">${money(row.unlinkedTaxKnown)}</td></tr>` : ''}
          ${row.remitted > 0 ? `<tr><td style="padding:0 0 8px;color:#6b7280">Already remitted</td>
              <td style="padding:0 0 8px;text-align:right;font-variant-numeric:tabular-nums">−${money(row.remitted)}</td></tr>` : ''}
          <tr><td style="padding:10px 0;border-top:2px solid #111827;font-weight:700">To remit</td>
              <td style="padding:10px 0;border-top:2px solid #111827;text-align:right;font-weight:700;font-size:20px;font-variant-numeric:tabular-nums">${money(outstanding)}</td></tr>
        </table>
+
+       ${undetermined ? `<p style="background:#fef3c7;border:1px solid #fcd34d;border-radius:8px;
+            padding:10px 12px;color:#78350f;font-size:13px;margin-top:14px">
+         <b>${undetermined} receipt(s) totalling ${money(row.unlinkedGross)}</b> have no tax portion
+         worked out, so the figure above is a floor rather than a total.
+         <a href="${PUBLIC_BASE_URL}/books" style="color:#78350f">Settle them</a> before filing.</p>` : ''}
 
        ${others.length ? `<p style="color:#b45309;font-size:13px;margin-top:14px">
          <b>Also unpaid:</b> ${others.map((m) => `${periodLabel(m.period)} ${money(m.outstanding)}`).join(' · ')}<br>
@@ -12748,6 +12817,69 @@ app.post('/tax/remit', requireAdmin, async (req, res) => {
     console.error('tax remit failed:', err.message);
   }
   res.redirect('/quotes');
+});
+
+/* Settle the tax portion of a payment that arrived outside the quote flow.
+ *
+ * Until this existed, `tax_portion` had exactly one writer — the `jt_tax` stamp
+ * the studio puts on its Stripe session — so anything that arrived without one
+ * was UNKNOWN forever. `resolved_at` was documented as "set once the tax portion
+ * has been established" and exported as `tax_settled_at`, with nothing able to
+ * establish it. Every Clover payment lands with empty metadata, and every studio
+ * order placed before the stamp shipped is in the same position, so
+ * `undeterminedPayments` was permanently non-zero: a warning that is always on
+ * is a warning nobody reads, and it would have sat there next to the one figure
+ * it exists to qualify.
+ *
+ * Zero is a legitimate answer here, and a different one from unknown — a payment
+ * really can carry no tax. So an empty box clears the figure back to UNKNOWN and
+ * an explicit 0 settles it at zero, which is why this cannot be a plain number
+ * input that treats blank as nothing.
+ */
+app.post('/unlinked/:id/tax', requireAdmin, async (req, res) => {
+  const id = parseInt(req.params.id, 10);
+  const b = req.body || {};
+  const back = String(b.back || '/books');
+  if (!Number.isFinite(id)) return res.redirect('/books');
+
+  /* Blank means "put it back to unknown", which is not the same as 0. */
+  const raw = String(b.tax ?? '').trim();
+  let tax = null;
+  if (raw !== '') {
+    const n = round2(Number(raw));
+    if (!Number.isFinite(n)) return res.redirect(back);
+    tax = n;
+  }
+
+  try {
+    const { rows } = await pool.query(
+      `SELECT amount FROM unlinked_payments WHERE id = $1`, [id]);
+    if (!rows.length) return res.redirect(back);
+
+    /* The tax cannot exceed the payment, and it has to share the payment's sign:
+       a refund carries its tax back OUT. Getting this wrong writes a figure that
+       makes a period's total tax larger than its receipts, which is the kind of
+       number that survives all the way onto a filed return. */
+    const amount = round2(Number(rows[0].amount) || 0);
+    if (tax !== null) {
+      if (amount < 0 && tax > 0) tax = -tax;
+      if (amount > 0 && tax < 0) tax = Math.abs(tax);
+      if (Math.abs(tax) > Math.abs(amount)) {
+        console.warn(`unlinked tax rejected: ${money(tax)} exceeds payment ${money(amount)}`);
+        return res.redirect(back);
+      }
+    }
+
+    await pool.query(
+      `UPDATE unlinked_payments
+          SET tax_portion = $2,
+              resolved_at = CASE WHEN $2::numeric IS NULL THEN NULL ELSE NOW() END
+        WHERE id = $1`, [id, tax]);
+    console.log(`unlinked payment ${id} tax ${tax === null ? 'cleared to unknown' : money(tax)}`);
+  } catch (err) {
+    console.error('unlinked tax update failed:', err.message);
+  }
+  res.redirect(back);
 });
 
 /* Send review requests that have come due. Runs inside the existing hourly

--- a/server.js
+++ b/server.js
@@ -7297,7 +7297,11 @@ async function recordUnlinkedPayment(session, reason, opts = {}) {
     const stamped = Number(session.metadata?.jt_tax);
     if (Number.isFinite(stamped)) {
       const amt = round2(opts.amount ?? gross);
-      taxPortion = round2(amt < 0 && gross > 0 ? -Math.abs(stamped) : stamped);
+      /* `amt < 0` alone. The refund caller passes amount_total: 0 with
+         allowZero, so gross is always 0 there and the old `&& gross > 0`
+         made this unreachable — a stamped refund would have stored a
+         POSITIVE tax on a negative row. */
+      taxPortion = round2(amt < 0 ? -Math.abs(stamped) : stamped);
     }
   }
 
@@ -7597,7 +7601,19 @@ async function handleStripeEvent(event) {
            ledger. Saying nothing is not. Tell the shop, and hand over the
            Stripe receipt URL so a customer asking "where is my receipt" can be
            answered from the email rather than from the dashboard. */
-        if (!out.ok && !out.duplicate) {
+        /* Only money that belongs to NO QUOTE. `not paid` is a different
+           animal: bankStripeSession checks the quote code BEFORE the payment
+           status, so a delayed method on a real quote — Klarna, Cash App,
+           Affirm and Afterpay are all live on this account, and ACH is one
+           Dashboard toggle away — completes `unpaid`, lands here, and gets
+           written to the unlinked ledger. Moments later
+           async_payment_succeeded banks the same session to quote_payments and
+           the money is counted in both: taxPositionByMonth adds `gross` and
+           `unlinkedGross` separately, and /tax.csv emits two rows. If the
+           payment instead FAILS, the unlinked row records a receipt that never
+           arrived. Neither is money that has no quote, so neither belongs here. */
+        const noQuote = out.reason === 'no quote code' || out.reason === 'unknown quote';
+        if (!out.ok && !out.duplicate && noQuote) {
           /* Record first, alert second. The alert closed the silence; it did
              not close the hole. An email is not a record — the money still
              reached no table, no export and no tax position, and sales tax is
@@ -7640,7 +7656,8 @@ async function handleStripeEvent(event) {
              place or the books keep money that was returned. Recorded as a
              negative row, matching how the quote ledger expresses a refund. */
           const { rows: unl } = await pool.query(
-            `SELECT id, order_ref, client_ref, customer_email, customer_name
+            `SELECT id, order_ref, client_ref, customer_email, customer_name,
+                    amount, tax_portion
                FROM unlinked_payments WHERE stripe_pi = $1 AND amount > 0
               ORDER BY created_at LIMIT 1`, [pi]);
           if (!unl.length) {
@@ -7648,6 +7665,17 @@ async function handleStripeEvent(event) {
             break;
           }
           const u = unl[0];
+          /* Carry the tax back out in proportion, the way the quote ledger
+             does. Two things go wrong without it: the period keeps the
+             refunded tax as still owed, and the NULL on the negative row makes
+             COUNT(*) FILTER (tax_portion IS NULL) non-zero — so a fully
+             reconciled month flips to `undetermined` permanently the moment
+             any refund is issued. A tax that was never known stays NULL. */
+          const origAmt = round2(Number(u.amount) || 0);
+          const origTax = u.tax_portion == null ? null : round2(Number(u.tax_portion));
+          const backTax = (origTax === null || !(origAmt > 0))
+            ? null
+            : -round2(origTax * Math.min(refunded, origAmt) / origAmt);
           const back = await recordUnlinkedPayment(
             { id: null, payment_intent: pi, amount_total: 0,
               currency: obj.currency,
@@ -7656,6 +7684,7 @@ async function handleStripeEvent(event) {
               customer_details: { email: u.customer_email, name: u.customer_name } },
             'refund of an unlinked payment',
             { amount: -refunded, kind: 'refund', allowZero: true,
+              taxPortion: backTax,
               extRef: obj.id + ':' + obj.amount_refunded,
               note: `Refund of ${money(refunded)} via Stripe` });
           if (!back.duplicate) {

--- a/tests/stripe-payment-visibility.test.js
+++ b/tests/stripe-payment-visibility.test.js
@@ -71,8 +71,27 @@ test('a real quote code still passes', () => {
 const ALERT_SRC = extractFn('async function alertUnbankedPayment(');
 
 test('an unbanked payment raises an alert instead of only a log line', () => {
-  assert.match(src, /if \(!out\.ok && !out\.duplicate\) await alertUnbankedPayment\(obj, out\.reason\);/,
+  assert.match(src, /if \(!out\.ok && !out\.duplicate\) \{[\s\S]{0,900}?alertUnbankedPayment\(obj, out\.reason\)/,
     'the checkout.session.completed branch must alert when the payment did not bank');
+});
+
+/* The alert closed the silence. It did not close the hole: an email is not a
+   record, so the money still reached no table, no export and no tax position —
+   and sales tax is filed on receipts, so a return built from this data was
+   understated by however much the studio took. */
+test('an unbanked payment is RECORDED, not just announced', () => {
+  assert.match(src, /if \(!out\.ok && !out\.duplicate\) \{[\s\S]{0,900}?await recordUnlinkedPayment\(obj, out\.reason\)/,
+    'money that arrived must land in a table, not only in an inbox');
+});
+
+test('it is recorded before it is alerted', () => {
+  const branch = /if \(!out\.ok && !out\.duplicate\) \{([\s\S]{0,900}?)\n        \}/.exec(src);
+  assert.ok(branch, 'the unbanked branch should still be a block');
+  const record = branch[1].indexOf('recordUnlinkedPayment');
+  const alert  = branch[1].indexOf('alertUnbankedPayment');
+  assert.ok(record !== -1 && alert !== -1, 'both the record and the alert must be present');
+  assert.ok(record < alert,
+    'record first: a swallowed alert costs a notification, a lost write costs a tax return');
 });
 
 test('the alert names the amount and the reference it arrived under', () => {

--- a/tests/stripe-payment-visibility.test.js
+++ b/tests/stripe-payment-visibility.test.js
@@ -70,8 +70,19 @@ test('a real quote code still passes', () => {
 
 const ALERT_SRC = extractFn('async function alertUnbankedPayment(');
 
+/* Anchored on the shortest stable text, not on the whole condition: the guard
+   has since gained `&& noQuote` (a delayed payment on a real quote must not be
+   recorded here, or async_payment_succeeded banks the same money twice), and an
+   anchor pinned to the old spelling reports a REWRITE as a missing branch while
+   the assertions that would name a real regression never run. */
+const UNBANKED = (() => {
+  const i = src.indexOf('!out.ok && !out.duplicate');
+  assert.notStrictEqual(i, -1, 'the unbanked branch should still exist');
+  return src.slice(i, i + 900);
+})();
+
 test('an unbanked payment raises an alert instead of only a log line', () => {
-  assert.match(src, /if \(!out\.ok && !out\.duplicate\) \{[\s\S]{0,900}?alertUnbankedPayment\(obj, out\.reason\)/,
+  assert.match(UNBANKED, /alertUnbankedPayment\(obj, out\.reason\)/,
     'the checkout.session.completed branch must alert when the payment did not bank');
 });
 
@@ -80,18 +91,24 @@ test('an unbanked payment raises an alert instead of only a log line', () => {
    and sales tax is filed on receipts, so a return built from this data was
    understated by however much the studio took. */
 test('an unbanked payment is RECORDED, not just announced', () => {
-  assert.match(src, /if \(!out\.ok && !out\.duplicate\) \{[\s\S]{0,900}?await recordUnlinkedPayment\(obj, out\.reason\)/,
+  assert.match(UNBANKED, /await recordUnlinkedPayment\(obj, out\.reason\)/,
     'money that arrived must land in a table, not only in an inbox');
 });
 
 test('it is recorded before it is alerted', () => {
-  const branch = /if \(!out\.ok && !out\.duplicate\) \{([\s\S]{0,900}?)\n        \}/.exec(src);
-  assert.ok(branch, 'the unbanked branch should still be a block');
-  const record = branch[1].indexOf('recordUnlinkedPayment');
-  const alert  = branch[1].indexOf('alertUnbankedPayment');
+  const record = UNBANKED.indexOf('recordUnlinkedPayment');
+  const alert  = UNBANKED.indexOf('alertUnbankedPayment');
   assert.ok(record !== -1 && alert !== -1, 'both the record and the alert must be present');
   assert.ok(record < alert,
     'record first: a swallowed alert costs a notification, a lost write costs a tax return');
+});
+
+test('only money with no quote reaches the unlinked ledger', () => {
+  /* `not paid` is a delayed method on a REAL quote — the session completes
+     before the funds clear, and async_payment_succeeded banks it moments later.
+     Recording it here as well counts the same money in both ledgers. */
+  assert.match(UNBANKED, /noQuote/,
+    'the guard must exclude reasons that are not "this money has no quote"');
 });
 
 test('the alert names the amount and the reference it arrived under', () => {

--- a/tests/unlinked-payments.test.js
+++ b/tests/unlinked-payments.test.js
@@ -115,6 +115,33 @@ test('a duplicate is reported, so it can suppress a second alert', () => {
   assert.match(RECORD_SRC, /duplicate: true/);
 });
 
+test('the tax is taken from the payment when the payer stamps it', () => {
+  /* The studio computes sales tax at checkout and used to fold it into one
+     opaque Stripe line item, so the money arrived with no way to separate
+     revenue from tax held for the state. It now stamps jt_tax on the session
+     metadata, which travels with the payment — the backend has no access to
+     the studio's database, so metadata is the only channel there is. */
+  assert.match(RECORD_SRC, /session\.metadata\?\.jt_tax/,
+    'read the tax the studio already worked out rather than guessing it');
+});
+
+test('an absent stamp stays NULL rather than becoming 0', () => {
+  assert.match(RECORD_SRC, /let taxPortion = null;/,
+    'a payment from before the stamp existed has an UNKNOWN tax portion, not a zero one');
+  assert.match(RECORD_SRC, /Number\.isFinite\(stamped\)/,
+    'a malformed stamp must fall back to unknown, never to NaN or 0');
+});
+
+test('a refund carries its tax back out', () => {
+  assert.match(RECORD_SRC, /amt < 0 && gross > 0 \? -Math\.abs\(stamped\) : stamped/,
+    'a negative row with a positive tax portion would leave tax behind on a refunded sale');
+});
+
+test('resolving the tax stamps when it was resolved', () => {
+  assert.match(src, /CASE WHEN \$16::numeric IS NULL THEN NULL ELSE NOW\(\) END/,
+    'resolved_at is what separates "settled at import" from "still to be worked out"');
+});
+
 test('the studio order number is kept when it sent one', () => {
   assert.match(RECORD_SRC, /session\.metadata\?\.order_id/,
     'order_id is the only identifier on a Payment Link balance payment');

--- a/tests/unlinked-payments.test.js
+++ b/tests/unlinked-payments.test.js
@@ -1,0 +1,325 @@
+'use strict';
+
+/* Money that arrived outside the quote flow, and the tax position that has to
+ * admit it exists.
+ *
+ * The design studio at design.jtees.net runs its own Stripe Checkout against
+ * THIS webhook, sending its order number as client_reference_id. That fails
+ * QUOTE_CODE_RE, so bankStripeSession declines it — correctly, an order is not
+ * a quote. Alerting the shop (see stripe-payment-visibility.test.js) stopped
+ * the money being invisible, but an email is not a record: it still reached no
+ * table, no export and no tax position.
+ *
+ * Sales tax is filed on RECEIPTS. Revenue that exists only in an inbox
+ * understates the ST-1 by exactly that much, and the ST-1 is the number a
+ * payment plan gets built on. So the rule this file defends is:
+ *
+ *   money that arrived is written down, and tax that is UNKNOWN is reported as
+ *   unknown — never as zero.
+ *
+ * Run: node --test tests/*.test.js
+ */
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const src = fs.readFileSync(path.join(__dirname, '..', 'server.js'), 'utf8');
+
+/* Keeps the `async` keyword: these are database functions, and a lifted body
+   full of `await` will not parse without it. */
+function lift(name) {
+  let start = src.indexOf(`function ${name}(`);
+  assert.notStrictEqual(start, -1, `${name} not found`);
+  if (src.slice(start - 6, start) === 'async ') start -= 6;
+
+  /* Skip the parameter list before hunting for the body. `opts = {}` is a brace
+     too, and matching on it returns a signature with no body — which parses,
+     runs, and silently asserts nothing. */
+  let i = src.indexOf('(', src.indexOf(name, start));
+  for (let paren = 0; i < src.length; i++) {
+    if (src[i] === '(') paren++;
+    else if (src[i] === ')' && --paren === 0) { i++; break; }
+  }
+
+  let depth = 0;
+  for (i = src.indexOf('{', i); i < src.length; i++) {
+    if (src[i] === '{') depth++;
+    else if (src[i] === '}' && --depth === 0) return src.slice(start, i + 1);
+  }
+  throw new Error('unbalanced braces reading ' + name);
+}
+
+/* ── The table ───────────────────────────────────────────────────────────── */
+
+const DDL = (() => {
+  const m = /CREATE TABLE IF NOT EXISTS unlinked_payments \(([\s\S]*?)\n    \)/.exec(src);
+  assert.ok(m, 'unlinked_payments table not found in initDB');
+  return m[1];
+})();
+
+test('unlinked money has somewhere to go', () => {
+  assert.match(DDL, /amount\s+NUMERIC\(10,2\) NOT NULL/,
+    'the amount is the whole point of the row');
+  assert.match(DDL, /stripe_pi/, 'a refund is matched back by payment intent');
+});
+
+test('tax_portion is NULLABLE and has no DEFAULT 0', () => {
+  /* This is the load-bearing line of the whole change. NULL means "nobody has
+     worked out the tax on this yet". 0 means "there was no tax". Writing 0 for
+     an unknown asserts something false about a period, and that assertion ends
+     up on a filed return. */
+  const col = /tax_portion\s+NUMERIC\(10,2\)([^\n]*)/.exec(DDL);
+  assert.ok(col, 'tax_portion column missing');
+  assert.doesNotMatch(col[1], /NOT NULL/, 'an unknown tax portion must be expressible');
+  assert.doesNotMatch(col[1], /DEFAULT\s+0/,
+    'defaulting to 0 would silently claim no tax was collected on studio orders');
+});
+
+test('a retried webhook cannot become two payments', () => {
+  assert.match(src, /CREATE UNIQUE INDEX IF NOT EXISTS unlinked_payments_extref_uniq[\s\S]{0,120}ext_ref/,
+    'Stripe retries every non-2xx; without this each retry books the money again');
+});
+
+test('the quote ledger is left alone', () => {
+  /* quote_payments.quote_code is NOT NULL and syncPaidAmount() rolls that
+     ledger onto the quote. A payment belonging to no quote cannot live there
+     without corrupting a rollup every other reader depends on. */
+  assert.match(src, /CREATE TABLE IF NOT EXISTS unlinked_payments/,
+    'unlinked money belongs in its own table, not smuggled into quote_payments');
+});
+
+/* ── Recording ───────────────────────────────────────────────────────────── */
+
+const RECORD_SRC = lift('recordUnlinkedPayment');
+
+test('the gross is recorded, not a net invented from the quote-flow surcharge', () => {
+  /* CARD_FEE is a convention of the quote checkout. The studio's checkout is
+     not obliged to share it, so dividing by (1 + CARD_FEE) here would invent a
+     fee that may not exist and understate revenue. */
+  assert.doesNotMatch(RECORD_SRC, /CARD_FEE/,
+    'do not apply the quote-flow card surcharge to a payment from another flow');
+});
+
+test('a failed write is NOT swallowed', () => {
+  /* The alert may swallow its own failure — a lost email costs a
+     notification. This may not: the only thing that will try again is Stripe's
+     retry, and that only happens on a non-2xx. */
+  assert.match(RECORD_SRC, /if \(err\.code === '23505'\) return \{ ok: true, duplicate: true \};[\s\S]{0,40}throw err;/,
+    'only a duplicate is tolerated; every other write failure must reach Stripe as a retry');
+});
+
+test('a duplicate is reported, so it can suppress a second alert', () => {
+  assert.match(RECORD_SRC, /duplicate: true/);
+});
+
+test('the studio order number is kept when it sent one', () => {
+  assert.match(RECORD_SRC, /session\.metadata\?\.order_id/,
+    'order_id is the only identifier on a Payment Link balance payment');
+});
+
+/* ── The tax position ────────────────────────────────────────────────────── */
+
+function runTaxPosition({ collected = [], remitted = [], unlinked = [], unlinkedFails = false }) {
+  const sandbox = {
+    round2: (n) => Math.round((Number(n) || 0) * 100) / 100,
+    pool: {
+      query(sql) {
+        if (/FROM quote_payments/.test(sql)) return Promise.resolve({ rows: collected });
+        if (/FROM tax_remittances/.test(sql)) return Promise.resolve({ rows: remitted });
+        if (/FROM unlinked_payments/.test(sql)) {
+          return unlinkedFails
+            ? Promise.reject(new Error('relation "unlinked_payments" does not exist'))
+            : Promise.resolve({ rows: unlinked });
+        }
+        throw new Error('unexpected query: ' + sql);
+      },
+    },
+  };
+  vm.createContext(sandbox);
+  return vm.runInContext(lift('taxPositionByMonth') + '\ntaxPositionByMonth', sandbox)();
+}
+
+test('quote-ledger tax still totals the way it always did', async () => {
+  const pos = await runTaxPosition({
+    collected: [{ period: '2026-08', collected: '100.00', gross: '1000.00', payments: '4' }],
+    remitted: [{ period: '2026-08', remitted: '40.00', last_paid: '2026-09-20' }],
+  });
+  assert.strictEqual(pos.months[0].outstanding, 60);
+  assert.strictEqual(pos.setAside, 60);
+});
+
+test('an unlinked payment with unknown tax does NOT quietly add zero', async () => {
+  const pos = await runTaxPosition({
+    collected: [{ period: '2026-08', collected: '100.00', gross: '1000.00', payments: '4' }],
+    unlinked: [{ period: '2026-08', gross: '535.75', payments: '3',
+                 tax_known: '0', tax_unknown: '3' }],
+  });
+  const m = pos.months[0];
+  /* The known tax is still 100 — inventing tax for the studio orders would be
+     as wrong as ignoring them. What changes is that the period now SAYS it is
+     incomplete. */
+  assert.strictEqual(m.outstanding, 100);
+  assert.strictEqual(m.undetermined, true, 'the period must declare itself unfinished');
+  assert.strictEqual(m.unlinkedGross, 535.75, 'the receipts are visible even when the tax is not');
+  assert.strictEqual(pos.undeterminedPayments, 3);
+  assert.strictEqual(pos.undeterminedGross, 535.75);
+});
+
+test('once the tax on an unlinked payment is established it counts', async () => {
+  const pos = await runTaxPosition({
+    collected: [{ period: '2026-08', collected: '100.00', gross: '1000.00', payments: '4' }],
+    unlinked: [{ period: '2026-08', gross: '535.75', payments: '3',
+                 tax_known: '49.86', tax_unknown: '0' }],
+  });
+  assert.strictEqual(pos.months[0].outstanding, 149.86);
+  assert.strictEqual(pos.months[0].undetermined, false);
+  assert.strictEqual(pos.undeterminedPayments, 0);
+});
+
+test('a period with ONLY unlinked money still appears', async () => {
+  /* Otherwise a month whose entire revenue came through the studio reads as no
+     business at all — the same class of lie as an empty export. */
+  const pos = await runTaxPosition({
+    unlinked: [{ period: '2026-07', gross: '35.75', payments: '1',
+                 tax_known: '0', tax_unknown: '1' }],
+  });
+  assert.strictEqual(pos.months.length, 1);
+  assert.strictEqual(pos.months[0].period, '2026-07');
+  assert.strictEqual(pos.months[0].unlinkedGross, 35.75);
+  assert.strictEqual(pos.months[0].undetermined, true);
+});
+
+test('the set-aside figure never counts undetermined money as remitted-safe', async () => {
+  const pos = await runTaxPosition({
+    collected: [{ period: '2026-08', collected: '100.00', gross: '1000.00', payments: '4' }],
+    remitted: [{ period: '2026-08', remitted: '100.00', last_paid: '2026-09-20' }],
+    unlinked: [{ period: '2026-08', gross: '535.75', payments: '3',
+                 tax_known: '0', tax_unknown: '3' }],
+  });
+  /* Outstanding is zero — every penny of KNOWN tax has been paid over. The
+     period is still not safe to file, and undeterminedPayments is what says so.
+     A caller reading only setAside would think August was closed. */
+  assert.strictEqual(pos.months[0].outstanding, 0);
+  assert.strictEqual(pos.undeterminedPayments, 3,
+    'a closed-looking period with unknown receipts must still be flagged');
+});
+
+test('a database without the table yet does not take the tax page down', async () => {
+  /* initDB creates it on boot, but the query is guarded so a deploy that races
+     the migration degrades to the old behaviour instead of 500ing the books. */
+  const pos = await runTaxPosition({
+    collected: [{ period: '2026-08', collected: '100.00', gross: '1000.00', payments: '4' }],
+    unlinkedFails: true,
+  });
+  assert.strictEqual(pos.months[0].outstanding, 60 + 40);
+  assert.strictEqual(pos.undeterminedPayments, 0);
+});
+
+/* ── The records that get filed from ─────────────────────────────────────── */
+
+const TAX_CSV = (() => {
+  const start = src.indexOf("app.get('/tax.csv'");
+  assert.notStrictEqual(start, -1, '/tax.csv route not found');
+  return src.slice(start, src.indexOf("\napp.get(", start + 10));
+})();
+
+test('the tax file reports the STORED tax portion, not a fresh calculation', () => {
+  /* recordPayment() works the portion out when the money lands and writes it on
+     the row, so that editing a quote afterwards cannot rewrite what was
+     collected in a period already reported. Recomputing here re-derived it from
+     today's quote total, so this file could disagree with the tax page — and
+     they are meant to be the same number, filed twice. */
+  assert.match(TAX_CSV, /p\.tax_portion/, 'read the recorded figure');
+  assert.doesNotMatch(TAX_CSV, /round\(q\.tax \* \(p\.amount \/ q\.total\), 2\)/,
+    'recomputing lets a later quote edit silently restate a filed period');
+});
+
+test('the tax file is escaped like every other export', () => {
+  /* It had its own local escaper that handled quotes and commas but NOT the
+     leading =/+/-/@ that Excel, Numbers and Sheets all evaluate. Every other
+     export goes through csvEsc, which does. */
+  assert.match(TAX_CSV, /sendCsv\(res,/,
+    'use the shared writer so the formula-injection guard applies here too');
+});
+
+test('the tax file includes money that belongs to no quote', () => {
+  assert.match(TAX_CSV, /FROM unlinked_payments/,
+    'the ST-1 is filed on everything taken in, not on everything that had a quote');
+});
+
+test('an unknown tax portion exports BLANK, never 0', () => {
+  assert.match(TAX_CSV, /tax_portion == null \? '' :/,
+    'a blank cell asks the bookkeeper a question; a zero answers it wrongly');
+});
+
+test('unlinked receipts have a full export of their own', () => {
+  assert.match(src, /app\.get\('\/exports\/unlinked\.csv'/,
+    'the Stripe identifiers are what make the studio order findable');
+  assert.match(src, /app\.get\('\/exports\/unlinked\.csv', requireAdmin/,
+    'it carries customer names and money — admin only, like every other export');
+});
+
+test('a month with only unlinked money still shows on the records page', () => {
+  assert.match(src, /would not\n       appear at all otherwise|seen\.has\(u\.ym\)/,
+    'otherwise a month whose revenue all came through the studio reads as no business');
+});
+
+/* ── Clover ──────────────────────────────────────────────────────────────── */
+
+const CLOVER = (() => {
+  const start = src.indexOf("app.post('/webhooks/clover'");
+  assert.notStrictEqual(start, -1, 'clover webhook not found');
+  return src.slice(start, src.indexOf('\napp.', start + 10));
+})();
+
+test('a Clover payment is written down, not just emailed', () => {
+  /* `submissions` has no amount column at all. The handler fetched the amount,
+     put it in a customer email, flipped a status to 'paid' and stored no figure
+     anywhere — so Clover revenue existed in this database only as a boolean. */
+  assert.match(CLOVER, /recordUnlinkedPayment\(/,
+    'the amount must reach a table, not only an inbox');
+});
+
+test('the payment is recorded BEFORE the submission is matched', () => {
+  /* Both early returns below it — no matching submission, and already marked
+     paid — used to drop the payment entirely. Money that arrived is a fact
+     independent of whether this side can match it to a row. */
+  const record = CLOVER.indexOf('recordUnlinkedPayment');
+  const bail   = CLOVER.indexOf('if (!rows.length) return;');
+  assert.ok(record !== -1 && bail !== -1);
+  assert.ok(record < bail,
+    'a payment with no matching enquiry is still a payment, and still carries tax');
+});
+
+test('an unmatched Clover payment says so rather than looking ordinary', () => {
+  assert.match(CLOVER, /clover payment with no matching enquiry/,
+    'the reason column is what makes it findable later');
+});
+
+test('a Clover payment cannot be booked twice', () => {
+  assert.match(CLOVER, /extRef: `clover:\$\{paymentId\}`/,
+    'the Clover payment id is what makes the row unique');
+});
+
+test('a failed Clover write is escalated, not just logged', () => {
+  /* This handler acks 200 at the top, so throwing earns no retry — only an
+     unhandled rejection. That makes the error table the only way anyone finds
+     out a payment went unrecorded. */
+  assert.match(CLOVER, /recordError\('clover-payment-unrecorded'/,
+    'a lost payment must reach the digest the shop actually reads');
+});
+
+/* ── Refunds ─────────────────────────────────────────────────────────────── */
+
+test('a refund of an unlinked payment comes back out of the same ledger', () => {
+  assert.match(src, /no quote claimed the original payment[\s\S]{0,700}FROM unlinked_payments WHERE stripe_pi/i,
+    'otherwise the books keep money that was given back');
+});
+
+test('an unmatchable refund is still reported rather than dropped silently', () => {
+  assert.match(src, /no matching quote or unlinked payment for PI/,
+    'the 08-16 lesson: code that decides nothing is wrong and says nothing');
+});

--- a/tests/unlinked-payments.test.js
+++ b/tests/unlinked-payments.test.js
@@ -132,9 +132,14 @@ test('an absent stamp stays NULL rather than becoming 0', () => {
     'a malformed stamp must fall back to unknown, never to NaN or 0');
 });
 
-test('a refund carries its tax back out', () => {
-  assert.match(RECORD_SRC, /amt < 0 && gross > 0 \? -Math\.abs\(stamped\) : stamped/,
-    'a negative row with a positive tax portion would leave tax behind on a refunded sale');
+test('the refund sign flip does not depend on a gross it will never have', () => {
+  /* Was `amt < 0 && gross > 0`. The refund caller passes amount_total: 0 with
+     allowZero, so gross is always 0 there and the branch could not fire. The
+     assertion that used to live here matched that expression in the SOURCE, so
+     it passed while the behaviour was absent — which is why the replacement
+     below exercises the function instead. */
+  assert.doesNotMatch(RECORD_SRC, /amt < 0 && gross > 0/,
+    'the refund path never has a positive gross, so this can never be true');
 });
 
 test('resolving the tax stamps when it was resolved', () => {
@@ -145,6 +150,100 @@ test('resolving the tax stamps when it was resolved', () => {
 test('the studio order number is kept when it sent one', () => {
   assert.match(RECORD_SRC, /session\.metadata\?\.order_id/,
     'order_id is the only identifier on a Payment Link balance payment');
+});
+
+/* ── What must NOT reach the unlinked ledger ─────────────────────────────── */
+
+test('a delayed payment on a real quote is not banked twice', () => {
+  /* bankStripeSession tests the quote code BEFORE the payment status, so a
+     delayed method — Klarna, Cash App, Affirm, Afterpay are all enabled on
+     this account, ACH is one Dashboard toggle away — completes as `unpaid` and
+     returns { ok:false, reason:'not paid' }. Recording that here puts the money
+     on the unlinked ledger; async_payment_succeeded then banks the same session
+     to quote_payments, and taxPositionByMonth counts `gross` and
+     `unlinkedGross` separately. The same money, twice, on a filed return. */
+  assert.match(src,
+    /const noQuote = out\.reason === 'no quote code' \|\| out\.reason === 'unknown quote';/,
+    'only money belonging to no quote may be recorded as unlinked');
+  assert.match(src, /if \(!out\.ok && !out\.duplicate && noQuote\) \{/,
+    'the guard has to be on the recording branch itself');
+});
+
+/* ── Recording, for real ─────────────────────────────────────────────────── */
+
+/** Runs recordUnlinkedPayment against a fake pool and returns the INSERT args. */
+function captureInsert(session, reason, opts) {
+  let captured = null;
+  const sandbox = {
+    round2: (n) => Math.round((Number(n) || 0) * 100) / 100,
+    pool: {
+      query(sql, args) {
+        if (/INSERT INTO unlinked_payments/.test(sql)) { captured = args; }
+        return Promise.resolve({ rows: [] });
+      },
+    },
+  };
+  vm.createContext(sandbox);
+  const fn = vm.runInContext(
+    lift('recordUnlinkedPayment') + '\nrecordUnlinkedPayment', sandbox);
+  return fn(session, reason, opts).then(() => captured);
+}
+
+/* tax_portion is the last positional argument of the INSERT. */
+const TAX_ARG = 15;
+
+test('a refund carries its tax back out as a NEGATIVE portion', async () => {
+  /* Behavioural, not a grep. The previous version of this assertion matched
+     the expression in the source, so it passed while the branch it guarded was
+     unreachable — the refund caller passes amount_total: 0, and the old
+     condition also required gross > 0. */
+  const args = await captureInsert(
+    { id: null, payment_intent: 'pi_x', amount_total: 0, currency: 'usd',
+      metadata: { jt_tax: '2.77' } },
+    'refund of an unlinked payment',
+    { amount: -35.75, kind: 'refund', allowZero: true });
+  assert.strictEqual(args[TAX_ARG], -2.77,
+    'a refund that returns the money must return the tax with it');
+});
+
+test('a payment stamped with its tax records that tax as positive', async () => {
+  const args = await captureInsert(
+    { id: 'cs_1', payment_intent: 'pi_y', amount_total: 3575, currency: 'usd',
+      metadata: { order_id: '10', jt_tax: '2.77' } },
+    'no quote code', {});
+  assert.strictEqual(args[TAX_ARG], 2.77);
+});
+
+test('an unstamped payment stays UNKNOWN, never zero', async () => {
+  const args = await captureInsert(
+    { id: 'cs_2', payment_intent: 'pi_z', amount_total: 3575, currency: 'usd',
+      metadata: {} },
+    'no quote code', {});
+  assert.strictEqual(args[TAX_ARG], null,
+    '0 would assert no tax was collected, and that assertion gets filed');
+});
+
+test('an explicit tax portion overrides the stamp', async () => {
+  /* This is how the refund path passes a portion worked out from the ORIGINAL
+     row, which is the only place the number still exists. */
+  const args = await captureInsert(
+    { id: null, payment_intent: 'pi_w', amount_total: 0, currency: 'usd',
+      metadata: { jt_tax: '9.99' } },
+    'refund of an unlinked payment',
+    { amount: -10, kind: 'refund', allowZero: true, taxPortion: -1.25 });
+  assert.strictEqual(args[TAX_ARG], -1.25);
+});
+
+test('the refund path reads the original amount and tax to apportion from', () => {
+  /* Selecting only the identity columns left taxPortion NULL on every refund,
+     which both kept the refunded tax as owed AND marked the period
+     undetermined forever. */
+  assert.match(src, /SELECT id, order_ref, client_ref, customer_email, customer_name,\s*\n\s*amount, tax_portion/,
+    'the original row is the only place the tax portion still exists');
+  assert.match(src, /taxPortion: backTax/,
+    'the apportioned figure has to actually be passed');
+  assert.match(src, /-round2\(origTax \* Math\.min\(refunded, origAmt\) \/ origAmt\)/,
+    'a partial refund returns a proportional share, and never more than was taken');
 });
 
 /* ── The tax position ────────────────────────────────────────────────────── */

--- a/tests/unlinked-payments.test.js
+++ b/tests/unlinked-payments.test.js
@@ -27,6 +27,8 @@ const path = require('node:path');
 const vm = require('node:vm');
 
 const src = fs.readFileSync(path.join(__dirname, '..', 'server.js'), 'utf8');
+const backfillSrc = fs.readFileSync(
+  path.join(__dirname, '..', 'tools', 'backfill-unlinked.js'), 'utf8');
 
 /* Keeps the `async` keyword: these are database functions, and a lifted body
    full of `await` will not parse without it. */
@@ -244,6 +246,103 @@ test('the refund path reads the original amount and tax to apportion from', () =
     'the apportioned figure has to actually be passed');
   assert.match(src, /-round2\(origTax \* Math\.min\(refunded, origAmt\) \/ origAmt\)/,
     'a partial refund returns a proportional share, and never more than was taken');
+});
+
+/* ── Settling an unknown tax portion by hand ─────────────────────────────── */
+
+const SETTLE = (() => {
+  const i = src.indexOf("app.post('/unlinked/:id/tax'");
+  assert.notStrictEqual(i, -1, 'there must be a way to establish a tax portion');
+  return src.slice(i, i + 2600);
+})();
+
+test('an unknown tax portion can actually be established', () => {
+  /* Before this route, tax_portion had exactly one writer — the jt_tax stamp —
+     so anything arriving without one was unknown forever. resolved_at was
+     documented as "set once the tax portion has been established" with nothing
+     able to establish it, which made undeterminedPayments permanently non-zero.
+     A warning that is always on is a warning nobody reads. */
+  assert.match(SETTLE, /requireAdmin/, 'the books are not public');
+  assert.match(SETTLE, /UPDATE unlinked_payments[\s\S]{0,200}SET tax_portion = \$2/);
+  assert.match(SETTLE, /resolved_at = CASE WHEN \$2::numeric IS NULL THEN NULL ELSE NOW\(\) END/,
+    'settling it is what stamps when it was settled');
+});
+
+test('blank means UNKNOWN and 0 means no tax, and they are different', () => {
+  /* The whole ledger is built on that distinction. A number input that treats
+     an empty box as 0 would quietly assert "no tax was collected" on every row
+     somebody tabbed past. */
+  assert.match(SETTLE, /const raw = String\(b\.tax \?\? ''\)\.trim\(\);/);
+  assert.match(SETTLE, /let tax = null;[\s\S]{0,120}if \(raw !== ''\)/,
+    'an empty box has to put the row back to unknown, not to zero');
+});
+
+test('the tax cannot exceed the payment or contradict its sign', () => {
+  /* A tax larger than the receipt, or a positive tax on a refund, produces a
+     period whose tax exceeds its receipts — a number that survives all the way
+     onto a filed return. */
+  assert.match(SETTLE, /if \(amount < 0 && tax > 0\) tax = -tax;/,
+    'a refund carries its tax back OUT');
+  assert.match(SETTLE, /if \(Math\.abs\(tax\) > Math\.abs\(amount\)\)/,
+    'tax cannot be more than the money it came in');
+});
+
+test('the books page offers the rows that are holding a period open', () => {
+  assert.match(src, /WHERE tax_portion IS NULL\s*\n\s*ORDER BY created_at LIMIT 50/,
+    'the unsettled receipts are the ones worth showing');
+  assert.match(src, /action="\/unlinked\/\$\{u\.id\}\/tax"/,
+    'each row needs a way to settle it, or the route is unreachable');
+});
+
+/* ── The ST-1 reminder ───────────────────────────────────────────────────── */
+
+test('a period with only undetermined receipts still sends a reminder', () => {
+  /* `if (outstanding <= 0) return` skipped exactly the month that most needed
+     the email: nothing provably owed, and receipts nobody has worked the tax
+     out on. */
+  assert.match(src, /if \(outstanding <= 0 && !undetermined\) return;/,
+    'silence on an unfileable month is the worst possible answer');
+  assert.match(src, /cannot be filed yet — \$\{undetermined\} receipt\(s\)/,
+    'the subject has to say why, since there is no amount to lead with');
+});
+
+test('the reminder\'s three figures add up', () => {
+  /* `outstanding` is collected + unlinkedTaxKnown − remitted, but the table
+     printed only `collected` and `remitted`, so once any unlinked tax was
+     settled the email disagreed with itself — on the one document a return is
+     filed from. */
+  assert.match(src, /row\.unlinkedTaxKnown > 0 \? `<tr><td[^`]*Collected outside quotes/,
+    'settled unlinked tax needs its own line or the arithmetic is wrong');
+});
+
+/* ── Recovering history ──────────────────────────────────────────────────── */
+
+test('the backfill keeps tax the payer already stamped', () => {
+  assert.match(backfillSrc, /const stampedTax = \(s\) => \{/,
+    'a recovered payment is the same money as a live one');
+  assert.match(backfillSrc, /stampedTax\(s\)\]\);/,
+    'the stamped figure has to reach the INSERT');
+  assert.match(backfillSrc, /tax_portion, resolved_at\)/,
+    'importing everything as unknown holds periods open for nothing');
+});
+
+test('a six-character reference is not treated as proof of banking', () => {
+  /* bankStripeSession also declines with 'unknown quote'. Counting the code
+     alone as banked hid those sessions from this pass and from the orphan
+     report — the exact blind spot the tool exists to close. */
+  assert.doesNotMatch(backfillSrc, /QUOTE_CODE_RE\.test\(code\) \|\| seenQuote\.has\(s\.id\)/,
+    'only a row on the quote ledger proves a session banked');
+  assert.match(backfillSrc, /if \(seenQuote\.has\(s\.id\)\) \{ banked\+\+; continue; \}/);
+  assert.match(backfillSrc, /SELECT 1 FROM quotes WHERE code=\$1/,
+    'a real quote and an unknown one are different situations');
+});
+
+test('money belonging to a real quote is reported, never written as unlinked', () => {
+  /* Banking it here would bypass the net/fee split and the paid_amount rollup
+     that bankStripeSession does, so it is named for a human instead. */
+  assert.match(backfillSrc, /stranded\.push\(s\)/);
+  assert.match(backfillSrc, /name a REAL quote but are on no /,
+    'the operator has to be told, not left to notice');
 });
 
 /* ── The tax position ────────────────────────────────────────────────────── */

--- a/tools/backfill-unlinked.js
+++ b/tools/backfill-unlinked.js
@@ -1,0 +1,217 @@
+#!/usr/bin/env node
+/*
+ * Recover payments Stripe took that this database never recorded.
+ *
+ * WHY
+ * ---
+ * The design studio at design.jtees.net runs its own Stripe Checkout against
+ * this backend's webhook, sending its ORDER NUMBER as client_reference_id.
+ * That fails QUOTE_CODE_RE, so bankStripeSession declined it — correctly, an
+ * order is not a quote — and until now the money reached no table at all. It
+ * was alerted by email and then existed only in the Stripe dashboard.
+ *
+ * Sales tax is filed on RECEIPTS. Every one of those payments is missing from
+ * the ST-1, and the ST-1 is the number a payment plan gets built on. This walks
+ * Stripe back to a date you choose and writes the missing ones onto the
+ * unlinked ledger, so the tax position stops being a guess.
+ *
+ *   node tools/backfill-unlinked.js                      dry run, last 2 years
+ *   node tools/backfill-unlinked.js --since 2024-01-01   dry run from a date
+ *   node tools/backfill-unlinked.js --since 2024-01-01 --apply    write it
+ *
+ * Against production:
+ *   railway run --service junesteesnthings-backend \
+ *     node tools/backfill-unlinked.js --since 2024-01-01 --apply
+ *
+ * Nothing is written without --apply. Re-running is safe: rows are keyed on
+ * the Stripe object id, so a second run inserts nothing.
+ *
+ * It also reconciles the other way — every succeeded CHARGE is checked against
+ * both ledgers, and anything represented in neither is listed. Those are the
+ * ones no automated rule can place, and they need a person.
+ *
+ * Env: STRIPE_SECRET_KEY, DATABASE_URL
+ */
+
+/* Optional: every other tool here reads process.env directly and is run under
+   `railway run`, which injects the variables. Loading .env is a convenience for
+   running it locally, not a dependency. */
+try { require('dotenv').config(); } catch { /* not installed, or no .env */ }
+const { Pool } = require('pg');
+
+const KEY = process.env.STRIPE_SECRET_KEY || '';
+const args = process.argv.slice(2);
+const APPLY = args.includes('--apply');
+const sinceArg = (args[args.indexOf('--since') + 1] || '').match(/^\d{4}-\d{2}-\d{2}$/)
+  ? args[args.indexOf('--since') + 1] : null;
+const SINCE = sinceArg
+  ? Math.floor(new Date(sinceArg + 'T00:00:00Z').getTime() / 1000)
+  : Math.floor(Date.now() / 1000) - 60 * 60 * 24 * 730;
+
+const QUOTE_CODE_RE = /^[A-Z0-9]{6}$/;
+const round2 = (n) => Math.round((Number(n) || 0) * 100) / 100;
+const money = (n) => '$' + round2(n).toFixed(2);
+const day = (unix) => new Date(unix * 1000).toISOString().slice(0, 10);
+
+const ok = (m) => console.log('  \x1b[32m✓\x1b[0m ' + m);
+const bad = (m) => console.log('  \x1b[31m✗\x1b[0m ' + m);
+const warn = (m) => console.log('  \x1b[33m!\x1b[0m ' + m);
+
+async function stripe(path, params = {}) {
+  const qs = new URLSearchParams(params).toString();
+  const r = await fetch(`https://api.stripe.com/v1/${path}${qs ? '?' + qs : ''}`, {
+    headers: { Authorization: 'Bearer ' + KEY },
+    signal: AbortSignal.timeout(20000),
+  });
+  const body = await r.json();
+  if (!r.ok) throw new Error(`Stripe ${path} ${r.status}: ${body?.error?.message || ''}`);
+  return body;
+}
+
+/** Every page of a Stripe list endpoint, oldest first. */
+async function* paginate(path, params) {
+  let after = null;
+  for (;;) {
+    const page = await stripe(path, {
+      ...params, limit: '100', ...(after ? { starting_after: after } : {}),
+    });
+    for (const item of page.data) yield item;
+    if (!page.has_more || !page.data.length) return;
+    after = page.data[page.data.length - 1].id;
+  }
+}
+
+(async () => {
+  console.log(`\nUnrecorded Stripe payments since ${day(SINCE)}` +
+              `${APPLY ? '' : '  (DRY RUN — nothing will be written)'}\n` + '-'.repeat(64));
+
+  if (!KEY) { bad('STRIPE_SECRET_KEY is not set'); process.exit(1); }
+  if (!process.env.DATABASE_URL) { bad('DATABASE_URL is not set'); process.exit(1); }
+
+  const pool = new Pool({
+    connectionString: process.env.DATABASE_URL,
+    ssl: { rejectUnauthorized: false },
+  });
+
+  try {
+    const seenQuote = new Set((await pool.query(
+      `SELECT DISTINCT stripe_session FROM quote_payments WHERE stripe_session IS NOT NULL`
+    )).rows.map((r) => r.stripe_session));
+    const seenPI = new Set((await pool.query(
+      `SELECT DISTINCT stripe_pi FROM quote_payments WHERE stripe_pi IS NOT NULL`
+    )).rows.map((r) => r.stripe_pi));
+    const seenUnlinked = new Set((await pool.query(
+      `SELECT ext_ref FROM unlinked_payments WHERE ext_ref IS NOT NULL`
+    )).rows.map((r) => r.ext_ref));
+
+    ok(`${seenQuote.size} session(s) already on the quote ledger, ` +
+       `${seenUnlinked.size} on the unlinked ledger`);
+
+    const found = [];
+    let sessions = 0, banked = 0, already = 0, unpaid = 0;
+
+    for await (const s of paginate('checkout/sessions', { 'created[gte]': String(SINCE) })) {
+      sessions++;
+      if (s.payment_status !== 'paid') { unpaid++; continue; }
+
+      const code = String(s.client_reference_id || '').toUpperCase();
+      // Banked against a quote already, by code or by having been seen.
+      if (QUOTE_CODE_RE.test(code) || seenQuote.has(s.id)) { banked++; continue; }
+      if (seenUnlinked.has(s.id)) { already++; continue; }
+
+      found.push(s);
+    }
+
+    console.log(`\n  ${sessions} checkout session(s): ${banked} banked to a quote, ` +
+                `${already} already recorded, ${unpaid} not paid, ` +
+                `\x1b[1m${found.length} missing\x1b[0m`);
+
+    if (found.length) {
+      console.log('');
+      let total = 0;
+      for (const s of found) {
+        const gross = round2((s.amount_total || 0) / 100);
+        total += gross;
+        const orderRef = String(s.metadata?.order_id || '').trim();
+        const ref = orderRef ? `studio #${orderRef}`
+                  : (s.client_reference_id || '(no reference)');
+        console.log(`    ${day(s.created)}  ${money(gross).padStart(10)}  ${ref}` +
+                    `  ${s.customer_details?.email || ''}`);
+      }
+      console.log(`\n    ${'TOTAL'.padStart(12)}  \x1b[1m${money(total)}\x1b[0m ` +
+                  `of receipts missing from the books`);
+      warn('The sales tax inside this is UNKNOWN on this side — it is recorded as');
+      warn('NULL, not zero, and the tax page will report the period as undetermined');
+      warn('until someone reconciles it against the studio\'s own order records.');
+    }
+
+    if (APPLY && found.length) {
+      let written = 0, dupes = 0;
+      for (const s of found) {
+        const orderRef = String(s.metadata?.order_id || '').trim() || null;
+        const pi = typeof s.payment_intent === 'string' ? s.payment_intent : null;
+        try {
+          await pool.query(
+            `INSERT INTO unlinked_payments
+               (amount, currency, channel, order_ref, client_ref, kind, source,
+                stripe_session, stripe_pi, ext_ref, customer_email, customer_name,
+                reason, note, created_at)
+             VALUES ($1,$2,$3,$4,$5,'payment','backfill',$6,$7,$8,$9,$10,$11,$12,$13)`,
+            [round2((s.amount_total || 0) / 100),
+             String(s.currency || 'usd').toLowerCase(),
+             orderRef ? 'studio' : 'unknown', orderRef,
+             String(s.client_reference_id || '').trim() || null,
+             s.id, pi, s.id,
+             s.customer_details?.email || null, s.customer_details?.name || null,
+             'no quote code', 'Recovered from Stripe by tools/backfill-unlinked.js',
+             new Date(s.created * 1000).toISOString()]);
+          written++;
+        } catch (err) {
+          if (err.code === '23505') { dupes++; continue; }
+          throw err;
+        }
+      }
+      ok(`${written} payment(s) written to the unlinked ledger` +
+         (dupes ? `, ${dupes} already there` : ''));
+    } else if (found.length) {
+      console.log(`\n  Re-run with \x1b[1m--apply\x1b[0m to write these.`);
+    }
+
+    /* ── The other direction ──────────────────────────────────────────────
+       A Checkout Session is not the only way money reaches a Stripe account.
+       Walk the charges too and name anything represented in NEITHER ledger,
+       so the gap is bounded by what actually settled rather than by what
+       happened to have a session. These are not written — a charge with no
+       session carries no reference at all, so placing it is a human job. */
+    const orphans = [];
+    let charges = 0;
+    for await (const c of paginate('charges', { 'created[gte]': String(SINCE) })) {
+      charges++;
+      if (c.status !== 'succeeded') continue;
+      const pi = typeof c.payment_intent === 'string' ? c.payment_intent : null;
+      if (pi && seenPI.has(pi)) continue;
+      const { rows } = await pool.query(
+        `SELECT 1 FROM unlinked_payments WHERE stripe_pi = $1 LIMIT 1`, [pi]);
+      if (rows.length) continue;
+      if (found.some((s) => s.payment_intent === pi)) continue; // covered above
+      orphans.push(c);
+    }
+
+    console.log(`\n  ${charges} charge(s) checked against both ledgers.`);
+    if (orphans.length) {
+      warn(`${orphans.length} succeeded charge(s) match NOTHING in either ledger:`);
+      for (const c of orphans.slice(0, 25)) {
+        console.log(`    ${day(c.created)}  ${money((c.amount || 0) / 100).padStart(10)}  ` +
+                    `${c.id}  ${c.billing_details?.email || c.receipt_email || ''}`);
+      }
+      if (orphans.length > 25) console.log(`    …and ${orphans.length - 25} more`);
+      warn('These have no checkout session to identify them. Place them by hand.');
+    } else {
+      ok('Every succeeded charge is accounted for in one ledger or the other.');
+    }
+
+    console.log('');
+  } finally {
+    await pool.end();
+  }
+})().catch((e) => { bad(e.message); process.exit(1); });

--- a/tools/backfill-unlinked.js
+++ b/tools/backfill-unlinked.js
@@ -52,6 +52,11 @@ const QUOTE_CODE_RE = /^[A-Z0-9]{6}$/;
 const round2 = (n) => Math.round((Number(n) || 0) * 100) / 100;
 const money = (n) => '$' + round2(n).toFixed(2);
 const day = (unix) => new Date(unix * 1000).toISOString().slice(0, 10);
+/** The sales tax the payer stamped on the session, or null for unknown. */
+const stampedTax = (s) => {
+  const n = Number(s.metadata?.jt_tax);
+  return Number.isFinite(n) ? round2(n) : null;
+};
 
 const ok = (m) => console.log('  \x1b[32m✓\x1b[0m ' + m);
 const bad = (m) => console.log('  \x1b[31m✗\x1b[0m ' + m);
@@ -108,6 +113,7 @@ async function* paginate(path, params) {
        `${seenUnlinked.size} on the unlinked ledger`);
 
     const found = [];
+    const stranded = [];
     let sessions = 0, banked = 0, already = 0, unpaid = 0;
 
     for await (const s of paginate('checkout/sessions', { 'created[gte]': String(SINCE) })) {
@@ -115,9 +121,26 @@ async function* paginate(path, params) {
       if (s.payment_status !== 'paid') { unpaid++; continue; }
 
       const code = String(s.client_reference_id || '').toUpperCase();
-      // Banked against a quote already, by code or by having been seen.
-      if (QUOTE_CODE_RE.test(code) || seenQuote.has(s.id)) { banked++; continue; }
+      // Actually on the quote ledger — the only thing that proves it banked.
+      if (seenQuote.has(s.id)) { banked++; continue; }
       if (seenUnlinked.has(s.id)) { already++; continue; }
+
+      /* A six-character reference is NOT proof of banking. bankStripeSession
+         also declines with 'unknown quote' when no row matches the code, and
+         treating the code alone as banked made those sessions invisible to
+         this pass AND to the orphan report below — the exact blind spot this
+         tool exists to close. So ask which it is. */
+      if (QUOTE_CODE_RE.test(code)) {
+        const { rows: q } = await pool.query('SELECT 1 FROM quotes WHERE code=$1', [code]);
+        if (q.length) {
+          /* The quote is real and the money is not on its ledger. That is not
+             unlinked money — it belongs to a quote — so it is reported rather
+             than written, because banking it here would bypass the fee split
+             and the paid_amount rollup that bankStripeSession does. */
+          stranded.push(s);
+          continue;
+        }
+      }
 
       found.push(s);
     }
@@ -125,6 +148,15 @@ async function* paginate(path, params) {
     console.log(`\n  ${sessions} checkout session(s): ${banked} banked to a quote, ` +
                 `${already} already recorded, ${unpaid} not paid, ` +
                 `\x1b[1m${found.length} missing\x1b[0m`);
+
+    if (stranded.length) {
+      console.log(`\n  \x1b[31m${stranded.length} session(s) name a REAL quote but are on no ` +
+                  `ledger.\x1b[0m Bank these from the quote page, not from here:`);
+      for (const s of stranded) {
+        console.log(`    ${day(s.created)}  ${money(round2((s.amount_total || 0) / 100)).padStart(10)}` +
+                    `  quote ${s.client_reference_id}  ${s.id}`);
+      }
+    }
 
     if (found.length) {
       console.log('');
@@ -155,16 +187,27 @@ async function* paginate(path, params) {
             `INSERT INTO unlinked_payments
                (amount, currency, channel, order_ref, client_ref, kind, source,
                 stripe_session, stripe_pi, ext_ref, customer_email, customer_name,
-                reason, note, created_at)
-             VALUES ($1,$2,$3,$4,$5,'payment','backfill',$6,$7,$8,$9,$10,$11,$12,$13)`,
+                reason, note, created_at, tax_portion, resolved_at)
+             VALUES ($1,$2,$3,$4,$5,'payment','backfill',$6,$7,$8,$9,$10,$11,$12,$13,
+                     $14, CASE WHEN $14::numeric IS NULL THEN NULL ELSE NOW() END)`,
             [round2((s.amount_total || 0) / 100),
              String(s.currency || 'usd').toLowerCase(),
              orderRef ? 'studio' : 'unknown', orderRef,
              String(s.client_reference_id || '').trim() || null,
              s.id, pi, s.id,
              s.customer_details?.email || null, s.customer_details?.name || null,
-             'no quote code', 'Recovered from Stripe by tools/backfill-unlinked.js',
-             new Date(s.created * 1000).toISOString()]);
+             /* Say which it actually was. 'no quote code' on a session carrying
+                a six-character reference sends whoever reads the ledger looking
+                for the wrong thing. */
+             QUOTE_CODE_RE.test(String(s.client_reference_id || '').toUpperCase())
+               ? 'unknown quote' : 'no quote code',
+             'Recovered from Stripe by tools/backfill-unlinked.js',
+             new Date(s.created * 1000).toISOString(),
+             /* The studio stamps jt_tax on the session metadata. Importing it as
+                unknown discards a figure the payer already gave us and holds the
+                period open for nothing — recordUnlinkedPayment reads it on the
+                live path, and a recovered payment is the same money. */
+             stampedTax(s)]);
           written++;
         } catch (err) {
           if (err.code === '23505') { dupes++; continue; }


### PR DESCRIPTION
## Why

Sales tax is filed on **receipts**. Two channels were taking money that never reached a table, so every ST-1 figure this system can produce is understated by an unknown amount — and that figure is what an IDOR payment plan gets built on.

**The design studio** (`design.jtees.net`) runs its own Stripe Checkout against *this* webhook, sending its order number as `client_reference_id`. That fails `QUOTE_CODE_RE`, so `bankStripeSession` declines it — correctly, an order is not a quote and has its own ledger. #19 closed the silence by alerting the shop. It did not close the hole: an email is not a record, and the money still appeared in no export, no `/books` page and no tax position.

**Clover** was worse. It fetched the amount, put it in a customer email, flipped `submissions.status` to `'paid'`, and stored no figure anywhere. Both of its early returns — no matching enquiry, already paid — dropped the payment entirely.

## What this does

Adds an `unlinked_payments` ledger for money that belongs to no quote. Separate from `quote_payments` because `quote_code` is `NOT NULL` there and `syncPaidAmount()` rolls that ledger onto the quote; a payment belonging to no quote cannot live in it without corrupting a rollup every other reader depends on.

Two rules it is built around:

- **Record before matching.** The write happens before any logic that might fail to place the money. Money that arrived is a fact independent of whether this side can match it to a row.
- **`tax_portion` is nullable and means UNKNOWN — never 0.** The studio holds its own tax detail; this side genuinely does not know it. Writing 0 asserts no tax was collected, and that assertion flows onto a filed return. `taxPositionByMonth` now reports such periods as `undetermined` rather than quietly adding nothing, and a period can look fully remitted while still being unsafe to file.

Same failure, so also here:

- Refunds of unlinked payments come back out of the same ledger, instead of logging "no matching quote" and leaving the books holding returned money.
- `/tax.csv` reads the **stored** `tax_portion` instead of recomputing it from the current quote. `recordPayment()` writes it when the money lands precisely so a later quote edit cannot restate a period already reported — recomputing threw that away, and let this file disagree with the tax page.
- `/tax.csv` now goes through `csvEsc`, gaining the formula-injection guard (leading `=`/`+`/`-`/`@`) that every other export already had.
- `/exports/unlinked.csv`, and an "Outside quotes" column on the records page. A month whose only revenue came through the studio now appears at all.
- `tools/backfill-unlinked.js` recovers the history from Stripe (dry-run by default) and, in the other direction, checks every succeeded charge against both ledgers and names anything in neither.

## Testing

`node --test tests/*.test.js` — **641 pass, 0 fail.**

New `tests/unlinked-payments.test.js` (27 tests) executes `taxPositionByMonth` against a fake pool rather than pattern-matching it, covering: unknown tax not counted as zero, known tax counting once established, a period with only unlinked money still appearing, a fully-remitted period still flagged when receipts are undetermined, and graceful degradation if the table does not exist yet.

One existing assertion in `stripe-payment-visibility.test.js` matched the exact line this changes. Its intent — "an unbanked payment must not end as only a log line" — is now more strongly satisfied, so it was rewritten to assert the intent, plus two new tests that the payment is recorded *and* that recording happens before alerting.

## Not verified here

No Postgres or Docker in this environment, so **the SQL has not been executed** — the DDL, the new queries and the backfill tool are statically checked only (placeholder/argument counts verified programmatically). Worth watching the first boot log for `Database ready.` and running the backfill as a dry run before `--apply`.

## Boundary — why radar-gate refuses this, and why it is needed

The gate refuses three lines. Recording them here as it asks. It has no
acceptance path for out-of-bounds *content*, so this check stays red by
design: merging is an owner decision, not an agent one.

| flagged | why it cannot be left out |
|---|---|
| `server.js` — `CREATE TABLE IF NOT EXISTS unlinked_payments (` | The entire change is a new ledger. Money belonging to no quote cannot go in `quote_payments`, where `quote_code` is `NOT NULL` and `syncPaidAmount()` rolls the table onto a quote. There is no version of this fix without a new table. |
| `tests/unlinked-payments.test.js` — the regex reading that DDL | The test asserts the shipped schema matches what the queries assume. It reads the DDL rather than changing it; removing it removes the check that the table and its readers agree. |
| `tools/backfill-unlinked.js` — `process.env.STRIPE_SECRET_KEY` | Recovering historical payments means asking Stripe what it took. It is a manual, dry-run-by-default operator tool that reads the key from the environment — never a literal, never committed, and it runs on demand rather than in the request path. |

The boundary exists to stop an agent doing schema work on a design or copy
task. This is the schema work, requested directly. Read the diff rather than
the check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J1q9YngZFnZTrztS3X8nZC
