### PR TITLE
Serve the books app at jtees.net/books

### DIFF
--- a/server.js
+++ b/server.js
@@ -37,6 +37,84 @@ app.use(helmet({
   crossOriginResourcePolicy: { policy: 'cross-origin' },
 }));
 app.use(cors({ origin: ['https://www.jtees.net', 'https://jtees.net', 'https://design.jtees.net'] }));
+/* ── The books app, served at /books ───────────────────────────────────────────
+   `books` is a separate Railway service with NO public domain: its only address
+   is books.railway.internal, so the open internet cannot reach it at all. This
+   is the single door, and it is behind whatever protection this app already has.
+
+   Mounted BEFORE express.json on purpose. Once a body parser has consumed the
+   stream, forwarding a POST means re-serialising what was parsed — which
+   silently changes multipart bodies and anything the parser did not recognise.
+   Here `req` is still an untouched stream and is piped straight through.
+
+   Next.js is configured with basePath "/books", so the prefix is NOT stripped:
+   the app generates its own asset, route and auth-callback URLs already
+   carrying it. Rewriting /books/x to /x would serve the first page and then
+   hand the browser links to /_next/... that do not exist on this domain. */
+const BOOKS_ORIGIN = process.env.BOOKS_ORIGIN || '';
+
+app.use('/books', async (req, res) => {
+  if (!BOOKS_ORIGIN) {
+    return res.status(503).type('text/plain')
+      .send('The books app is not configured on this environment.');
+  }
+
+  const headers = {};
+  for (const [k, v] of Object.entries(req.headers)) {
+    // Hop-by-hop headers describe THIS connection and must not be relayed.
+    if (['host', 'connection', 'keep-alive', 'transfer-encoding', 'upgrade'].includes(k)) continue;
+    headers[k] = v;
+  }
+  /* Next builds absolute URLs from these. Without them it would see
+     books.railway.internal and put that in a redirect the browser cannot
+     follow — the classic "login redirects you to a hostname that does not
+     resolve" behind a proxy. */
+  headers['x-forwarded-proto'] = 'https';
+  headers['x-forwarded-host'] = req.headers.host || 'jtees.net';
+
+  const hasBody = !['GET', 'HEAD'].includes(req.method);
+
+  try {
+    const upstream = await fetch(BOOKS_ORIGIN + req.originalUrl, {
+      method: req.method,
+      headers,
+      body: hasBody ? req : undefined,
+      // Required by undici when the body is a stream rather than a buffer.
+      duplex: hasBody ? 'half' : undefined,
+      /* manual: a 302 from the books app is an instruction for the BROWSER.
+         Following it here would return the destination's body under the
+         original URL and break every login round trip. */
+      redirect: 'manual',
+      signal: AbortSignal.timeout(30000),
+    });
+
+    res.status(upstream.status);
+    for (const [k, v] of upstream.headers) {
+      // Length and encoding describe the upstream body, not what is sent on.
+      if (['content-encoding', 'content-length', 'transfer-encoding', 'connection'].includes(k)) continue;
+      if (k === 'set-cookie') continue; // handled below, as a list
+      res.setHeader(k, v);
+    }
+    /* Several Set-Cookie headers must stay several. Iterating the Headers
+       object joins them with a comma, which produces one malformed cookie and
+       silently logs the user out. getSetCookie is the only correct reader. */
+    const cookies = typeof upstream.headers.getSetCookie === 'function'
+      ? upstream.headers.getSetCookie()
+      : [];
+    if (cookies.length) res.setHeader('set-cookie', cookies);
+
+    if (!upstream.body) return res.end();
+    const { Readable } = require('stream');
+    Readable.fromWeb(upstream.body).pipe(res);
+  } catch (err) {
+    // A dead or slow books service must not read as a broken jtees.net.
+    console.error('books proxy failed:', err.message);
+    if (!res.headersSent) {
+      res.status(502).type('text/plain').send('The books app is not responding.');
+    }
+  }
+});
+
 app.use(express.json({
   limit: '1mb',
   verify: (req, _res, buf) => {

--- a/tests/books-proxy.test.js
+++ b/tests/books-proxy.test.js
@@ -1,0 +1,113 @@
+'use strict';
+
+/* The books app, served at jtees.net/books.
+ *
+ * `books` is a separate Railway service with NO public domain — its only
+ * address is books.railway.internal. This proxy is the single door to it, which
+ * means the door has to be built correctly: every failure below produces a page
+ * that half works, which is worse than one that plainly does not.
+ *
+ * Run: node --test tests/*.test.js
+ */
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const src = fs.readFileSync(path.join(__dirname, '..', 'server.js'), 'utf8');
+
+const PROXY = (() => {
+  const i = src.indexOf("app.use('/books'");
+  assert.notStrictEqual(i, -1, 'the /books proxy should exist');
+  return src.slice(i, i + 3200);
+})();
+
+test('the proxy is mounted BEFORE the body parsers', () => {
+  /* Once express.json has consumed the stream, forwarding a POST means
+     re-serialising what was parsed — which silently changes multipart bodies
+     and anything the parser did not recognise. Mounted first, `req` is still
+     an untouched stream and is piped through as it arrived. */
+  const proxyAt = src.indexOf("app.use('/books'");
+  const jsonAt = src.indexOf('app.use(express.json(');
+  const urlencodedAt = src.indexOf('app.use(express.urlencoded(');
+
+  assert.ok(proxyAt < jsonAt, 'the proxy must come before express.json');
+  assert.ok(proxyAt < urlencodedAt, 'the proxy must come before express.urlencoded');
+});
+
+test('the /books prefix is NOT stripped', () => {
+  /* Next is configured with basePath "/books", so it generates its own asset,
+     route and auth-callback URLs already carrying the prefix. Rewriting
+     /books/x to /x serves the first page and then hands the browser links to
+     /_next/... that do not exist on this domain. */
+  assert.match(PROXY, /BOOKS_ORIGIN \+ req\.originalUrl/,
+    'originalUrl keeps the prefix; req.url inside app.use() has it stripped');
+});
+
+test('hop-by-hop headers are not relayed', () => {
+  /* They describe THIS connection. Forwarding Connection or
+     Transfer-Encoding to another server is a protocol error that some proxies
+     tolerate and others do not, which makes it an intermittent bug. */
+  for (const h of ['host', 'connection', 'keep-alive', 'transfer-encoding', 'upgrade']) {
+    assert.match(PROXY, new RegExp(`'${h}'`), `${h} should be dropped`);
+  }
+});
+
+test('forwarded proto and host are set, so redirects point somewhere real', () => {
+  /* Without these Next sees books.railway.internal and puts that hostname in a
+     302. The browser cannot resolve it, and the symptom is a login that
+     appears to hang. */
+  assert.match(PROXY, /x-forwarded-proto'\] = 'https'/);
+  assert.match(PROXY, /x-forwarded-host'\] = req\.headers\.host/);
+});
+
+test('redirects are passed through, not followed', () => {
+  /* A 302 from the books app is an instruction for the browser. Following it
+     here returns the destination's body under the original URL, which breaks
+     every login round trip in a way that looks like a caching bug. */
+  assert.match(PROXY, /redirect: 'manual'/);
+});
+
+test('multiple Set-Cookie headers stay multiple', () => {
+  /* Iterating a Headers object joins them with a comma, producing one
+     malformed cookie. The session then silently fails to set and the user is
+     logged out on every navigation. getSetCookie is the only correct reader. */
+  assert.match(PROXY, /getSetCookie/,
+    'set-cookie must be read as a list');
+  assert.match(PROXY, /if \(k === 'set-cookie'\) continue;/,
+    'and must be skipped in the plain header loop, or it is set twice');
+});
+
+test('upstream content-length and encoding are not copied', () => {
+  /* They describe the upstream body. Copied onto a response whose body has
+     been decoded and re-streamed, they disagree with what is actually sent and
+     the browser truncates the page. */
+  for (const h of ['content-encoding', 'content-length']) {
+    assert.match(PROXY, new RegExp(`'${h}'`), `${h} should be dropped`);
+  }
+});
+
+test('a body is only forwarded when there is one', () => {
+  /* fetch rejects a GET that carries a body, so proxying a plain page view
+     would throw rather than render. */
+  assert.match(PROXY, /const hasBody = !\['GET', 'HEAD'\]\.includes\(req\.method\)/);
+  assert.match(PROXY, /duplex: hasBody \? 'half' : undefined/,
+    'undici requires duplex when the body is a stream');
+});
+
+test('a dead books service does not read as a broken jtees.net', () => {
+  assert.match(PROXY, /AbortSignal\.timeout\(/, 'a hung upstream must not hang this app');
+  assert.match(PROXY, /status\(502\)/, 'an upstream failure is a 502, not a 500');
+  assert.match(PROXY, /if \(!res\.headersSent\)/,
+    'the stream may already have started; writing a second status throws');
+  assert.doesNotMatch(PROXY, /res\.send\(err/, 'never return the upstream error to the browser');
+});
+
+test('an unconfigured environment says so instead of guessing a host', () => {
+  /* BOOKS_ORIGIN is absent on any environment without a books service. A
+     default of books.railway.internal would make every /books request hang for
+     the full timeout rather than answer immediately. */
+  assert.match(PROXY, /if \(!BOOKS_ORIGIN\)/);
+  assert.match(src, /const BOOKS_ORIGIN = process\.env\.BOOKS_ORIGIN \|\| ''/);
+});


### PR DESCRIPTION
**Stacked on #108**, which is stacked on #105. It targets `tax-exempt-sales-need-a-reason` and retargets cleanly as each merges.

## Why

`books` is the double-entry ledger the ST-1 figures will eventually be filed from. It is a separate Railway service with **no public domain** — its only address is `books.railway.internal` — so the open internet cannot reach it at all. This proxy is the single door, behind whatever protection this app already has, and the app carries its own login on top of that.

## What this does

Mounts `/books` and pipes it to `BOOKS_ORIGIN`. Four decisions, each of which produces a *half-working* page rather than a clear failure if made the other way, so each has a test:

| decision | what the other way costs |
|---|---|
| Mounted **before** `express.json` | Once a body parser has consumed the stream, forwarding a POST means re-serialising what was parsed — silently changing multipart bodies and anything the parser did not recognise. Here `req` is untouched and pipes straight through. |
| The `/books` prefix is **not stripped** | Next is configured with `basePath: "/books"` and already generates asset, route and auth-callback URLs carrying it. Rewriting `/books/x` to `/x` serves the first page, then hands the browser links to `/_next/...` that do not exist on this domain. |
| `Set-Cookie` read with `getSetCookie()` | Iterating the `Headers` object joins multiple cookies with a comma into one malformed cookie, and the session silently never sets. |
| `redirect: 'manual'` | A 302 from books is an instruction for the *browser*. Following it here returns the destination's body under the original URL and breaks every login round trip. |

`x-forwarded-proto` / `x-forwarded-host` are set because Next builds absolute URLs from them — without them it puts `books.railway.internal` in its redirects and the browser cannot resolve the hostname.

Hop-by-hop headers are dropped in both directions. A dead or slow upstream is a **502 with no error text**, not a 500 with a stack trace.

## Testing

`node --test tests/*.test.js` — **701 pass, 0 fail.** New `tests/books-proxy.test.js` covers the four decisions above plus the unconfigured and dead-upstream paths.

## Deploy prerequisite

`BOOKS_ORIGIN` must be set on this service, and the `books` service must be deployed. Without the variable the route answers **503 with a plain-text explanation** rather than erroring — so merging this ahead of the deploy is safe and inert.

## Boundary

radar-gate passes here: no schema change, and `BOOKS_ORIGIN` is not a credential. Unlike #105, nothing to accept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015jQyV7LMhkSzDFLKkk3TLh
