### PR TITLE
Say why a sale was not taxed, instead of leaving a bare zero

### DIFF
--- a/server.js
+++ b/server.js
@@ -8653,7 +8653,7 @@ app.get('/books', requireAdmin, async (req, res) => {
           ${pos.undeterminedPayments > 0 ? `<div><strong>${pos.undeterminedPayments} receipt(s)</strong>
             totalling ${money(pos.undeterminedGross)} have no tax portion worked out, so every figure
             above is a floor rather than a total.
-            <a href="/exports/unlinked.csv" style="color:#78350f">See which</a>.</div>` : ''}
+            <a href="#settle-tax" style="color:#78350f">Settle them below</a>.</div>` : ''}
           ${pos.exemptUndocumented > 0 ? `<div style="margin-top:${pos.undeterminedPayments > 0 ? '6px' : '0'}">
             <strong>${pos.exemptUndocumented} untaxed sale(s)</strong> have no exemption number on
             file${pos.exemptGross > 0 ? `, against ${money(pos.exemptGross)} of receipts being deducted` : ''}.
@@ -8667,7 +8667,7 @@ app.get('/books', requireAdmin, async (req, res) => {
       </div>
 
       ${unsettled.length ? `
-      <div class="card" style="margin-top:14px">
+      <div class="card" id="settle-tax" style="margin-top:14px">
         <h2 style="margin:0 0 4px;font-size:16px">Receipts with the tax still to work out</h2>
         <p class="muted" style="font-size:12px;margin:0 0 10px">
           Money that arrived outside a quote, so this side never learned what tax it carried.

--- a/server.js
+++ b/server.js
@@ -137,6 +137,22 @@ async function initDB() {
   for (const col of [
     'needed_by DATE',                 // when the customer needs it
     'tax NUMERIC(10,2) DEFAULT 0',
+    /* Whether tax was CHARGED, as a decision rather than something inferred
+       from the amount. The quote form inferred it — `Number(E.tax) > 0` — so a
+       taxable job that happened to price at zero read back as untaxed, and a
+       genuine exemption read back exactly like someone forgetting the box.
+
+       Deliberately nullable with no default. NULL means "written before this
+       column existed", where the amount is the only evidence there is and the
+       old inference is still the right answer; see quoteTaxable(). Backfilling
+       it to a guess would destroy the distinction this column exists to make. */
+    'taxable BOOLEAN',
+    /* The purchaser's Illinois exemption ("E") number. Illinois does not want
+       exempt sales omitted from the ST-1 — they are reported as receipts and
+       then DEDUCTED — and expects the seller to produce the number on audit.
+       So a zero with no reference here is an open question, not a settled
+       figure, and taxPositionByMonth counts those separately. */
+    'tax_exempt_ref TEXT',
     'total NUMERIC(10,2) DEFAULT 0',  // subtotal + tax (card fee is added at payment)
     'deposit NUMERIC(10,2) DEFAULT 0',
     /* An off-the-top discount on the whole job — the "I'll do it for X" that
@@ -524,9 +540,25 @@ async function taxPositionByMonth(limit = 24) {
        FROM unlinked_payments
       GROUP BY 1`).catch(() => ({ rows: [] }));
 
+  /* Receipts deliberately not taxed. Illinois files these as receipts and then
+     DEDUCTS them, so the return needs the figure — leaving an exempt sale out
+     understates gross receipts, which is its own kind of wrong answer.
+     `undocumented` is the subset with no exemption number on file: still a
+     deduction being claimed, but not one that would survive an audit. */
+  const { rows: exempt } = await pool.query(
+    `SELECT to_char(date_trunc('month', p.created_at), 'YYYY-MM') AS period,
+            COALESCE(SUM(p.amount),0) AS exempt_gross,
+            COUNT(*)                  AS exempt_payments,
+            COUNT(*) FILTER (WHERE NULLIF(btrim(q.tax_exempt_ref), '') IS NULL)
+                                      AS exempt_undocumented
+       FROM quote_payments p JOIN quotes q ON q.code = p.quote_code
+      WHERE COALESCE(q.taxable, q.tax > 0) = false
+      GROUP BY 1`).catch(() => ({ rows: [] }));
+
   const blank = (period) => ({
     period, collected: 0, gross: 0, payments: 0, remitted: 0, last_paid: null,
     unlinkedGross: 0, unlinkedPayments: 0, unlinkedTaxKnown: 0, unlinkedTaxUnknown: 0,
+    exemptGross: 0, exemptPayments: 0, exemptUndocumented: 0,
   });
 
   const byPeriod = {};
@@ -548,6 +580,12 @@ async function taxPositionByMonth(limit = 24) {
     byPeriod[r.period].unlinkedPayments = Number(r.payments);
     byPeriod[r.period].unlinkedTaxKnown = round2(Number(r.tax_known));
     byPeriod[r.period].unlinkedTaxUnknown = Number(r.tax_unknown);
+  }
+  for (const r of exempt) {
+    byPeriod[r.period] ||= blank(r.period);
+    byPeriod[r.period].exemptGross = round2(Number(r.exempt_gross));
+    byPeriod[r.period].exemptPayments = Number(r.exempt_payments);
+    byPeriod[r.period].exemptUndocumented = Number(r.exempt_undocumented);
   }
 
   const list = Object.values(byPeriod)
@@ -571,6 +609,11 @@ async function taxPositionByMonth(limit = 24) {
     undeterminedPayments: list.reduce((s, p) => s + p.unlinkedTaxUnknown, 0),
     undeterminedGross: round2(list.reduce(
       (s, p) => s + (p.unlinkedTaxUnknown > 0 ? p.unlinkedGross : 0), 0)),
+    /* The ST-1 deduction line, and how much of it has nothing behind it. An
+       exempt sale is DETERMINED — its tax really is zero — so this never feeds
+       `undetermined`; it is a separate question about evidence, not amount. */
+    exemptGross: round2(list.reduce((s, p) => s + p.exemptGross, 0)),
+    exemptUndocumented: list.reduce((s, p) => s + p.exemptUndocumented, 0),
   };
 }
 
@@ -3652,6 +3695,32 @@ function quoteTax(subtotal, taxable) {
   return taxable ? round2(Number(subtotal) * TAX_RATE) : 0;
 }
 
+/**
+ * Was this job taxed? One definition, because the answer is read by the quote
+ * form, the tax export and the ST-1 position, and those three disagreeing is
+ * how an exempt sale turns into a missing sale.
+ *
+ * `taxable` NULL means the quote predates the stored flag. There the amount is
+ * the only evidence, so fall back to the inference the form used to make —
+ * which is correct for every historical row and wrong only for the case that
+ * could not previously be expressed anyway.
+ */
+function quoteTaxable(q) {
+  if (q && q.taxable != null) return !!q.taxable;
+  return Number(q && q.tax) > 0;
+}
+
+/**
+ * An untaxed sale with nothing on file to justify it.
+ *
+ * Not the same as "not exempt": it is the sale whose zero nobody can defend on
+ * audit yet. Reported rather than corrected, because only the shop knows
+ * whether the certificate exists and simply was not typed in.
+ */
+function quoteExemptUndocumented(q) {
+  return !quoteTaxable(q) && !String((q && q.tax_exempt_ref) || '').trim();
+}
+
 /** Deposit: half, unless the job is small enough that it is simpler to take it
  *  all up front. Never more than the total. */
 function depositFor(total) {
@@ -5250,7 +5319,16 @@ app.get(['/quote/new', '/quote/:code/edit'], requireAdmin, async (req, res) => {
             </div></td>
             <td class="num" id="disc" style="color:#166534">—</td></tr>
           <tr><td class="muted"><label style="display:inline;margin:0;text-transform:none;letter-spacing:0;font-size:14px;font-weight:400">
-            <input type="checkbox" name="taxable" value="1" ${!existing || Number(E.tax) > 0 ? 'checked' : ''} style="width:auto;margin-right:6px" onchange="calc()"> Illinois sales tax</label></td>
+            <input type="checkbox" name="taxable" value="1" ${!existing || quoteTaxable(E) ? 'checked' : ''} style="width:auto;margin-right:6px" onchange="calc()"> Illinois sales tax</label>
+            <div id="exemptbox" style="display:none;margin-top:5px">
+              <input name="tax_exempt_ref" value="${val(E.tax_exempt_ref)}" maxlength="60"
+                     placeholder="Exemption E-number — who is exempt, and under what"
+                     style="width:100%;padding:5px 7px;font-size:13px">
+              <div class="muted" style="font-size:11px;margin-top:3px;text-transform:none;letter-spacing:0">
+                Illinois reports exempt sales as receipts, then deducts them. Without the
+                number this reads as untaxed rather than exempt.
+              </div>
+            </div></td>
             <td class="num" id="tax">$0.00</td></tr>
           <tr><td class="tot">Total</td><td class="num tot" id="tot">$0.00</td></tr>
           <tr><td class="muted" style="padding-top:6px">Deposit to start</td><td class="num" id="dep" style="padding-top:6px">$0.00</td></tr>
@@ -5726,7 +5804,12 @@ ${quotePricingSource()}
         disc = Math.round(disc*100)/100;
         var net = gross - disc;
 
-        var tax = document.querySelector('[name=taxable]').checked ? net*TAX : 0;
+        var taxable = document.querySelector('[name=taxable]').checked;
+        /* The reason is asked for exactly when there is a zero to explain, so an
+           exempt sale cannot be saved as a silently untaxed one. */
+        var exbox = document.getElementById('exemptbox');
+        if (exbox) exbox.style.display = taxable ? 'none' : '';
+        var tax = taxable ? net*TAX : 0;
         var tot = net + tax;
         var dep = tot <= 0 ? 0 : (tot < FULL_UNDER ? tot : tot*DEP);
         document.getElementById('sub').textContent = m2(sub);
@@ -6370,6 +6453,13 @@ app.post(['/api/quotes', '/api/quotes/:code'], requireAdmin, async (req, res) =>
     const net = round2(gross - discount);
 
     const taxable = b.taxable === '1' || b.taxable === 'on' || b.taxable === true;
+    /* Kept only when the sale is actually untaxed. A reference sitting on a
+       taxable quote is a contradiction the export would have to interpret, and
+       it would survive un-ticking the box later as evidence for an exemption
+       nobody claimed. */
+    const exemptRef = taxable
+      ? null
+      : (String(one(b.tax_exempt_ref) || '').trim().slice(0, 60) || null);
     const tax = quoteTax(net, taxable);
     const total = round2(net + tax);
     const deposit = depositFor(total);
@@ -6389,12 +6479,13 @@ app.post(['/api/quotes', '/api/quotes/:code'], requireAdmin, async (req, res) =>
         `UPDATE quotes SET name=$2, phone=$3, email=$4, items=$5, subtotal=$6, tax=$7,
                 total=$8, deposit=$9, notes=$10, valid_until=$11, needed_by=$12,
                 discount_kind=$13, discount_value=$14, discount_note=$15, rush_pct=$16,
+                taxable=$17, tax_exempt_ref=$18,
                 change_request=NULL, requested_items=NULL, revision=COALESCE(revision,1)+1,
                 status = CASE WHEN accepted_at IS NULL THEN 'sent' ELSE status END
           WHERE code=$1 RETURNING *`,
         [editing, name, phone, email, JSON.stringify(items), subtotal, tax, total, deposit,
          String(b.notes || '').trim().slice(0, 2000), validUntil, neededBy,
-         discountKind, discountValue, discountNote || null, rushPct]));
+         discountKind, discountValue, discountNote || null, rushPct, taxable, exemptRef]));
       if (!rows.length) {
         return res.status(404).send(quotePage('Not found',
           `<div class="card"><div class="warn">That quote no longer exists.</div>
@@ -6413,11 +6504,11 @@ app.post(['/api/quotes', '/api/quotes/:code'], requireAdmin, async (req, res) =>
            would sit on the board until the contact-matching fallback happened
            to catch it, which it only does when the details match exactly. */
         `INSERT INTO quotes (code,name,phone,email,items,subtotal,tax,total,deposit,notes,status,valid_until,needed_by,
-                             discount_kind,discount_value,discount_note,rush_pct,from_submission_id)
-         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,'sent',$11,$12,$13,$14,$15,$16,$17) RETURNING *`,
+                             discount_kind,discount_value,discount_note,rush_pct,taxable,tax_exempt_ref,from_submission_id)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,'sent',$11,$12,$13,$14,$15,$16,$17,$18,$19) RETURNING *`,
         [code, name, phone, email, JSON.stringify(items), subtotal, tax, total, deposit,
          String(b.notes || '').trim().slice(0, 2000), validUntil, neededBy,
-         discountKind, discountValue, discountNote || null, rushPct,
+         discountKind, discountValue, discountNote || null, rushPct, taxable, exemptRef,
          (Number.isFinite(parseInt(one(b.from_submission_id), 10))
            ? parseInt(one(b.from_submission_id), 10) : null)]));
     }
@@ -8928,7 +9019,8 @@ app.get('/tax.csv', requireAdmin, async (req, res) => {
        page — and the two are meant to be the same number filed twice. */
     const { rows } = await pool.query(
       `SELECT p.created_at, p.quote_code, q.name, q.subtotal, q.tax, q.total,
-              p.amount, p.method, p.kind, p.tax_portion
+              p.amount, p.method, p.kind, p.tax_portion,
+              q.taxable, q.tax_exempt_ref
          FROM quote_payments p JOIN quotes q ON q.code = p.quote_code
         ORDER BY p.created_at`);
 
@@ -8946,21 +9038,27 @@ app.get('/tax.csv', requireAdmin, async (req, res) => {
     const all = [
       ...rows.map((r) => ({
         at: r.created_at,
+        /* `exempt` is what the ST-1 deducts, so it has to be readable without
+           inferring it from a zero in the tax column — a zero says nothing
+           about whether the sale was exempt or simply not charged tax. */
         cells: [day(r.created_at), r.quote_code, r.name, r.subtotal, r.tax,
-                r.total, r.amount, r.method, r.kind, r.tax_portion, 'quote'],
+                r.total, r.amount, r.method, r.kind, r.tax_portion,
+                quoteTaxable(r) ? '' : 'exempt',
+                String(r.tax_exempt_ref || '').trim(), 'quote'],
       })),
       ...unlinked.map((u) => ({
         at: u.created_at,
         cells: [day(u.created_at),
                 u.order_ref ? `studio #${u.order_ref}` : (u.client_ref || u.stripe_pi || ''),
                 u.customer_name || '', '', '', '', u.amount, 'card', u.kind,
-                u.tax_portion == null ? '' : u.tax_portion, u.channel],
+                u.tax_portion == null ? '' : u.tax_portion, '', '', u.channel],
       })),
     ].sort((a, b) => new Date(a.at) - new Date(b.at));
 
     sendCsv(res, `jtees-sales-tax-${new Date().toISOString().slice(0, 10)}.csv`,
       ['date', 'quote', 'customer', 'job_subtotal', 'job_tax', 'job_total',
-       'payment', 'method', 'kind', 'tax_portion_of_payment', 'source'],
+       'payment', 'method', 'kind', 'tax_portion_of_payment',
+       'exempt', 'exempt_ref', 'source'],
       all.map((r) => r.cells));
   } catch (err) {
     console.error('tax csv failed:', err.message);

--- a/server.js
+++ b/server.js
@@ -549,7 +549,11 @@ async function taxPositionByMonth(limit = 24) {
     `SELECT to_char(date_trunc('month', p.created_at), 'YYYY-MM') AS period,
             COALESCE(SUM(p.amount),0) AS exempt_gross,
             COUNT(*)                  AS exempt_payments,
-            COUNT(*) FILTER (WHERE NULLIF(btrim(q.tax_exempt_ref), '') IS NULL)
+            /* DISTINCT on the quote: a deposit and a balance are two payments
+               against ONE deduction, and counting both overstates how many
+               exemptions are missing evidence. */
+            COUNT(DISTINCT p.quote_code)
+              FILTER (WHERE NULLIF(btrim(q.tax_exempt_ref), '') IS NULL)
                                       AS exempt_undocumented
        FROM quote_payments p JOIN quotes q ON q.code = p.quote_code
       WHERE COALESCE(q.taxable, q.tax > 0) = false
@@ -5319,7 +5323,7 @@ app.get(['/quote/new', '/quote/:code/edit'], requireAdmin, async (req, res) => {
             </div></td>
             <td class="num" id="disc" style="color:#166534">—</td></tr>
           <tr><td class="muted"><label style="display:inline;margin:0;text-transform:none;letter-spacing:0;font-size:14px;font-weight:400">
-            <input type="checkbox" name="taxable" value="1" ${!existing || quoteTaxable(E) ? 'checked' : ''} style="width:auto;margin-right:6px" onchange="calc()"> Illinois sales tax</label>
+            <input type="checkbox" name="taxable" value="1" ${!isEdit || quoteTaxable(E) ? 'checked' : ''} style="width:auto;margin-right:6px" onchange="calc()"> Illinois sales tax</label>
             <div id="exemptbox" style="display:none;margin-top:5px">
               <input name="tax_exempt_ref" value="${val(E.tax_exempt_ref)}" maxlength="60"
                      placeholder="Exemption E-number — who is exempt, and under what"
@@ -8643,6 +8647,18 @@ app.get('/books', requireAdmin, async (req, res) => {
           ${tile('Held right now', money(pos.setAside),
                  pos.setAside > 0 ? '#b45309' : '#047857', 'across all periods')}
         </div>
+        ${(pos.undeterminedPayments > 0 || pos.exemptUndocumented > 0) ? `
+        <div style="margin-top:10px;padding:8px 10px;border-radius:6px;background:#fef3c7;
+                    border:1px solid #fcd34d;font-size:12px;color:#78350f">
+          ${pos.undeterminedPayments > 0 ? `<div><strong>${pos.undeterminedPayments} receipt(s)</strong>
+            totalling ${money(pos.undeterminedGross)} have no tax portion worked out, so every figure
+            above is a floor rather than a total.
+            <a href="/exports/unlinked.csv" style="color:#78350f">See which</a>.</div>` : ''}
+          ${pos.exemptUndocumented > 0 ? `<div style="margin-top:${pos.undeterminedPayments > 0 ? '6px' : '0'}">
+            <strong>${pos.exemptUndocumented} untaxed sale(s)</strong> have no exemption number on
+            file${pos.exemptGross > 0 ? `, against ${money(pos.exemptGross)} of receipts being deducted` : ''}.
+            Illinois expects the purchaser's E number to be producible on audit.</div>` : ''}
+        </div>` : ''}
         <div class="muted" style="font-size:11px;margin-top:10px">
           Held right now spans every period, not just ${year} — it is what should be in the bank today.
           <a href="/tax.csv" style="color:#1848B8">Download the payment-level detail</a>,
@@ -9022,7 +9038,17 @@ app.get('/tax.csv', requireAdmin, async (req, res) => {
               p.amount, p.method, p.kind, p.tax_portion,
               q.taxable, q.tax_exempt_ref
          FROM quote_payments p JOIN quotes q ON q.code = p.quote_code
-        ORDER BY p.created_at`);
+        ORDER BY p.created_at`)
+      /* A deploy that races the migration loses the exemption columns rather
+         than the whole export — the same guard the sibling queries carry.
+         Without it this route goes from working to a 500 for the deploy
+         window, on the one file the shop files a return from. */
+      .catch(() => pool.query(
+        `SELECT p.created_at, p.quote_code, q.name, q.subtotal, q.tax, q.total,
+                p.amount, p.method, p.kind, p.tax_portion,
+                NULL::boolean AS taxable, NULL::text AS tax_exempt_ref
+           FROM quote_payments p JOIN quotes q ON q.code = p.quote_code
+          ORDER BY p.created_at`));
 
     /* Receipts from the design studio and anything else that arrived outside
        the quote flow. They belong in this file because the ST-1 is filed on

--- a/server.js
+++ b/server.js
@@ -3725,6 +3725,11 @@ function quoteExemptUndocumented(q) {
   return !quoteTaxable(q) && !String((q && q.tax_exempt_ref) || '').trim();
 }
 
+/** Can this sale carry an exemption number? Only one that charged no tax. */
+function quoteExemptable(q) {
+  return !quoteTaxable(q);
+}
+
 /** Deposit: half, unless the job is small enough that it is simpler to take it
  *  all up front. Never more than the total. */
 function depositFor(total) {
@@ -8361,6 +8366,20 @@ app.get('/books', requireAdmin, async (req, res) => {
         WHERE tax_portion IS NULL
         ORDER BY created_at LIMIT 50`).catch(() => ({ rows: [] }));
 
+    /* Sales that charged no tax with nothing on file saying why. Illinois
+       deducts these on the return and expects the purchaser's number to be
+       producible, so each is a deduction currently claimed without evidence. */
+    const { rows: undocumented } = await pool.query(
+      `SELECT code, name, subtotal, created_at,
+              COALESCE((SELECT SUM(amount) FROM quote_payments p
+                         WHERE p.quote_code = q.code), 0) AS paid
+         FROM quotes q
+        WHERE COALESCE(q.taxable, q.tax > 0) = false
+          AND COALESCE(q.subtotal, 0) > 0
+          AND NULLIF(btrim(q.tax_exempt_ref), '') IS NULL
+          AND q.cancelled_at IS NULL
+        ORDER BY q.created_at DESC LIMIT 50`).catch(() => ({ rows: [] }));
+
     /* Overheads by month, and the recent list for the register below. */
     const { rows: expMonths } = await pool.query(
       `SELECT to_char(date_trunc('month', spent_on), 'YYYY-MM') AS period,
@@ -8657,7 +8676,7 @@ app.get('/books', requireAdmin, async (req, res) => {
           ${pos.exemptUndocumented > 0 ? `<div style="margin-top:${pos.undeterminedPayments > 0 ? '6px' : '0'}">
             <strong>${pos.exemptUndocumented} untaxed sale(s)</strong> have no exemption number on
             file${pos.exemptGross > 0 ? `, against ${money(pos.exemptGross)} of receipts being deducted` : ''}.
-            Illinois expects the purchaser's E number to be producible on audit.</div>` : ''}
+            <a href="#exemptions" style="color:#78350f">Record them below</a>.</div>` : ''}
         </div>` : ''}
         <div class="muted" style="font-size:11px;margin-top:10px">
           Held right now spans every period, not just ${year} — it is what should be in the bank today.
@@ -8701,6 +8720,45 @@ app.get('/books', requireAdmin, async (req, res) => {
                        placeholder="unknown"
                        style="width:96px;padding:5px 7px;font-size:13px">
                 <button class="btn" style="padding:5px 12px;font-size:13px">Settle</button>
+              </form>
+            </td>
+          </tr>`).join('')}
+        </table>
+      </div>` : ''}
+
+      ${undocumented.length ? `
+      <div class="card" id="exemptions" style="margin-top:14px">
+        <h2 style="margin:0 0 4px;font-size:16px">Untaxed sales with no exemption number</h2>
+        <p class="muted" style="font-size:12px;margin:0 0 10px">
+          Illinois reports these as receipts and then deducts them, and expects the purchaser's
+          exemption (&ldquo;E&rdquo;) number to be producible on audit. Without one, a sale here is
+          indistinguishable from tax somebody forgot to charge. Recording a number does not
+          re-price the job.
+        </p>
+        <table style="width:100%;border-collapse:collapse;font-size:13px">
+          <tr style="text-align:left;color:#6b7280;font-size:11px;text-transform:uppercase">
+            <th style="padding:6px 4px">Quote</th>
+            <th style="padding:6px 4px">Customer</th>
+            <th class="num" style="padding:6px 4px">Sale</th>
+            <th class="num" style="padding:6px 4px">Paid</th>
+            <th style="padding:6px 4px">Exemption number</th>
+          </tr>
+          ${undocumented.map((q) => `
+          <tr style="border-top:1px solid #e5e7eb">
+            <td style="padding:7px 4px;white-space:nowrap">
+              <a href="/q/${escEmail(String(q.code))}" style="color:#1848B8">${escEmail(String(q.code))}</a>
+              <div class="muted" style="font-size:11px">${new Date(q.created_at).toISOString().slice(0, 10)}</div>
+            </td>
+            <td style="padding:7px 4px">${escEmail(String(q.name || ''))}</td>
+            <td class="num" style="padding:7px 4px;font-variant-numeric:tabular-nums">${money(q.subtotal)}</td>
+            <td class="num" style="padding:7px 4px;font-variant-numeric:tabular-nums">${money(q.paid)}</td>
+            <td style="padding:7px 4px">
+              <form method="post" action="/quotes/${escEmail(String(q.code))}/exemption"
+                    style="display:flex;gap:6px;margin:0">
+                <input type="hidden" name="back" value="/books?year=${year}#exemptions">
+                <input name="tax_exempt_ref" maxlength="60" placeholder="E-number"
+                       style="width:150px;padding:5px 7px;font-size:13px">
+                <button class="btn" style="padding:5px 12px;font-size:13px">Record</button>
               </form>
             </td>
           </tr>`).join('')}
@@ -12941,6 +12999,53 @@ app.post('/tax/remit', requireAdmin, async (req, res) => {
     console.error('tax remit failed:', err.message);
   }
   res.redirect('/quotes');
+});
+
+/* Put an exemption number on a sale that was already made.
+ *
+ * The quote form can set this, but only by re-saving the whole quote — which
+ * re-prices the job from the current catalogue, bumps `revision`, and resets an
+ * unaccepted quote to 'sent'. None of that should happen because somebody typed
+ * in a certificate number, and least of all on a quote that has already been
+ * paid, where re-pricing could move a total the customer has settled against.
+ *
+ * So this writes the one column, and pins `taxable` to false while it does:
+ * recording the number IS the decision that the sale was exempt, and leaving
+ * the flag NULL would keep the row relying on the "tax is zero so it must be
+ * untaxed" inference it exists to replace.
+ */
+app.post('/quotes/:code/exemption', requireAdmin, async (req, res) => {
+  const code = String(req.params.code || '').toUpperCase();
+  const b = req.body || {};
+  const back = String(b.back || '/books');
+  if (!QUOTE_CODE_RE.test(code)) return res.redirect('/books');
+
+  const ref = String(b.tax_exempt_ref ?? '').trim().slice(0, 60) || null;
+
+  try {
+    const { rows } = await pool.query(
+      `SELECT taxable, tax FROM quotes WHERE code = $1`, [code]);
+    if (!rows.length) return res.redirect(back);
+
+    /* An exemption number on a sale that CHARGED tax is a contradiction, and
+       one the export would then have to interpret. Refuse it rather than store
+       it — the fix is to un-tick the tax on the quote first, which is a pricing
+       decision and belongs in the quote form. */
+    if (ref && !quoteExemptable(rows[0])) {
+      console.warn(`exemption ref rejected for ${code}: the quote charged tax`);
+      return res.redirect(back);
+    }
+
+    await pool.query(
+      `UPDATE quotes
+          SET tax_exempt_ref = $2,
+              taxable = CASE WHEN $2::text IS NULL THEN taxable ELSE false END
+        WHERE code = $1`, [code, ref]);
+    console.log(`quote ${code} exemption ${ref ? 'recorded' : 'cleared'}`);
+  } catch (err) {
+    console.error('exemption update failed:', err.message);
+  }
+  res.redirect(back);
 });
 
 /* Settle the tax portion of a payment that arrived outside the quote flow.

--- a/tests/tax-exemption.test.js
+++ b/tests/tax-exemption.test.js
@@ -132,8 +132,31 @@ test('the form asks for the reason exactly when there is a zero to explain', () 
   assert.match(src, /name="tax_exempt_ref"/, 'no field, no reason, no deduction');
   assert.match(src, /exbox\.style\.display = taxable \? 'none' : ''/,
     'the reason appears when tax comes off, so it cannot be quietly skipped');
-  assert.match(src, /\$\{!existing \|\| quoteTaxable\(E\) \? 'checked' : ''\}/,
+  assert.match(src, /\$\{!isEdit \|\| quoteTaxable\(E\) \? 'checked' : ''\}/,
     'the checkbox must read the stored flag, not re-derive it from the amount');
+});
+
+test('a new quote prefilled from an enquiry still defaults to taxable', () => {
+  /* `existing` is truthy for BOTH a saved quote and a blank one prefilled from
+     a lead or an abandoned cart — those carry tax: 0 and no code. Keying the
+     checkbox off `existing` therefore opened every enquiry-sourced quote with
+     tax un-ticked, which used to produce merely an untaxed row and now would
+     persist taxable=false and file it as a deliberate ST-1 deduction.
+     `isEdit` is the discriminator that already exists for this exact reason. */
+  assert.match(src, /const isEdit = !!\(existing && existing\.code\)/,
+    'isEdit is what separates an edit from a prefilled blank');
+  assert.doesNotMatch(src, /\$\{!existing \|\| quoteTaxable/,
+    'a prefilled blank is not an exemption');
+});
+
+test('the books page says when its own numbers are incomplete', () => {
+  /* A figure computed and rendered nowhere warns nobody. The whole point of
+     separating unknown tax and undocumented exemptions is that someone sees
+     them before filing. */
+  assert.match(src, /pos\.undeterminedPayments > 0 \|\| pos\.exemptUndocumented > 0/,
+    'the tax card must raise both, or the distinction never reaches a human');
+  assert.match(src, /untaxed sale\(s\)<\/strong> have no exemption number on/,
+    'an undocumented deduction has to be visible where the return is read from');
 });
 
 /* ── The export ──────────────────────────────────────────────────────────── */
@@ -187,6 +210,23 @@ test('every row has exactly as many cells as there are headers', () => {
     'quote rows must line up with the header');
   assert.strictEqual(topLevelCount(unlinkedCells.inner), headers,
     'unlinked rows must line up with the header');
+});
+
+test('/tax.csv survives a deploy that races the migration', () => {
+  /* Its sibling queries are all guarded. Unguarded, the export goes from
+     working to a 500 during the deploy window — on the one file a return is
+     filed from. */
+  assert.match(TAXCSV, /\.catch\(\(\) => pool\.query\(/,
+    'a missing column must cost the exemption columns, not the whole export');
+  assert.match(TAXCSV, /NULL::boolean AS taxable, NULL::text AS tax_exempt_ref/,
+    'the fallback has to return the same shape the rows print');
+});
+
+test('one exempt quote paid twice is one undocumented exemption', () => {
+  /* COUNT(*) over quote_payments counts a deposit and a balance separately,
+     so a single missing E number reads as two. */
+  assert.match(src, /COUNT\(DISTINCT p\.quote_code\)\s*\n?\s*FILTER \(WHERE NULLIF\(btrim\(q\.tax_exempt_ref\)/,
+    'the count is of deductions, not of payments');
 });
 
 test('the export says exempt rather than leaving a bare zero', () => {

--- a/tests/tax-exemption.test.js
+++ b/tests/tax-exemption.test.js
@@ -238,6 +238,62 @@ test('the export says exempt rather than leaving a bare zero', () => {
     'the query has to actually select the columns the rows print');
 });
 
+/* ── Documenting a sale that has already happened ────────────────────────── */
+
+const EXEMPT_ROUTE = (() => {
+  const i = src.indexOf("app.post('/quotes/:code/exemption'");
+  assert.notStrictEqual(i, -1, 'an exemption must be recordable after the sale');
+  return src.slice(i, i + 2200);
+})();
+
+test('an exemption can be recorded without re-pricing the job', () => {
+  /* The quote form can set the reference, but only by re-saving the whole
+     quote: that re-prices from the current catalogue, bumps `revision`, and
+     resets an unaccepted quote to 'sent'. On a quote already PAID it could move
+     a total the customer has settled against — all because somebody typed in a
+     certificate number. */
+  assert.match(EXEMPT_ROUTE, /requireAdmin/);
+  assert.match(EXEMPT_ROUTE, /UPDATE quotes\s*\n\s*SET tax_exempt_ref = \$2/,
+    'it writes the reference, not the quote');
+  assert.doesNotMatch(EXEMPT_ROUTE, /subtotal|items|quoteTotals|revision/,
+    'recording evidence must not touch the money');
+});
+
+test('recording the number also records the decision', () => {
+  /* Leaving `taxable` NULL would keep the row relying on the "tax is zero so
+     it must be untaxed" inference that the column exists to replace. */
+  assert.match(EXEMPT_ROUTE,
+    /taxable = CASE WHEN \$2::text IS NULL THEN taxable ELSE false END/,
+    'an E number IS the statement that this sale was exempt');
+});
+
+test('an exemption number is refused on a sale that charged tax', () => {
+  /* Otherwise the export has to interpret a contradiction, and the reference
+     survives to look like evidence for an exemption nobody claimed. */
+  assert.match(EXEMPT_ROUTE, /if \(ref && !quoteExemptable\(rows\[0\]\)\)/,
+    'a taxed sale cannot carry an exemption');
+  assert.strictEqual(run('quoteExemptable', { taxable: true, tax: 10 }, ['quoteTaxable']), false);
+  assert.strictEqual(run('quoteExemptable', { taxable: false, tax: 0 }, ['quoteTaxable']), true);
+  assert.strictEqual(run('quoteExemptable', { tax: 0 }, ['quoteTaxable']), true,
+    'a historical untaxed quote can still be documented');
+});
+
+test('clearing the number leaves the taxable decision alone', () => {
+  /* Removing evidence is not the same as deciding the sale was taxable. That
+     is a pricing change and belongs in the quote form. */
+  assert.match(EXEMPT_ROUTE, /WHEN \$2::text IS NULL THEN taxable/,
+    'a blank must not silently re-tax the sale');
+});
+
+test('the books page lists the sales that need a number', () => {
+  assert.match(src, /COALESCE\(q\.taxable, q\.tax > 0\) = false\s*\n\s*AND COALESCE\(q\.subtotal, 0\) > 0\s*\n\s*AND NULLIF\(btrim\(q\.tax_exempt_ref\), ''\) IS NULL/,
+    'the undocumented sales are the ones worth showing');
+  assert.match(src, /AND q\.cancelled_at IS NULL/,
+    'a cancelled quote is not a deduction being claimed');
+  assert.match(src, /action="\/quotes\/\$\{escEmail\(String\(q\.code\)\)\}\/exemption"/,
+    'each row needs a way to record it, or the route is unreachable');
+});
+
 /* ── The tax position ────────────────────────────────────────────────────── */
 
 function runTaxPosition({ collected = [], remitted = [], unlinked = [], exempt = [] }) {

--- a/tests/tax-exemption.test.js
+++ b/tests/tax-exemption.test.js
@@ -1,0 +1,321 @@
+'use strict';
+
+/* Sales tax that is zero ON PURPOSE.
+ *
+ * The ledger already learned that an UNKNOWN tax portion is not zero
+ * (unlinked-payments.test.js). This is the third state it still could not
+ * express: a tax of zero that is CORRECT, because the buyer is exempt — and
+ * that needs evidence behind it, because Illinois does not simply drop an
+ * exempt sale from the return. Exempt sales are reported as receipts and then
+ * DEDUCTED, and the seller is expected to produce the purchaser's exemption
+ * ("E") number on audit.
+ *
+ * Before this, quote tax was zero and nothing said why. The form even inferred
+ * the taxable flag from the amount — `Number(E.tax) > 0` — so three different
+ * situations collapsed into one indistinguishable row:
+ *
+ *   - a genuinely exempt organisation
+ *   - a taxable job that happened to price at zero
+ *   - somebody forgetting to tick the box
+ *
+ * The rule this file defends: a zero that is deliberate says so, and says on
+ * whose authority.
+ *
+ * Run: node --test tests/*.test.js
+ */
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const src = fs.readFileSync(path.join(__dirname, '..', 'server.js'), 'utf8');
+const backfill = fs.readFileSync(
+  path.join(__dirname, '..', 'tools', 'backfill-unlinked.js'), 'utf8');
+
+function lift(name) {
+  let start = src.indexOf(`function ${name}(`);
+  assert.notStrictEqual(start, -1, `${name} not found`);
+  if (src.slice(start - 6, start) === 'async ') start -= 6;
+  let i = src.indexOf('(', src.indexOf(name, start));
+  for (let paren = 0; i < src.length; i++) {
+    if (src[i] === '(') paren++;
+    else if (src[i] === ')' && --paren === 0) { i++; break; }
+  }
+  let depth = 0;
+  for (i = src.indexOf('{', i); i < src.length; i++) {
+    if (src[i] === '{') depth++;
+    else if (src[i] === '}' && --depth === 0) return src.slice(start, i + 1);
+  }
+  throw new Error('unbalanced braces reading ' + name);
+}
+
+/* `deps` are the other functions the one under test calls. Lifting a function
+   that calls a helper without it throws ReferenceError at call time, which
+   reads as a bug in the code rather than a gap in the harness. */
+function run(name, args, deps = []) {
+  const sandbox = { round2: (n) => Math.round((Number(n) || 0) * 100) / 100 };
+  vm.createContext(sandbox);
+  const source = [...deps, name].map(lift).join('\n');
+  return vm.runInContext(source + '\n' + name, sandbox)(args);
+}
+
+/* ── The columns ─────────────────────────────────────────────────────────── */
+
+test('taxable is nullable and has no default', () => {
+  /* The load-bearing line. A NOT NULL DEFAULT TRUE would silently declare
+     every historical quote taxable — including the exempt one that prompted
+     this — and a DEFAULT FALSE would do the reverse. NULL means "written
+     before the column existed", where the amount is the only evidence and the
+     old inference is still the right answer. */
+  const m = /'taxable BOOLEAN([^']*)'/.exec(src);
+  assert.ok(m, 'taxable column missing from the quotes ALTER list');
+  assert.doesNotMatch(m[1], /NOT NULL/, 'an undecided quote must stay expressible');
+  assert.doesNotMatch(m[1], /DEFAULT/,
+    'backfilling a guess destroys the distinction the column exists to make');
+});
+
+test('there is somewhere to put the exemption number', () => {
+  assert.match(src, /'tax_exempt_ref TEXT'/,
+    'a deduction with no reference behind it is not one that survives an audit');
+});
+
+/* ── Reading the decision ────────────────────────────────────────────────── */
+
+test('a stored taxable flag beats the amount', () => {
+  /* The whole point: a taxable job priced at zero is still taxable, and an
+     exempt job is exempt even if someone typed a figure into tax. */
+  assert.strictEqual(run('quoteTaxable', { taxable: true, tax: 0 }), true);
+  assert.strictEqual(run('quoteTaxable', { taxable: false, tax: 12.5 }), false);
+});
+
+test('a quote written before the column falls back to the old inference', () => {
+  /* Every historical row reads exactly as it did yesterday. Changing how they
+     read would restate periods that have already been filed. */
+  assert.strictEqual(run('quoteTaxable', { tax: 9.5 }), true);
+  assert.strictEqual(run('quoteTaxable', { tax: 0 }), false);
+  assert.strictEqual(run('quoteTaxable', { taxable: null, tax: 9.5 }), true);
+  assert.strictEqual(run('quoteTaxable', {}), false);
+});
+
+test('an untaxed sale with no reference is flagged, a documented one is not', () => {
+  assert.strictEqual(run('quoteExemptUndocumented', { taxable: false }, ['quoteTaxable']), true,
+    'a zero nobody can defend is the thing worth surfacing');
+  assert.strictEqual(
+    run('quoteExemptUndocumented', { taxable: false, tax_exempt_ref: 'E9998-1234-07' },
+        ['quoteTaxable']),
+    false);
+  assert.strictEqual(run('quoteExemptUndocumented', { taxable: false, tax_exempt_ref: '   ' }, ['quoteTaxable']),
+    true, 'whitespace is not evidence');
+  assert.strictEqual(run('quoteExemptUndocumented', { taxable: true, tax: 10 }, ['quoteTaxable']), false,
+    'a taxed sale is not an undocumented exemption');
+});
+
+/* ── Writing the decision ────────────────────────────────────────────────── */
+
+test('an exemption reference is not kept on a taxable quote', () => {
+  /* Otherwise it survives un-ticking the box later and reads as evidence for
+     an exemption nobody actually claimed. */
+  assert.match(src, /const exemptRef = taxable\s*\n?\s*\?\s*null/,
+    'a taxable quote must store no exemption reference');
+});
+
+test('both the flag and the reference are actually persisted', () => {
+  assert.match(src, /UPDATE quotes SET[\s\S]{0,600}taxable=\$\d+, tax_exempt_ref=\$\d+/,
+    'editing a quote must be able to change the exemption');
+  assert.match(src, /INSERT INTO quotes \([^)]*taxable,tax_exempt_ref/,
+    'a new quote must record the decision it was written under');
+});
+
+test('the form asks for the reason exactly when there is a zero to explain', () => {
+  assert.match(src, /name="tax_exempt_ref"/, 'no field, no reason, no deduction');
+  assert.match(src, /exbox\.style\.display = taxable \? 'none' : ''/,
+    'the reason appears when tax comes off, so it cannot be quietly skipped');
+  assert.match(src, /\$\{!existing \|\| quoteTaxable\(E\) \? 'checked' : ''\}/,
+    'the checkbox must read the stored flag, not re-derive it from the amount');
+});
+
+/* ── The export ──────────────────────────────────────────────────────────── */
+
+const TAXCSV = (() => {
+  const i = src.indexOf("app.get('/tax.csv'");
+  assert.notStrictEqual(i, -1, '/tax.csv route not found');
+  const j = src.indexOf("app.get('/exports/unlinked.csv'", i);
+  assert.notStrictEqual(j, -1, 'could not find the end of the /tax.csv route');
+  return src.slice(i, j);
+})();
+
+/** The contents of the array literal starting at or after `from`. */
+function arrayAt(text, from) {
+  const start = text.indexOf('[', from);
+  assert.notStrictEqual(start, -1, 'no array literal found');
+  let depth = 0;
+  for (let i = start; i < text.length; i++) {
+    if (text[i] === '[') depth++;
+    else if (text[i] === ']' && --depth === 0) {
+      return { inner: text.slice(start + 1, i), end: i };
+    }
+  }
+  throw new Error('unbalanced brackets');
+}
+
+/** How many elements an array literal has, ignoring nested ones. */
+function topLevelCount(inner) {
+  if (!inner.trim()) return 0;
+  let depth = 0, n = 1;
+  for (const c of inner) {
+    if ('[({'.includes(c)) depth++;
+    else if ('])}'.includes(c)) depth--;
+    else if (c === ',' && depth === 0) n++;
+  }
+  return n;
+}
+
+test('every row has exactly as many cells as there are headers', () => {
+  /* A CSV whose rows are one cell short does not fail — it shifts every value
+     into the wrong column, and the file still opens. On a tax export that is a
+     wrong number filed rather than an error anyone sees. */
+  const header = arrayAt(TAXCSV, TAXCSV.indexOf('jtees-sales-tax-'));
+  const headers = topLevelCount(header.inner);
+  assert.ok(headers >= 13, `expected the widened header, got ${headers} columns`);
+
+  const quoteCells = arrayAt(TAXCSV, TAXCSV.indexOf('cells: ['));
+  const unlinkedCells = arrayAt(TAXCSV, TAXCSV.indexOf('cells: [', quoteCells.end));
+
+  assert.strictEqual(topLevelCount(quoteCells.inner), headers,
+    'quote rows must line up with the header');
+  assert.strictEqual(topLevelCount(unlinkedCells.inner), headers,
+    'unlinked rows must line up with the header');
+});
+
+test('the export says exempt rather than leaving a bare zero', () => {
+  assert.match(TAXCSV, /'exempt', 'exempt_ref'/,
+    'the ST-1 deducts exempt sales, so they have to be identifiable as exempt');
+  assert.match(TAXCSV, /quoteTaxable\(r\) \? '' : 'exempt'/,
+    'exemption is read through the shared helper, not re-derived here');
+  assert.match(TAXCSV, /q\.taxable, q\.tax_exempt_ref/,
+    'the query has to actually select the columns the rows print');
+});
+
+/* ── The tax position ────────────────────────────────────────────────────── */
+
+function runTaxPosition({ collected = [], remitted = [], unlinked = [], exempt = [] }) {
+  const sandbox = {
+    round2: (n) => Math.round((Number(n) || 0) * 100) / 100,
+    pool: {
+      query(sql) {
+        if (/JOIN quotes/.test(sql)) return Promise.resolve({ rows: exempt });
+        if (/FROM quote_payments/.test(sql)) return Promise.resolve({ rows: collected });
+        if (/FROM tax_remittances/.test(sql)) return Promise.resolve({ rows: remitted });
+        if (/FROM unlinked_payments/.test(sql)) return Promise.resolve({ rows: unlinked });
+        throw new Error('unexpected query: ' + sql);
+      },
+    },
+  };
+  vm.createContext(sandbox);
+  return vm.runInContext(lift('taxPositionByMonth') + '\ntaxPositionByMonth', sandbox)();
+}
+
+test('exempt receipts are reported, not silently dropped', async () => {
+  /* Leaving an exempt sale out understates gross receipts. It belongs on the
+     return as a receipt and then as a deduction. */
+  const pos = await runTaxPosition({
+    collected: [{ period: '2026-08', collected: '100.00', gross: '1000.00', payments: '4' }],
+    exempt: [{ period: '2026-08', exempt_gross: '584.95', exempt_payments: '1',
+               exempt_undocumented: '0' }],
+  });
+  assert.strictEqual(pos.months[0].exemptGross, 584.95);
+  assert.strictEqual(pos.exemptGross, 584.95);
+});
+
+test('an exempt sale never adds tax that was not collected', async () => {
+  const pos = await runTaxPosition({
+    collected: [{ period: '2026-08', collected: '100.00', gross: '1000.00', payments: '4' }],
+    exempt: [{ period: '2026-08', exempt_gross: '584.95', exempt_payments: '1',
+               exempt_undocumented: '0' }],
+  });
+  assert.strictEqual(pos.months[0].outstanding, 100,
+    'the deduction is receipts, not tax — it must not move the set-aside');
+  assert.strictEqual(pos.setAside, 100);
+});
+
+test('an exempt sale does NOT make the period undetermined', async () => {
+  /* Exempt is a KNOWN zero. Conflating it with an unknown would make every
+     month carrying a nonprofit order look unfileable. */
+  const pos = await runTaxPosition({
+    exempt: [{ period: '2026-08', exempt_gross: '584.95', exempt_payments: '1',
+               exempt_undocumented: '0' }],
+  });
+  assert.strictEqual(pos.months[0].undetermined, false);
+  assert.strictEqual(pos.undeterminedPayments, 0);
+});
+
+test('an exemption with nothing on file is counted separately', async () => {
+  const pos = await runTaxPosition({
+    exempt: [{ period: '2026-08', exempt_gross: '584.95', exempt_payments: '2',
+               exempt_undocumented: '1' }],
+  });
+  assert.strictEqual(pos.months[0].exemptUndocumented, 1);
+  assert.strictEqual(pos.exemptUndocumented, 1,
+    'a deduction claimed with no reference is the one an audit removes');
+});
+
+test('a period with only exempt sales still appears', async () => {
+  const pos = await runTaxPosition({
+    exempt: [{ period: '2026-07', exempt_gross: '120.00', exempt_payments: '1',
+               exempt_undocumented: '0' }],
+  });
+  assert.strictEqual(pos.months.length, 1);
+  assert.strictEqual(pos.months[0].period, '2026-07');
+});
+
+test('the exempt query survives a database that has not migrated yet', () => {
+  /* q.taxable does not exist until initDB has run. Without the catch, the
+     whole tax page dies on a stale schema instead of degrading. */
+  const fn = lift('taxPositionByMonth');
+  const i = fn.indexOf('WHERE COALESCE(q.taxable');
+  assert.notStrictEqual(i, -1, 'exempt query not found');
+  assert.match(fn.slice(i, i + 260), /\.catch\(\(\) => \(\{ rows: \[\] \}\)\)/,
+    'a missing column must not take the tax position down with it');
+});
+
+test('the exempt query reads taxable the same way the helper does', () => {
+  /* Two definitions of "was this taxed" is how the export and the return end
+     up disagreeing about the same sale. */
+  assert.match(src, /COALESCE\(q\.taxable, q\.tax > 0\) = false/,
+    'SQL must mirror quoteTaxable()\'s NULL fallback exactly');
+});
+
+/* ── Excluding a charge that is not a receipt ────────────────────────────── */
+
+test('--exclude does not eat the first argument when it is absent', () => {
+  /* `args[args.indexOf('--exclude') + 1]` is args[0] when the flag is missing,
+     so `--apply` alone would have excluded a charge id of "--apply" — harmless
+     — but `--since 2024-01-01` would silently exclude nothing while looking
+     like it did. Guarded with includes() first. */
+  assert.match(backfill, /args\.includes\('--exclude'\)/,
+    'the flag must be checked before its value is read');
+});
+
+test('exclusion is by id, never by amount', () => {
+  /* A minimum-amount filter would quietly swallow small REAL sales, which is
+     the exact failure this whole ledger exists to prevent. */
+  assert.doesNotMatch(backfill, /amount\s*<\s*\d|MIN_AMOUNT|minAmount/,
+    'no threshold filtering — drop charges by name or not at all');
+  assert.match(backfill, /const excluded = \(\.\.\.ids\) =>/,
+    'exclusion matches identifiers');
+});
+
+test('an excluded charge is counted out loud', () => {
+  /* A silent skip is indistinguishable from a bug. */
+  assert.match(backfill, /\$\{skipped\} excluded/);
+  assert.match(backfill, /chargesSkipped\} excluded by --exclude/);
+});
+
+test('both loops honour the exclusion', () => {
+  assert.match(backfill, /excluded\(s\.id, s\.payment_intent\)/,
+    'the session sweep must skip it');
+  assert.match(backfill, /excluded\(c\.id, pi\)/,
+    'the charge reconciliation must skip it too, or it reappears as an orphan');
+});

--- a/tests/unlinked-payments.test.js
+++ b/tests/unlinked-payments.test.js
@@ -347,11 +347,17 @@ test('money belonging to a real quote is reported, never written as unlinked', (
 
 /* ── The tax position ────────────────────────────────────────────────────── */
 
-function runTaxPosition({ collected = [], remitted = [], unlinked = [], unlinkedFails = false }) {
+function runTaxPosition({ collected = [], remitted = [], unlinked = [], exempt = [],
+                          unlinkedFails = false }) {
   const sandbox = {
     round2: (n) => Math.round((Number(n) || 0) * 100) / 100,
     pool: {
       query(sql) {
+        /* Checked BEFORE the plain quote_payments branch: the exempt query
+           reads the same table and would otherwise be handed the `collected`
+           rows, which carry none of the columns it reads — every exempt figure
+           would come back NaN and no test would notice. */
+        if (/JOIN quotes/.test(sql)) return Promise.resolve({ rows: exempt });
         if (/FROM quote_payments/.test(sql)) return Promise.resolve({ rows: collected });
         if (/FROM tax_remittances/.test(sql)) return Promise.resolve({ rows: remitted });
         if (/FROM unlinked_payments/.test(sql)) {

--- a/tools/backfill-unlinked.js
+++ b/tools/backfill-unlinked.js
@@ -18,6 +18,7 @@
  *   node tools/backfill-unlinked.js                      dry run, last 2 years
  *   node tools/backfill-unlinked.js --since 2024-01-01   dry run from a date
  *   node tools/backfill-unlinked.js --since 2024-01-01 --apply    write it
+ *   node tools/backfill-unlinked.js --exclude pi_x,cs_y         skip these
  *
  * Against production:
  *   railway run --service junesteesnthings-backend \
@@ -47,6 +48,20 @@ const sinceArg = (args[args.indexOf('--since') + 1] || '').match(/^\d{4}-\d{2}-\
 const SINCE = sinceArg
   ? Math.floor(new Date(sinceArg + 'T00:00:00Z').getTime() / 1000)
   : Math.floor(Date.now() / 1000) - 60 * 60 * 24 * 730;
+
+/* Charges that are real in Stripe but are not receipts — a card test, a
+   reversal. Left in, each one lands on the ledger with an UNKNOWN tax portion
+   and the tax page reports its whole period as undetermined, so a 57-cent test
+   can hold a settled month open indefinitely.
+
+   Named explicitly rather than filtered by a minimum amount: a threshold would
+   silently swallow small REAL sales, and the whole point of this ledger is that
+   money is never dropped quietly. Excluded ids are counted in the output, so
+   the decision stays visible every run. */
+const excludeArg = args.includes('--exclude')
+  ? String(args[args.indexOf('--exclude') + 1] || '') : '';
+const EXCLUDE = new Set(excludeArg.split(',').map((x) => x.trim()).filter(Boolean));
+const excluded = (...ids) => ids.some((id) => id && EXCLUDE.has(id));
 
 const QUOTE_CODE_RE = /^[A-Z0-9]{6}$/;
 const round2 = (n) => Math.round((Number(n) || 0) * 100) / 100;
@@ -114,11 +129,12 @@ async function* paginate(path, params) {
 
     const found = [];
     const stranded = [];
-    let sessions = 0, banked = 0, already = 0, unpaid = 0;
+    let sessions = 0, banked = 0, already = 0, unpaid = 0, skipped = 0;
 
     for await (const s of paginate('checkout/sessions', { 'created[gte]': String(SINCE) })) {
       sessions++;
       if (s.payment_status !== 'paid') { unpaid++; continue; }
+      if (excluded(s.id, s.payment_intent)) { skipped++; continue; }
 
       const code = String(s.client_reference_id || '').toUpperCase();
       // Actually on the quote ledger — the only thing that proves it banked.
@@ -147,6 +163,7 @@ async function* paginate(path, params) {
 
     console.log(`\n  ${sessions} checkout session(s): ${banked} banked to a quote, ` +
                 `${already} already recorded, ${unpaid} not paid, ` +
+                (skipped ? `${skipped} excluded, ` : '') +
                 `\x1b[1m${found.length} missing\x1b[0m`);
 
     if (stranded.length) {
@@ -227,11 +244,12 @@ async function* paginate(path, params) {
        happened to have a session. These are not written — a charge with no
        session carries no reference at all, so placing it is a human job. */
     const orphans = [];
-    let charges = 0;
+    let charges = 0, chargesSkipped = 0;
     for await (const c of paginate('charges', { 'created[gte]': String(SINCE) })) {
       charges++;
       if (c.status !== 'succeeded') continue;
       const pi = typeof c.payment_intent === 'string' ? c.payment_intent : null;
+      if (excluded(c.id, pi)) { chargesSkipped++; continue; }
       if (pi && seenPI.has(pi)) continue;
       const { rows } = await pool.query(
         `SELECT 1 FROM unlinked_payments WHERE stripe_pi = $1 LIMIT 1`, [pi]);
@@ -240,7 +258,8 @@ async function* paginate(path, params) {
       orphans.push(c);
     }
 
-    console.log(`\n  ${charges} charge(s) checked against both ledgers.`);
+    console.log(`\n  ${charges} charge(s) checked against both ledgers` +
+                (chargesSkipped ? `, ${chargesSkipped} excluded by --exclude` : '') + '.');
     if (orphans.length) {
       warn(`${orphans.length} succeeded charge(s) match NOTHING in either ledger:`);
       for (const c of orphans.slice(0, 25)) {


### PR DESCRIPTION
**Stacked on #105** — it needs that branch's `unlinked_payments` table and `/tax.csv` changes, so it targets `money-visible-outside-the-quote-flow` rather than `main`. Merge #105 first and this retargets cleanly.

## Why

Quote tax was a hand-entered figure, and the form inferred the taxable flag back out of it (`Number(E.tax) > 0`). Three different situations were therefore the same row:

- a genuinely exempt organisation
- a taxable job that happened to price at zero
- somebody forgetting the checkbox

Illinois doesn't drop exempt sales from the ST-1 — they're reported as receipts and then **deducted**, and the purchaser's exemption ("E") number is expected to be producible on audit. So the books couldn't answer either question the return asks: which sales were exempt, and under whose number.

This is the same bug class #105 fixed one layer up. That work taught the ledger that *unknown* ≠ *zero*. This is the third state: **zero, on purpose, for a documented reason**.

## What changed

**Two columns on `quotes`.** `taxable BOOLEAN` is nullable **with no default** — deliberately. NULL means the row predates the column, where the amount is the only evidence and the old inference is still correct. A `DEFAULT TRUE` would silently declare every historical quote taxable, including the exempt one that prompted this; `DEFAULT FALSE` does the reverse. Every existing quote reads exactly as it did before. `tax_exempt_ref TEXT` holds the E number.

**One reader.** `quoteTaxable()` is the only definition, mirrored exactly in SQL as `COALESCE(q.taxable, q.tax > 0)`. Two definitions of "was this taxed" is how an export and a return end up disagreeing about the same sale.

**Surfaced where it's read.** `/tax.csv` gains `exempt` and `exempt_ref`. `taxPositionByMonth` reports exempt receipts as their own figure — the deduction line — and counts exemptions with nothing on file. The books tax card now warns on both undetermined receipts and undocumented exemptions; previously both numbers were computed and rendered nowhere.

An exempt sale is a **known** zero, so it never feeds `undetermined`. That stays for receipts whose tax nobody has worked out.

**`--exclude` on the backfill**, by id rather than minimum amount — a threshold would silently swallow small real sales, which is the exact failure this ledger exists to prevent. Excluded ids are counted in the output so the decision stays visible.

## Found on the first real run

Against production data there are three zero-tax quotes, not one:

| quote | subtotal | paid | |
|---|---|---|---|
| `A7BFAD` | $1,169.90 | $584.95 | a conservation nonprofit — confirmed exempt |
| `2C4E67` | $900.00 | $0 | a public high school — plausibly exempt |
| `83AE71` | $757.50 | $385.00 | an individual's name |

`83AE71` doesn't read like an exempt institution, and $757.50 at 10.25% is ~$77.64. Not asserting it's wrong — only the shop knows whether a certificate exists. It's the case the old schema made invisible. All three will show as undocumented until a reference is added, which is intended.

## Review findings fixed in this branch

`/code-review high` found three in this change, all fixed here:

- **The taxable checkbox keyed off `existing`**, which is truthy for a quote prefilled from a lead or an abandoned cart — those carry `tax: 0`, so every enquiry-sourced quote opened untaxed. Previously that produced merely an untaxed row; with this change it would persist `taxable = false` and file it as a deliberate deduction. Now uses `isEdit`, the discriminator that already exists for exactly this distinction.
- **`/tax.csv` had no fallback** for the new columns, unlike its three siblings, so a deploy racing the migration turned the export into a 500.
- **`exempt_undocumented` counted payments, not quotes** — a deposit plus a balance on one exempt quote reported as two missing certificates.

Three further findings were against #105's code and are fixed **on that branch**, not this one: double-banking of delayed payments, refunds not returning their tax, and an unreachable sign flip.

## Verification

- **677 tests pass** (25 new here).
- The migration was applied to the **production** `quotes` table inside a transaction and rolled back — both columns land nullable with no default, and the rollback left nothing behind.
- The exempt query was run against real data inside that same transaction; that's where the third zero-tax quote came from.

## Not done

- No way yet to record an exemption on a quote that's already been paid — the reference is set through the quote form, so the three above need editing to be documented.
- radar-gate **passes** on this branch. I expected it to refuse the schema change as it does on #105, but its content check matches `CREATE TABLE`, not column names in an `ALTER` list — so the two columns here go through. Worth knowing the boundary has that gap rather than reading the green tick as approval of the schema.
